### PR TITLE
docs: Fixed sphinx requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx<3.5.0
 sphinx-rtd-theme==0.4.3
 sphinxemoji


### PR DESCRIPTION
This PR simply fixes the sphinx requirement that is now troublesome since version 3.5.0. The bug has been reported but won't be in stable version before next release, hence the version constraint.