### PR TITLE
fix: tf below 2.4.0 are now supported in tests

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -81,6 +81,7 @@ def test_export_sizes(test_convert_to_tflite, test_convert_to_fp16, test_quantiz
         assert sys.getsizeof(test_convert_to_tflite) > sys.getsizeof(test_convert_to_fp16)
         assert sys.getsizeof(test_convert_to_fp16) > sys.getsizeof(test_quantize_model)
 
+
 def test_detpreprocessor(mock_pdf):  # noqa: F811
     num_docs = 3
     batch_size = 4


### PR DESCRIPTION
Change in test_models to make tests pass with tensorflow versions < 2.4.0