### PR TITLE
fix: Fixed edge case of recognition crop resizing

### DIFF
--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -54,7 +54,7 @@ class DetectionPreProcessor(PreProcessor):
             the processed image after being resized
         """
 
-        return tf.image.resize(x, [self.output_size[0], self.output_size[1]], method=self.interpolation)
+        return tf.image.resize(x, self.output_size, method=self.interpolation)
 
 
 class DetectionModel(keras.Model):

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -58,16 +58,11 @@ class RecognitionPreProcessor(PreProcessor):
         Returns:
             the processed image after being resized
         """
-        image_shape = tf.shape(x)
-        image_height = tf.cast(image_shape[0], dtype=tf.float32)
-        image_width = tf.cast(image_shape[1], dtype=tf.float32)
 
-        scale = self.output_size[0] / image_height
-        max_width = tf.cast(self.output_size[1], tf.int32)
-        new_width = tf.minimum(tf.cast(scale * image_width, dtype=tf.int32), max_width)
-
-        resized = tf.image.resize(x, [self.output_size[0], new_width], method=self.interpolation)
-        padded = tf.image.pad_to_bounding_box(resized, 0, 0, self.output_size[0], self.output_size[1])
+        # Preserve aspect ratio during resizing
+        resized = tf.image.resize(x, self.output_size, method=self.interpolation, preserve_aspect_ratio=True)
+        # Pad on the side that is still too small
+        padded = tf.image.pad_to_bounding_box(resized, 0, 0, *self.output_size)
 
         return padded
 

--- a/doctr/models/recognition/postprocessor.py
+++ b/doctr/models/recognition/postprocessor.py
@@ -38,7 +38,7 @@ class CTCPostProcessor(RecognitionPostProcessor):
         # computing prediction with ctc decoder
         _prediction = tf.nn.ctc_greedy_decoder(
             tf.nn.softmax(tf.transpose(logits, perm=[1, 0, 2])),
-            tf.fill(tf.shape(logits)[0], tf.shape(logits)[1]),
+            tf.fill(logits.shape[0], logits.shape[1]),
             merge_repeated=True
         )[0][0]
         prediction = tf.sparse.to_dense(_prediction, default_value=len(self.vocab))

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -117,16 +117,15 @@ class SARDecoder(layers.Layer):
         **kwargs: Any,
     ) -> tf.Tensor:
 
-        batch_size = tf.shape(features)[0]
         # initialize states (each of shape (N, rnn_units))
         states = self.lstm_decoder.get_initial_state(
-            inputs=None, batch_size=batch_size, dtype=tf.float32
+            inputs=None, batch_size=features.shape[0], dtype=tf.float32
         )
         # run first step of lstm
         # holistic: shape (N, rnn_units)
         _, states = self.lstm_decoder(holistic, states, **kwargs)
         # Initialize with the index of virtual START symbol (placed after <eos>)
-        symbol = tf.fill(batch_size, self.vocab_size + 1)
+        symbol = tf.fill(features.shape[0], self.vocab_size + 1)
         logits_list = []
         for _ in range(self.max_length + 1):  # keep 1 step for <eos>
             # one-hot symbol with depth vocab_size + 1


### PR DESCRIPTION
This PR introduces the following modifications:
- removed all `tf.shape` in favor of the better `.shape` attribute of tensors
- fixed resizing for recognition crop for all edge cases

Successfully merging this will close #72 

Any feedback is welcome!