### PR TITLE
Fix: <eos> symbol removed from vocab str

### DIFF
--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -103,8 +103,8 @@ class RecognitionPostProcessor:
         ignore_accents: bool = False
     ) -> None:
 
-        self.vocab = vocab + '<eos>'
-        self._embedding = tf.constant([char for char in self.vocab], dtype=tf.string, shape=[len(self.vocab)])
+        self.vocab = vocab
+        self._embedding = tf.constant([char for char in self.vocab] + ['<eos>'], dtype=tf.string)
         self.ignore_case = ignore_case
         self.ignore_accents = ignore_accents
 

--- a/doctr/models/recognition/postprocessor.py
+++ b/doctr/models/recognition/postprocessor.py
@@ -47,7 +47,7 @@ class CTCPostProcessor(RecognitionPostProcessor):
 
         # masking -1 of CTC with num_classes (embedding <eos>)
         pred_shape = tf.shape(_predictions)
-        mask_eos = (len(self.vocab) - 1) * tf.ones(pred_shape, dtype=tf.int64)
+        mask_eos = len(self.vocab) * tf.ones(pred_shape, dtype=tf.int64)
         mask_1 = -1 * tf.ones(pred_shape, dtype=tf.int64)
         predictions = tf.where(mask_1 != _predictions, _predictions, mask_eos)
 


### PR DESCRIPTION
<eos> symbol has been removed from vocab (but kept in _embedded), len(vocab) = size of the alphabet