### PR TITLE
refactor: Refactored element children creation

### DIFF
--- a/doctr/documents/elements.py
+++ b/doctr/documents/elements.py
@@ -13,12 +13,13 @@ __all__ = ['Element', 'Word', 'Artefact', 'Line', 'Block', 'Page', 'Document']
 class Element:
     """Implements an abstract document element with exporting and text rendering capabilities"""
 
-    _children_names: List[str] = []
     _exported_keys: List[str] = []
 
     def __init__(self, **kwargs: Any) -> None:
+        self._children_names: List[str] = []
         for k, v in kwargs.items():
             setattr(self, k, v)
+            self._children_names.append(k)
 
     def export(self) -> Dict[str, Any]:
         """Exports the object into a nested dict format"""
@@ -89,7 +90,6 @@ class Line(Element):
             all words in it.
     """
 
-    _children_names: List[str] = ["words"]
     _exported_keys: List[str] = ["geometry"]
     words: List[Word] = []
 
@@ -121,7 +121,6 @@ class Block(Element):
             all lines and artefacts in it.
     """
 
-    _children_names: List[str] = ["lines", "artefacts"]
     _exported_keys: List[str] = ["geometry"]
     lines: List[Line] = []
     artefacts: List[Artefact] = []
@@ -156,7 +155,6 @@ class Page(Element):
         language: a dictionary with the language value and confidence of the prediction
     """
 
-    _children_names: List[str] = ["blocks"]
     _exported_keys: List[str] = ["page_idx", "dimensions", "orientation", "language"]
     blocks: List[Block] = []
 
@@ -186,7 +184,6 @@ class Document(Element):
         pages: list of page elements
     """
 
-    _children_names: List[str] = ["pages"]
     pages: List[Page] = []
 
     def __init__(


### PR DESCRIPTION
Following up on feedback from @mohamedmindee, this PR introduces the following modifications:
- make abstract element's purpose more explicit: instantiating children if there are any. The private children name attribute is created on the fly in the constructor to avoid any confusion.