### PR TITLE
test: Improved unittests for recognition post processors

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -192,9 +192,9 @@ def test_recognition_architectures(arch_name, input_shape, output_size):
 def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
     processor = models.recognition.__dict__[post_processor](mock_vocab)
     decoded = processor(tf.random.uniform(shape=input_shape, minval=0, maxval=1, dtype=tf.float32))
-    assert isinstance(decoded, list)
+    assert isinstance(decoded, list) and all(isinstance(word, str) for word in decoded)
     assert len(decoded) == input_shape[0]
-    assert all(len(word) <= input_shape[1] for word in decoded)
+    assert all(char in mock_vocab for word in decoded for char in word)
 
 
 @pytest.fixture(scope="module")

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -185,8 +185,8 @@ def test_recognition_architectures(arch_name, input_shape, output_size):
 @pytest.mark.parametrize(
     "post_processor, input_shape",
     [
-        ["SARPostProcessor", [2, 30, 116]],
-        ["CTCPostProcessor", [2, 30, 116]],
+        ["SARPostProcessor", [2, 30, 119]],
+        ["CTCPostProcessor", [2, 30, 119]],
     ],
 )
 def test_reco_postprocessors(post_processor, input_shape, mock_vocab):


### PR DESCRIPTION
This PR introduces the following modifications:
- updates the input size for the post processor unittest (from 116 to 119 to be the same as current models)
- replaced a useless assertion that was testing whether each word is shorter than the vocab with a test checking that each character is in the vocab

Any feedback is welcome!