### PR TITLE
docs: Fixed reference to alternative CI integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Everything you need to know to contribute efficiently to the project.
 
 This project uses the following integrations to ensure proper codebase maintenance:
 
-- [Github Worklow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) / [Jenkins](https://www.jenkins.io/) - run jobs for package build and coverage
+- [Github Worklow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) / [CircleCI](https://circleci.com/) - run jobs for package build and coverage
 - [Codecov](https://codecov.io/) - reports back coverage results
 
 As a contributor, you will only have to ensure coverage of your code by adding appropriate unit testing of your code.


### PR DESCRIPTION
This PR fixes a small typo in the CONTRIBUTING markdown file.