### PR TITLE
feat: Added a full pretrained predictor for upcoming release

### DIFF
--- a/doctr/models/__init__.py
+++ b/doctr/models/__init__.py
@@ -6,3 +6,4 @@ from ._utils import *
 from .vgg import *
 from .core import *
 from .export import *
+from .zoo import *

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -5,7 +5,7 @@
 
 
 import numpy as np
-from typing import List
+from typing import List, Any
 from .detection import DetectionPredictor
 from .recognition import RecognitionPredictor
 from ._utils import extract_crops

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -87,16 +87,17 @@ class OCRPredictor:
     def __call__(
         self,
         documents: List[List[np.ndarray]],
+        **kwargs: Any,
     ) -> List[Document]:
 
         pages = [page for doc in documents for page in doc]
 
         # Localize text elements
-        boxes = self.det_predictor(pages)
+        boxes = self.det_predictor(pages, **kwargs)
         # Crop images
         crops = [crop for page, _boxes in zip(pages, boxes) for crop in extract_crops(page, _boxes[:, :4])]
         # Identify character sequences
-        char_sequences = self.reco_predictor(crops)
+        char_sequences = self.reco_predictor(crops, **kwargs)
 
         # Reorganize
         num_pages = [len(doc) for doc in documents]

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -6,7 +6,7 @@
 import tensorflow as tf
 from tensorflow import keras
 import numpy as np
-from typing import Union, List, Tuple, Any
+from typing import Union, List, Tuple, Any, Optional, Dict
 from ..preprocessor import PreProcessor
 
 __all__ = ['DetectionPreProcessor', 'DetectionModel', 'DetectionPostProcessor', 'DetectionPredictor']

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -33,7 +33,7 @@ class DetectionPreProcessor(PreProcessor):
     def __init__(
         self,
         output_size: Tuple[int, int],
-        batch_size: int,
+        batch_size: int = 1,
         mean: Tuple[float, float, float] = (.5, .5, .5),
         std: Tuple[float, float, float] = (1., 1., 1.),
         interpolation: str = 'bilinear'
@@ -60,7 +60,9 @@ class DetectionPreProcessor(PreProcessor):
 class DetectionModel(keras.Model):
     """Implements abstract DetectionModel class"""
 
-    training: bool = False
+    def __init__(self, *args: Any, cfg: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.cfg = cfg
 
     def call(
         self,

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -24,12 +24,14 @@ __all__ = ['DBPostProcessor', 'DBNet', 'db_resnet50']
 
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
-    'db_resnet50': {'backbone': 'ResNet50',
-                    'fpn_layers': ["conv2_block3_out", "conv3_block4_out", "conv4_block6_out", "conv5_block3_out"],
-                    'fpn_channels': 128,
-                    'input_shape': (1024, 1024, 3),
-                    'post_processor': 'DBPostProcessor',
-                    'url': 'https://srv-store6.gofile.io/download/mTjlOo/db_resnet50-56f1e578.zip'},
+    'db_resnet50': {
+        'backbone': 'ResNet50',
+        'fpn_layers': ["conv2_block3_out", "conv3_block4_out", "conv4_block6_out", "conv5_block3_out"],
+        'fpn_channels': 128,
+        'input_shape': (1024, 1024, 3),
+        'post_processor': 'DBPostProcessor',
+        'url': 'https://github.com/publicMindee/doctr/releases/download/v0.1-models/db_resnet50-56f1e578.zip'
+    },
 }
 
 

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -257,6 +257,7 @@ class DBNet(DetectionModel):
 
         self.fpn = FeaturePyramidNetwork(channels=fpn_channels)
 
+        #####
         self.probability_head = keras.Sequential(
             [
                 layers.Conv2D(filters=64, kernel_size=(3, 3), padding='same', use_bias=False, name="p_map1"),
@@ -318,11 +319,11 @@ class DBNet(DetectionModel):
             return prob_map
 
 
-def _db_resnet(arch: str, pretrained: bool, input_size: Tuple[int, int, int] = None, **kwargs: Any) -> DBNet:
+def _db_resnet(arch: str, pretrained: bool, input_shape: Tuple[int, int, int] = None, **kwargs: Any) -> DBNet:
 
     # Patch the config
     _cfg = deepcopy(default_cfgs[arch])
-    _cfg['input_shape'] = input_size or _cfg['input_shape']
+    _cfg['input_shape'] = input_shape or _cfg['input_shape']
     _cfg['fpn_channels'] = kwargs.get('fpn_channels', _cfg['fpn_channels'])
 
     # Feature extractor

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -36,7 +36,6 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
 
 
 class DBPostProcessor(DetectionPostProcessor):
-    """Implements a post processor for DBNet
     """Implements a post processor for DBNet adapted from the implementation of `xuannianz
     <https://github.com/xuannianz/DifferentiableBinarization>`_.
 

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -30,7 +30,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'fpn_channels': 128,
         'input_shape': (1024, 1024, 3),
         'post_processor': 'DBPostProcessor',
-        'url': 'https://github.com/publicMindee/doctr/releases/download/v0.1-models/db_resnet50-56f1e578.zip'
+        'url': None,
     },
 }
 

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -3,6 +3,8 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
+# Credits: post-processing adapted from https://github.com/xuannianz/DifferentiableBinarization
+
 import cv2
 import json
 import os
@@ -35,6 +37,8 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
 
 class DBPostProcessor(DetectionPostProcessor):
     """Implements a post processor for DBNet
+    """Implements a post processor for DBNet adapted from the implementation of `xuannianz
+    <https://github.com/xuannianz/DifferentiableBinarization>`_.
 
     Args:
         unclip ratio: ratio used to unshrink polygons

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -104,7 +104,7 @@ class RecognitionPostProcessor:
     ) -> None:
 
         self.vocab = vocab + '<eos>'
-        self._embedding = tf.constant(value=[char for char in self.vocab], dtype=tf.string, shape=[len(self.vocab)])
+        self._embedding = tf.constant([char for char in self.vocab], dtype=tf.string, shape=[len(self.vocab)])
         self.ignore_case = ignore_case
         self.ignore_accents = ignore_accents
 

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -104,6 +104,7 @@ class RecognitionPostProcessor:
     ) -> None:
 
         self.vocab = vocab + '<eos>'
+        self._embedding = tf.constant(value=[char for char in self.vocab], dtype=tf.string, shape=[len(self.vocab)])
         self.ignore_case = ignore_case
         self.ignore_accents = ignore_accents
 

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -5,7 +5,7 @@
 
 import tensorflow as tf
 from tensorflow import keras
-from typing import Tuple, List, Any
+from typing import Tuple, List, Any, Optional, Dict
 import numpy as np
 
 from ..preprocessor import PreProcessor
@@ -32,7 +32,7 @@ class RecognitionPreProcessor(PreProcessor):
     def __init__(
         self,
         output_size: Tuple[int, int],
-        batch_size: int,
+        batch_size: int = 1,
         mean: Tuple[float, float, float] = (.5, .5, .5),
         std: Tuple[float, float, float] = (1., 1., 1.),
         interpolation: str = 'bilinear',
@@ -75,7 +75,9 @@ class RecognitionPreProcessor(PreProcessor):
 class RecognitionModel(keras.Model):
     """Implements abstract RecognitionModel class"""
 
-    training: bool = False
+    def __init__(self, *args: Any, cfg: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.cfg = cfg
 
     def call(
         self,
@@ -89,10 +91,21 @@ class RecognitionPostProcessor:
     """Abstract class to postprocess the raw output of the model
 
     Args:
-        min_size_box (int): minimal length (pix) to keep a box
-        max_candidates (int): maximum boxes to consider in a single page
-        box_thresh (float): minimal objectness score to consider a box
+        vocab: string containing the ordered sequence of supported characters
+        ignore_case: if True, ignore case of letters
+        ignore_accents: if True, ignore accents of letters
     """
+
+    def __init__(
+        self,
+        vocab: str,
+        ignore_case: bool = False,
+        ignore_accents: bool = False
+    ) -> None:
+
+        self.vocab = vocab + '<eos>'
+        self.ignore_case = ignore_case
+        self.ignore_accents = ignore_accents
 
     def __call__(
         self,

--- a/doctr/models/recognition/crnn.py
+++ b/doctr/models/recognition/crnn.py
@@ -78,7 +78,7 @@ def _crnn_vgg(arch: str, pretrained: bool, input_shape: Optional[Tuple[int, int,
 
     # Feature extractor
     feat_extractor = vgg.__dict__[_cfg['backbone']](
-        input_size=_cfg['input_shape'],
+        input_shape=_cfg['input_shape'],
         include_top=False,
     )
 

--- a/doctr/models/recognition/crnn.py
+++ b/doctr/models/recognition/crnn.py
@@ -31,13 +31,13 @@ class CRNN(RecognitionModel):
 
     Args:
         feature_extractor: the backbone serving as feature extractor
-        num_classes: number of output classes
+        vocab_size: number of output classes
         rnn_units: number of units in the LSTM layers
     """
     def __init__(
         self,
         feature_extractor: tf.keras.Model,
-        num_classes: int = 30,
+        vocab_size: int = 30,
         rnn_units: int = 128,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -47,7 +47,7 @@ class CRNN(RecognitionModel):
             [
                 layers.Bidirectional(layers.LSTM(units=rnn_units, return_sequences=True)),
                 layers.Bidirectional(layers.LSTM(units=rnn_units, return_sequences=True)),
-                layers.Dense(units=num_classes + 1)
+                layers.Dense(units=vocab_size + 1)
             ]
         )
 
@@ -73,7 +73,7 @@ def _crnn_vgg(arch: str, pretrained: bool, input_shape: Optional[Tuple[int, int,
     # Patch the config
     _cfg = deepcopy(default_cfgs[arch])
     _cfg['input_shape'] = input_shape or _cfg['input_shape']
-    _cfg['num_classes'] = kwargs.get('num_classes', len(_cfg['vocab']))
+    _cfg['vocab_size'] = kwargs.get('vocab_size', len(_cfg['vocab']))
     _cfg['rnn_units'] = kwargs.get('rnn_units', _cfg['rnn_units'])
 
     # Feature extractor
@@ -82,7 +82,7 @@ def _crnn_vgg(arch: str, pretrained: bool, input_shape: Optional[Tuple[int, int,
         include_top=False,
     )
 
-    kwargs['num_classes'] = _cfg['num_classes']
+    kwargs['vocab_size'] = _cfg['vocab_size']
     kwargs['rnn_units'] = _cfg['rnn_units']
 
     # Build the model

--- a/doctr/models/recognition/postprocessor.py
+++ b/doctr/models/recognition/postprocessor.py
@@ -5,7 +5,7 @@
 
 import tensorflow as tf
 import tensorflow.keras.backend as K
-from typing import List, Dict
+from typing import List
 
 from .core import RecognitionPostProcessor
 

--- a/doctr/models/recognition/postprocessor.py
+++ b/doctr/models/recognition/postprocessor.py
@@ -18,24 +18,10 @@ class CTCPostProcessor(RecognitionPostProcessor):
     Postprocess raw prediction of the model (logits) to a list of words using CTC decoding
 
     Args:
-        num_classes: number of classes of the model
-        label_to_idx: dictionnary mapping alphabet labels to idx of the model classes
+        vocab: string containing the ordered sequence of supported characters
         ignore_case: if True, ignore case of letters
         ignore_accents: if True, ignore accents of letters
-
     """
-    def __init__(
-        self,
-        num_classes: int,
-        label_to_idx: Dict[str, int],
-        ignore_case: bool = False,
-        ignore_accents: bool = False
-    ) -> None:
-
-        self.num_classes = num_classes
-        self.label_to_idx = label_to_idx
-        self.ignore_case = ignore_case
-        self.ignore_accents = ignore_accents
 
     def ctc_decoder(
         self,
@@ -62,7 +48,7 @@ class CTCPostProcessor(RecognitionPostProcessor):
 
         # masking -1 of CTC with num_classes (embedding <eos>)
         pred_shape = tf.shape(_predictions)
-        mask_eos = self.num_classes * tf.ones(pred_shape, dtype=tf.int64)
+        mask_eos = (len(self.vocab) - 1) * tf.ones(pred_shape, dtype=tf.int64)
         mask_1 = -1 * tf.ones(pred_shape, dtype=tf.int64)
         predictions = tf.where(mask_1 != _predictions, _predictions, mask_eos)
 
@@ -86,10 +72,10 @@ class CTCPostProcessor(RecognitionPostProcessor):
         # decode ctc for ctc models
         predictions = self.ctc_decoder(logits)
 
-        label_mapping = self.label_to_idx.copy()
-        label_mapping['<eos>'] = self.num_classes
-        label, _ = zip(*sorted(label_mapping.items(), key=lambda x: x[1]))
-        tf_label_to_idx = tf.constant(value=label, dtype=tf.string, shape=[self.num_classes + 1], name='label_mapping')
+        tf_label_to_idx = tf.constant(
+            value=[char for char in self.vocab], dtype=tf.string, shape=[len(self.vocab)], name='label_mapping'
+        )
+
         _decoded_strings_pred = tf.strings.reduce_join(
             inputs=tf.nn.embedding_lookup(tf_label_to_idx, predictions),
             axis=-1

--- a/doctr/models/recognition/postprocessor.py
+++ b/doctr/models/recognition/postprocessor.py
@@ -72,12 +72,8 @@ class CTCPostProcessor(RecognitionPostProcessor):
         # decode ctc for ctc models
         predictions = self.ctc_decoder(logits)
 
-        tf_label_to_idx = tf.constant(
-            value=[char for char in self.vocab], dtype=tf.string, shape=[len(self.vocab)], name='label_mapping'
-        )
-
         _decoded_strings_pred = tf.strings.reduce_join(
-            inputs=tf.nn.embedding_lookup(tf_label_to_idx, predictions),
+            inputs=tf.nn.embedding_lookup(self._embedding, predictions),
             axis=-1
         )
         _decoded_strings_pred = tf.strings.split(_decoded_strings_pred, "<eos>")

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -6,7 +6,7 @@
 from copy import deepcopy
 import tensorflow as tf
 from tensorflow.keras import Sequential, layers
-from typing import Tuple, Dict, List, Any
+from typing import Tuple, Dict, List, Any, Optional
 
 from .. import vgg
 from ..utils import load_pretrained_params
@@ -22,7 +22,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'post_processor': 'SARPostProcessor',
         'vocab': ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-'
                   'kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l'),
-        'url': 'https://github.com/mindee/doctr/releases/download/v0.1-models/sar_vgg16_bn-1aaf65b5.zip'
+        'url': None,
     },
 }
 

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -41,13 +41,13 @@ class AttentionModule(layers.Layer):
 
         super().__init__()
         self.hidden_state_projector = layers.Conv2D(
-            filters=attention_units, kernel_size=1, strides=1, use_bias=False, padding='same'
+            attention_units, 1, strides=1, use_bias=False, padding='same', kernel_initializer='he_normal',
         )
         self.features_projector = layers.Conv2D(
-            filters=attention_units, kernel_size=3, strides=1, use_bias=True, padding='same'
+            attention_units, 3, strides=1, use_bias=True, padding='same', kernel_initializer='he_normal',
         )
         self.attention_projector = layers.Conv2D(
-            filters=1, kernel_size=1, strides=1, use_bias=False, padding="same"
+            1, 1, strides=1, use_bias=False, padding="same", kernel_initializer='he_normal',
         )
         self.flatten = layers.Flatten()
 

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -22,7 +22,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'post_processor': 'SARPostProcessor',
         'vocab': ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-'
                   'kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l'),
-        'url': 'https://github.com/publicMindee/doctr/releases/download/v0.1-models/sar_vgg16_bn-1aaf65b5.zip'
+        'url': 'https://github.com/mindee/doctr/releases/download/v0.1-models/sar_vgg16_bn-1aaf65b5.zip'
     },
 }
 

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -16,12 +16,14 @@ from .core import RecognitionPostProcessor
 __all__ = ['SAR', 'SARPostProcessor', 'sar_vgg16_bn']
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
-    'sar_vgg16_bn': {'backbone': 'vgg16_bn', 'rnn_units': 512, 'max_length': 40, 'num_decoders': 2,
-                     'input_shape': (64, 256, 3),
-                     'post_processor': 'SARPostProcessor',
-                     'vocab': ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-'
-                               'kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l'),
-                     'url': 'https://srv-store6.gofile.io/download/pYIzXL/sar_vgg16_bn-1aaf65b5.zip'},
+    'sar_vgg16_bn': {
+        'backbone': 'vgg16_bn', 'rnn_units': 512, 'max_length': 40, 'num_decoders': 2,
+        'input_shape': (64, 256, 3),
+        'post_processor': 'SARPostProcessor',
+        'vocab': ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-'
+                  'kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l'),
+        'url': 'https://github.com/publicMindee/doctr/releases/download/v0.1-models/sar_vgg16_bn-1aaf65b5.zip'
+    },
 }
 
 

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -216,14 +216,9 @@ class SARPostProcessor(RecognitionPostProcessor):
         # compute pred with argmax for attention models
         pred = tf.math.argmax(logits, axis=2)
 
-        # create tf_label_to_idx mapping to decode classes
-        tf_label_to_idx = tf.constant(
-            value=[char for char in self.vocab], dtype=tf.string, shape=[len(self.vocab)], name='dic_idx_label'
-        )
-
         # decode raw output of the model with tf_label_to_idx
         pred = tf.cast(pred, dtype='int32')
-        decoded_strings_pred = tf.strings.reduce_join(inputs=tf.nn.embedding_lookup(tf_label_to_idx, pred), axis=-1)
+        decoded_strings_pred = tf.strings.reduce_join(inputs=tf.nn.embedding_lookup(self._embedding, pred), axis=-1)
         decoded_strings_pred = tf.strings.split(decoded_strings_pred, "<eos>")
         decoded_strings_pred = tf.sparse.to_dense(decoded_strings_pred.to_sparse(), default_value='not valid')[:, 0]
         words_list = [word.decode() for word in list(decoded_strings_pred.numpy())]

--- a/doctr/models/utils.py
+++ b/doctr/models/utils.py
@@ -79,6 +79,7 @@ def conv_sequence(
     activation: str = None,
     bn: bool = False,
     padding: str = 'same',
+    kernel_initializer: str = 'he_normal',
     **kwargs: Any,
 ) -> List[layers.Layer]:
     """Builds a convolutional-based layer sequence
@@ -88,11 +89,14 @@ def conv_sequence(
         activation: activation to be used (default: no activation)
         bn: should a batch normalization layer be added
         padding: padding scheme
+        kernel_initializer: kernel initializer
 
     Returns:
         list of layers
     """
-    conv_seq = [layers.Conv2D(out_channels, padding=padding, **kwargs)]
+    # No bias before Batch norm
+    kwargs['use_bias'] = kwargs.get('use_bias', not(bn))
+    conv_seq = [layers.Conv2D(out_channels, padding=padding, kernel_initializer=kernel_initializer, **kwargs)]
 
     if bn:
         conv_seq.append(layers.BatchNormalization())

--- a/doctr/models/utils.py
+++ b/doctr/models/utils.py
@@ -96,12 +96,14 @@ def conv_sequence(
     """
     # No bias before Batch norm
     kwargs['use_bias'] = kwargs.get('use_bias', not(bn))
+    # Add activation directly to the conv if there is no BN
+    kwargs['activation'] = activation if not bn else None
     conv_seq = [layers.Conv2D(out_channels, padding=padding, kernel_initializer=kernel_initializer, **kwargs)]
 
     if bn:
         conv_seq.append(layers.BatchNormalization())
 
-    if isinstance(activation, str):
+    if isinstance(activation, str) and not(bn):
         conv_seq.append(layers.Activation(activation))
 
     return conv_seq

--- a/doctr/models/vgg.py
+++ b/doctr/models/vgg.py
@@ -29,7 +29,7 @@ class VGG(Sequential):
         planes: number of output channels in each stage
         rect_pools: whether pooling square kernels should be replace with rectangular ones
         include_top: whether the classifier head should be added
-        input_size: shapes of the input tensor
+        input_shape: shapes of the input tensor
     """
     def __init__(
         self,
@@ -37,12 +37,12 @@ class VGG(Sequential):
         planes: Tuple[int, int, int, int, int],
         rect_pools: Tuple[bool, bool, bool, bool, bool],
         include_top: bool = False,
-        input_size: Tuple[int, int, int] = (640, 640, 3),
+        input_shape: Tuple[int, int, int] = (512, 512, 3),
     ) -> None:
 
         _layers = []
         # Specify input_shape only for the first layer
-        kwargs = {"input_shape": input_size}
+        kwargs = {"input_shape": input_shape}
         for nb_blocks, out_chan, rect_pool in zip(num_blocks, planes, rect_pools):
             for _ in range(nb_blocks):
                 _layers.extend(conv_sequence(out_chan, 'relu', True, kernel_size=3, **kwargs))  # type: ignore[arg-type]

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+from typing import Dict, Any
+from .core import OCRPredictor
+from . import detection, recognition
+
+
+__all__ = ["ocr_db_sar"]
+
+default_cfgs: Dict[str, Dict[str, Any]] = {
+    'ocr_db_sar': {
+        'detection': 'db_resnet50',
+        'recognition': 'sar_vgg16_bn',
+    },
+}
+
+
+def _predictor(arch: str, pretrained: bool, **kwargs: Any) -> OCRPredictor:
+
+    # Detection
+    _model = detection.__dict__[default_cfgs[arch]['detection']](pretrained=pretrained)
+    det_predictor = detection.DetectionPredictor(
+        detection.DetectionPreProcessor(output_size=_model.cfg['input_shape'][:2], batch_size=2),
+        _model,
+        detection.__dict__[_model.cfg['post_processor']]()
+    )
+
+    # Recognition
+    _model = recognition.__dict__[default_cfgs[arch]['recognition']](pretrained=pretrained)
+    reco_predictor = recognition.RecognitionPredictor(
+        recognition.RecognitionPreProcessor(output_size=_model.cfg['input_shape'][:2], batch_size=16),
+        _model,
+        recognition.__dict__[_model.cfg['post_processor']](_model.cfg['vocab'])
+    )
+
+    return OCRPredictor(det_predictor, reco_predictor)
+
+
+def ocr_db_sar(pretrained: bool, **kwargs: Any) -> OCRPredictor:
+    """End-to-end OCR architecture using a DBNet with a ResNet-50 backbone for localization, and SAR with a VGG-16BN
+    backbone as text recognition architecture.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+
+    Returns:
+        OCR predictor
+    """
+
+    return _predictor('ocr_db_sar', pretrained, **kwargs)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -70,7 +70,7 @@ def test_detpreprocessor(mock_pdf):  # noqa: F811
     num_docs = 3
     batch_size = 4
     docs = [read_pdf(mock_pdf) for _ in range(num_docs)]
-    processor = models.DetectionPreProcessor(output_size=(600, 600), batch_size=batch_size)
+    processor = models.DetectionPreProcessor(output_size=(512, 512), batch_size=batch_size)
     batched_docs = processor([page for doc in docs for page in doc])
 
     # Number of batches
@@ -83,10 +83,10 @@ def test_detpreprocessor(mock_pdf):  # noqa: F811
     # Data type
     assert all(batch.dtype == tf.float32 for batch in batched_docs)
     # Image size
-    assert all(batch.shape[1:] == (600, 600, 3) for batch in batched_docs)
+    assert all(batch.shape[1:] == (512, 512, 3) for batch in batched_docs)
     # Test with non-full last batch
     batch_size = 16
-    processor = models.DetectionPreProcessor(output_size=(600, 600), batch_size=batch_size)
+    processor = models.DetectionPreProcessor(output_size=(512, 512), batch_size=batch_size)
     batched_docs = processor([page for doc in docs for page in doc])
     assert batched_docs[-1].shape[0] == (8 * num_docs) % batch_size
 
@@ -118,11 +118,11 @@ def test_recopreprocessor(mock_pdf):  # noqa: F811
 
 def test_dbpostprocessor():
     postprocessor = models.DBPostProcessor()
-    mock_batch = tf.random.uniform(shape=[8, 600, 600, 1], minval=0, maxval=1)
+    mock_batch = tf.random.uniform(shape=[2, 512, 512, 1], minval=0, maxval=1)
     out = postprocessor(mock_batch)
     # Batch composition
     assert isinstance(out, list)
-    assert len(out) == 8
+    assert len(out) == 2
     assert all(isinstance(sample, np.ndarray) for sample in out)
     assert all(sample.shape[1] == 5 for sample in out)
     # Relative coords
@@ -132,11 +132,11 @@ def test_dbpostprocessor():
 def test_db_resnet50():
     model = models.db_resnet50(pretrained=True)
     assert isinstance(model, tf.keras.Model)
-    dbinput = tf.random.uniform(shape=[8, 1024, 1024, 3], minval=0, maxval=1)
+    dbinput = tf.random.uniform(shape=[2, 1024, 1024, 3], minval=0, maxval=1)
     # test prediction model
     dboutput_notrain = model(dbinput)
     assert isinstance(dboutput_notrain, tf.Tensor)
-    assert dboutput_notrain.numpy().shape == (8, 1024, 1024, 1)
+    assert dboutput_notrain.numpy().shape == (2, 1024, 1024, 1)
     assert np.all(dboutput_notrain.numpy() > 0) and np.all(dboutput_notrain.numpy() < 1)
     # test training model
     dboutput_train = model(dbinput, training=True)
@@ -144,7 +144,7 @@ def test_db_resnet50():
     assert len(dboutput_train) == 3
     assert all(np.all(np.logical_and(out_map.numpy() >= 0, out_map.numpy() <= 1)) for out_map in dboutput_train)
     # batch size
-    assert all(out.numpy().shape == (8, 1024, 1024, 1) for out in dboutput_train)
+    assert all(out.numpy().shape == (2, 1024, 1024, 1) for out in dboutput_train)
 
 
 def test_extract_crops(mock_pdf):  # noqa: F811

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -170,8 +170,8 @@ def test_extract_crops(mock_pdf):  # noqa: F811
 @pytest.mark.parametrize(
     "arch_name, input_shape, output_size",
     [
-        ["crnn_vgg16_bn", (32, 128, 3), (32, 31)],
-        ["sar_vgg16_bn", (64, 256, 3), (31, 111)],
+        ["crnn_vgg16_bn", (32, 128, 3), (32, 119)],
+        ["sar_vgg16_bn", (64, 256, 3), (41, 119)],
     ],
 )
 def test_recognition_architectures(arch_name, input_shape, output_size):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -197,8 +197,8 @@ def test_detectionpredictor(mock_pdf):  # noqa: F811
 
     batch_size = 4
     predictor = models.DetectionPredictor(
-        models.DetectionPreProcessor(output_size=(640, 640), batch_size=batch_size),
-        models.db_resnet50(input_shape=(640, 640, 3)),
+        models.DetectionPreProcessor(output_size=(512, 512), batch_size=batch_size),
+        models.db_resnet50(input_shape=(512, 512, 3)),
         models.DBPostProcessor()
     )
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -300,3 +300,16 @@ def test_load_pretrained_params(tmpdir_factory):
         assert os.path.exists(cache_dir.join('models').join("tmp_checkpoint-4a98e492.zip"))
     except Exception as e:
         warnings.warn(e)
+
+
+@pytest.mark.parametrize(
+    "arch_name",
+    [
+        "ocr_db_sar",
+    ],
+)
+def test_zoo_models(arch_name):
+    # Model
+    model = models.__dict__[arch_name](pretrained=True)
+    # Output checks
+    assert isinstance(model, models.OCRPredictor)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -168,16 +168,16 @@ def test_extract_crops(mock_pdf):  # noqa: F811
 
 
 @pytest.mark.parametrize(
-    "arch_name, input_size, output_size",
+    "arch_name, input_shape, output_size",
     [
         ["crnn_vgg16_bn", (32, 128, 3), (32, 31)],
         ["sar_vgg16_bn", (64, 256, 3), (31, 111)],
     ],
 )
-def test_recognition_architectures(arch_name, input_size, output_size):
+def test_recognition_architectures(arch_name, input_shape, output_size):
     batch_size = 8
-    reco_model = models.__dict__[arch_name](input_size=input_size)
-    input_tensor = tf.random.uniform(shape=[batch_size, *input_size], minval=0, maxval=1)
+    reco_model = models.__dict__[arch_name](input_shape=input_shape)
+    input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
     out = reco_model(input_tensor)
     assert isinstance(out, tf.Tensor)
     assert isinstance(reco_model, tf.keras.Model)
@@ -198,7 +198,7 @@ def test_detectionpredictor(mock_pdf):  # noqa: F811
     batch_size = 4
     predictor = models.DetectionPredictor(
         models.DetectionPreProcessor(output_size=(640, 640), batch_size=batch_size),
-        models.db_resnet50(input_size=(640, 640, 3)),
+        models.db_resnet50(input_shape=(640, 640, 3)),
         models.DBPostProcessor()
     )
 
@@ -217,7 +217,7 @@ def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
     batch_size = 4
     predictor = models.RecognitionPredictor(
         models.RecognitionPreProcessor(output_size=(32, 128), batch_size=batch_size),
-        models.crnn_vgg16_bn(num_classes=len(mock_vocab), input_size=(32, 128, 3)),
+        models.crnn_vgg16_bn(num_classes=len(mock_vocab), input_shape=(32, 128, 3)),
         models.CTCPostProcessor(mock_vocab)
     )
 
@@ -262,12 +262,12 @@ def test_sar_decoder(mock_vocab):
 
 
 @pytest.mark.parametrize(
-    "arch_name, top_implemented, input_size, output_size",
+    "arch_name, top_implemented, input_shape, output_size",
     [
         ["vgg16_bn", False, (224, 224, 3), (7, 56, 512)],
     ],
 )
-def test_classification_architectures(arch_name, top_implemented, input_size, output_size):
+def test_classification_architectures(arch_name, top_implemented, input_shape, output_size):
     # Head not implemented yet
     if not top_implemented:
         with pytest.raises(NotImplementedError):
@@ -277,7 +277,7 @@ def test_classification_architectures(arch_name, top_implemented, input_size, ou
     batch_size = 2
     model = models.__dict__[arch_name](pretrained=True)
     # Forward
-    out = model(tf.random.uniform(shape=[batch_size, *input_size], maxval=1, dtype=tf.float32))
+    out = model(tf.random.uniform(shape=[batch_size, *input_shape], maxval=1, dtype=tf.float32))
     # Output checks
     assert isinstance(out, tf.Tensor)
     assert out.numpy().shape == (batch_size, *output_size)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -176,7 +176,7 @@ def test_extract_crops(mock_pdf):  # noqa: F811
 )
 def test_recognition_architectures(arch_name, input_shape, output_size):
     batch_size = 8
-    reco_model = models.__dict__[arch_name](input_shape=input_shape)
+    reco_model = models.__dict__[arch_name](pretrained=True, input_shape=input_shape)
     input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
     out = reco_model(input_tensor)
     assert isinstance(out, tf.Tensor)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -132,11 +132,11 @@ def test_dbpostprocessor():
 def test_db_resnet50():
     model = models.db_resnet50(pretrained=True)
     assert isinstance(model, tf.keras.Model)
-    dbinput = tf.random.uniform(shape=[8, 640, 640, 3], minval=0, maxval=1)
+    dbinput = tf.random.uniform(shape=[8, 1024, 1024, 3], minval=0, maxval=1)
     # test prediction model
     dboutput_notrain = model(dbinput)
     assert isinstance(dboutput_notrain, tf.Tensor)
-    assert dboutput_notrain.numpy().shape == (8, 640, 640, 1)
+    assert dboutput_notrain.numpy().shape == (8, 1024, 1024, 1)
     assert np.all(dboutput_notrain.numpy() > 0) and np.all(dboutput_notrain.numpy() < 1)
     # test training model
     dboutput_train = model(dbinput, training=True)
@@ -144,7 +144,7 @@ def test_db_resnet50():
     assert len(dboutput_train) == 3
     assert all(np.all(np.logical_and(out_map.numpy() >= 0, out_map.numpy() <= 1)) for out_map in dboutput_train)
     # batch size
-    assert all(out.numpy().shape == (8, 640, 640, 1) for out in dboutput_train)
+    assert all(out.numpy().shape == (8, 1024, 1024, 1) for out in dboutput_train)
 
 
 def test_extract_crops(mock_pdf):  # noqa: F811
@@ -217,7 +217,7 @@ def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
     batch_size = 4
     predictor = models.RecognitionPredictor(
         models.RecognitionPreProcessor(output_size=(32, 128), batch_size=batch_size),
-        models.crnn_vgg16_bn(num_classes=len(mock_vocab), input_shape=(32, 128, 3)),
+        models.crnn_vgg16_bn(vocab_size=len(mock_vocab), input_shape=(32, 128, 3)),
         models.CTCPostProcessor(mock_vocab)
     )
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -32,24 +32,9 @@ def mock_model():
 
 
 @pytest.fixture(scope="module")
-def mock_mapping():
-    return {
-        "V": 0, "W": 1, ";": 2, "w": 3, "&": 4, "1": 5, "<": 6,
-        "\u00fb": 7, "p": 8, "h": 9, "9": 10, "\u00f9": 11, "\u00d9": 12, "j": 13,
-        "*": 14, "s": 15, "?": 16, ",": 17, "\u00ee": 18, "\u00d4": 19, "8": 20,
-        "@": 21, "D": 22, ">": 23, "$": 24, "\u00db": 25, "k": 26, "{": 27, "I": 28,
-        "F": 29, ":": 30, "O": 31, "\u00e0": 32, "a": 33, "\u00c0": 34, "v": 35, "X": 36,
-        "[": 37, "\u00ea": 38, "M": 39, "q": 40, "5": 41, "\u00c2": 42, "G": 43, "\u00f4": 44,
-        "\"": 45, "\u00e7": 46, "L": 47, "\u00e9": 48, "\u00ef": 49, "6": 50, "\u00ce": 51,
-        "y": 52, "/": 53, "#": 54, "3": 55, "N": 56, "x": 57, "\u00c8": 58, "]": 59, "K": 60,
-        "\u00a3": 61, "7": 62, "R": 63, "'": 64, "U": 65, "\u00e8": 66, "J": 67, "H": 68,
-        "t": 69, "r": 70, "c": 71, "P": 72, ".": 73, "\u00cf": 74, "z": 75, "m": 76, "Z": 77,
-        "}": 78, "0": 79, "(": 80, "\u00cb": 81, "b": 82, "\u00e2": 83, "-": 84, "B": 85, "T": 86,
-        "\u00eb": 87, "%": 88, "\u20ac": 89, "E": 90, ")": 91, "i": 92, "_": 93, "Q": 94, "|": 95,
-        "\u00c9": 96, "S": 97, "o": 98, "=": 99, "Y": 100, "A": 101, "4": 102, "e": 103, "n": 104,
-        "u": 105, "g": 106, "!": 107, "2": 108, "l": 109, "f": 110, "+": 111, "\u00c7": 112,
-        "C": 113, "d": 114
-    }
+def mock_vocab():
+    return ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-kçHëÀÂ2É/ûIJ\'j'
+            '(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l')
 
 
 @pytest.fixture(scope="module")
@@ -199,11 +184,8 @@ def test_recognition_architectures(arch_name, input_size, output_size):
     assert out.numpy().shape == (batch_size, *output_size)
 
 
-def test_ctc_decoder(mock_mapping):
-    ctc_postprocessor = models.recognition.CTCPostProcessor(
-        num_classes=len(mock_mapping),
-        label_to_idx=mock_mapping
-    )
+def test_ctc_decoder(mock_vocab):
+    ctc_postprocessor = models.recognition.CTCPostProcessor(mock_vocab)
     decoded = ctc_postprocessor(logits=tf.random.uniform(shape=[8, 30, 116], minval=0, maxval=1, dtype=tf.float32))
     assert isinstance(decoded, list)
     assert len(decoded) == 8
@@ -230,13 +212,13 @@ def test_detectionpredictor(mock_pdf):  # noqa: F811
 
 
 @pytest.fixture(scope="module")
-def test_recognitionpredictor(mock_pdf, mock_mapping):  # noqa: F811
+def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
 
     batch_size = 4
     predictor = models.RecognitionPredictor(
         models.RecognitionPreProcessor(output_size=(32, 128), batch_size=batch_size),
-        models.crnn_vgg16_bn(num_classes=len(mock_mapping), input_size=(32, 128, 3)),
-        models.CTCPostProcessor(num_classes=len(mock_mapping), label_to_idx=mock_mapping)
+        models.crnn_vgg16_bn(num_classes=len(mock_vocab), input_size=(32, 128, 3)),
+        models.CTCPostProcessor(mock_vocab)
     )
 
     pages = read_pdf(mock_pdf)
@@ -253,7 +235,7 @@ def test_recognitionpredictor(mock_pdf, mock_mapping):  # noqa: F811
     return predictor
 
 
-def test_ocrpredictor(mock_pdf, mock_mapping, test_detectionpredictor, test_recognitionpredictor):  # noqa: F811
+def test_ocrpredictor(mock_pdf, test_detectionpredictor, test_recognitionpredictor):  # noqa: F811
 
     num_docs = 3
     predictor = models.OCRPredictor(
@@ -271,8 +253,8 @@ def test_ocrpredictor(mock_pdf, mock_mapping, test_detectionpredictor, test_reco
     assert all(len(doc.pages) == 8 for doc in out)
 
 
-def test_sar_decoder(mock_mapping):
-    sar_postprocessor = models.recognition.SARPostProcessor(label_to_idx=mock_mapping)
+def test_sar_decoder(mock_vocab):
+    sar_postprocessor = models.recognition.SARPostProcessor(mock_vocab)
     decoded = sar_postprocessor(logits=tf.random.uniform(shape=[8, 30, 116], minval=0, maxval=1, dtype=tf.float32))
     assert isinstance(decoded, list)
     assert len(decoded) == 8

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -74,11 +74,10 @@ def test_quantize_model(mock_model):
 
 
 def test_export_sizes(test_convert_to_tflite, test_convert_to_fp16, test_quantize_model):
+    assert sys.getsizeof(test_convert_to_tflite) > sys.getsizeof(test_convert_to_fp16)
     if tf.__version__ < "2.4.0":
-        assert sys.getsizeof(test_convert_to_tflite) >= sys.getsizeof(test_convert_to_fp16)
         assert sys.getsizeof(test_convert_to_fp16) >= sys.getsizeof(test_quantize_model)
     else:
-        assert sys.getsizeof(test_convert_to_tflite) > sys.getsizeof(test_convert_to_fp16)
         assert sys.getsizeof(test_convert_to_fp16) > sys.getsizeof(test_quantize_model)
 
 


### PR DESCRIPTION
This PR introduces the following modifications:
- renamed all model input_size constructor arg to input_shape
- added a cfg attribute to each model to be able to access its build parameters
- fixed DB post processing by adding safeguard against edge cases
- added credits for DB post processing
- fixed bias before BN in conv_sequence
- added model zoo for full OCR predictors
- fixed model export unittest (cf. #27)
- simplified recognition architecture passing down the vocab (rather than num_classes + label_mapping)
- reflected changes on unittests
- avoids embedding recreation in recognition architectures

Successfully merging this PR will close #53

Any feedback is welcome!