### PR TITLE
chore: Fixed docker deps for cv2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY ./setup.py /tmp/setup.py
 COPY ./doctr /tmp/doctr
 
 RUN apt-get update \
-    && apt-get install ffmpeg libsm6 libxext6 -y \
+    && apt-get install --no-install-recommends ffmpeg libsm6 libxext6 -y \
     && pip install --upgrade pip setuptools wheel \
     && pip install -e /tmp/. \
     && pip cache purge \


### PR DESCRIPTION
The cv2 dependency of the docker is not correctly set up by pip and some OS-level deps are needed. This PR adds required dependencies for opencv.

Surprisingly, pip was not doing a good job at it: by adding the OS-level deps, the image size drops significantly from 1.2Gb+ to less than 700Mb.

Expected docker image size is 673Mb, the build is a bit longer than before with the OS deps installation.

Any feedback is welcome!