### PR TITLE
docs: Added multiple examples in docstrings

### DIFF
--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -348,6 +348,13 @@ def db_resnet50(pretrained: bool = False, **kwargs: Any) -> DBNet:
     """DBNet as described in `"Real-time Scene Text Detection with Differentiable Binarization"
     <https://arxiv.org/pdf/1911.08947.pdf>`_, using a ResNet-50 backbone.
 
+    Example::
+        >>> import tensorflow as tf
+        >>> from doctr.models import db_resnet50
+        >>> model = db_resnet50(pretrained=True)
+        >>> input_tensor = tf.random.uniform(shape=[1, 1024, 1024, 3], maxval=1, dtype=tf.float32)
+        >>> out = model(input_tensor)
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 

--- a/doctr/models/export.py
+++ b/doctr/models/export.py
@@ -18,6 +18,12 @@ __all__ = ['convert_to_tflite', 'convert_to_fp16', 'quantize_model']
 def convert_to_tflite(tf_model: Model) -> bytes:
     """Converts a model to TFLite format
 
+    Example::
+        >>> from tensorflow.keras import Sequential
+        >>> from doctr.models import convert_to_tflite, conv_sequence
+        >>> model = Sequential(conv_sequence(32, 'relu', True, kernel_size=3, input_shape=(224, 224, 3)))
+        >>> serialized_model = convert_to_tflite(model)
+
     Args:
         tf_model: a keras model
 
@@ -30,6 +36,12 @@ def convert_to_tflite(tf_model: Model) -> bytes:
 
 def convert_to_fp16(tf_model: Model) -> bytes:
     """Converts a model to half precision
+
+    Example::
+        >>> from tensorflow.keras import Sequential
+        >>> from doctr.models import convert_to_fp16, conv_sequence
+        >>> model = Sequential(conv_sequence(32, 'relu', True, kernel_size=3, input_shape=(224, 224, 3)))
+        >>> serialized_model = convert_to_fp16(model)
 
     Args:
         tf_model: a keras model
@@ -46,6 +58,12 @@ def convert_to_fp16(tf_model: Model) -> bytes:
 
 def quantize_model(tf_model: Model, input_shape: Tuple[int, int, int]) -> bytes:
     """Quantize a Tensorflow model
+
+    Example::
+        >>> from tensorflow.keras import Sequential
+        >>> from doctr.models import quantize_model, conv_sequence
+        >>> model = Sequential(conv_sequence(32, 'relu', True, kernel_size=3, input_shape=(224, 224, 3)))
+        >>> serialized_model = quantize_model(model, (224, 224, 3))
 
     Args:
         tf_model: a keras model

--- a/doctr/models/recognition/crnn.py
+++ b/doctr/models/recognition/crnn.py
@@ -97,6 +97,13 @@ def crnn_vgg16_bn(pretrained: bool = False, **kwargs: Any) -> CRNN:
     """CRNN with a VGG-16 backbone as described in `"Convolutional RNN: an Enhanced Model for Extracting Features
     from Sequential Data" <https://arxiv.org/pdf/1602.05875.pdf>`_.
 
+    Example::
+        >>> import tensorflow as tf
+        >>> from doctr.models import crnn_vgg16_bn
+        >>> model = crnn_vgg16_bn(pretrained=True)
+        >>> input_tensor = tf.random.uniform(shape=[1, 32, 128, 3], maxval=1, dtype=tf.float32)
+        >>> out = model(input_tensor)
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -273,6 +273,13 @@ def sar_vgg16_bn(pretrained: bool = False, **kwargs: Any) -> SAR:
     """SAR with a VGG16 feature extractor as described in `"Show, Attend and Read:A Simple and Strong
     Baseline for Irregular Text Recognition" <https://arxiv.org/pdf/1811.00751.pdf>`_.
 
+    Example::
+        >>> import tensorflow as tf
+        >>> from doctr.models import sar_vgg16_bn
+        >>> model = sar_vgg16_bn(pretrained=False)
+        >>> input_tensor = tf.random.uniform(shape=[1, 64, 256, 3], maxval=1, dtype=tf.float32)
+        >>> out = model(input_tensor)
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 

--- a/doctr/models/resnet.py
+++ b/doctr/models/resnet.py
@@ -168,6 +168,13 @@ def resnet31(pretrained: bool = False, **kwargs: Any) -> Resnet:
     `"Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition",
     <https://arxiv.org/pdf/1811.00751.pdf>`_. Downsizing: (H, W) --> (H/8, W/4)
 
+    Example::
+        >>> import tensorflow as tf
+        >>> from doctr.models import resnet31
+        >>> model = resnet31(pretrained=False)
+        >>> input_tensor = tf.random.uniform(shape=[1, 224, 224, 3], maxval=1, dtype=tf.float32)
+        >>> out = model(input_tensor)
+
     Args:
         pretrained: boolean, True if model is pretrained
 

--- a/doctr/models/utils.py
+++ b/doctr/models/utils.py
@@ -33,6 +33,10 @@ def load_pretrained_params(
 ) -> None:
     """Load a set of parameters onto a model
 
+    Example::
+        >>> from doctr.models import load_pretrained_params
+        >>> load_pretrained_params(model, "https://yoursource.com/yourcheckpoint-yourhash.zip")
+
     Args:
         model: the keras model to be loaded
         url: URL of the set of parameters
@@ -83,6 +87,11 @@ def conv_sequence(
 ) -> List[layers.Layer]:
     """Builds a convolutional-based layer sequence
 
+    Example::
+        >>> from doctr.models import conv_sequence
+        >>> from tensorflow.keras import Sequential
+        >>> module = Sequential(conv_sequence(32, 'relu', True, kernel_size=3, input_shape=[224, 224, 3]))
+
     Args:
         out_channels: number of output channels
         activation: activation to be used (default: no activation)
@@ -110,6 +119,12 @@ def conv_sequence(
 
 class IntermediateLayerGetter(Model):
     """Implements an intermediate layer getter
+
+    Example::
+        >>> from doctr.models import IntermediateLayerGetter
+        >>> from tensorflow.keras.applications import ResNet50
+        >>> target_layers = ["conv2_block3_out", "conv3_block4_out", "conv4_block6_out", "conv5_block3_out"]
+        >>> feat_extractor = IntermediateLayerGetter(ResNet50(include_top=False, pooling=False), target_layers)
 
     Args:
         model: the model to extract feature maps from

--- a/doctr/models/utils.py
+++ b/doctr/models/utils.py
@@ -39,8 +39,9 @@ def load_pretrained_params(
 
     Args:
         model: the keras model to be loaded
-        url: URL of the set of parameters
+        url: URL of the zipped set of parameters
         hash_prefix: first characters of SHA256 expected hash
+        overwrite: should the zip extraction be enforced if the archive has already been extracted
         internal_name: name of the ckpt files
     """
 

--- a/doctr/models/vgg.py
+++ b/doctr/models/vgg.py
@@ -69,6 +69,13 @@ def vgg16_bn(pretrained: bool = False, **kwargs: Any) -> VGG:
     """VGG-16 architecture as described in `"Very Deep Convolutional Networks for Large-Scale Image Recognition"
     <https://arxiv.org/pdf/1409.1556.pdf>`_, modified by adding batch normalization.
 
+    Example::
+        >>> import tensorflow as tf
+        >>> from doctr.models import vgg16_bn
+        >>> model = vgg16_bn(pretrained=False)
+        >>> input_tensor = tf.random.uniform(shape=[1, 224, 224, 3], maxval=1, dtype=tf.float32)
+        >>> out = model(input_tensor)
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -41,6 +41,13 @@ def ocr_db_sar(pretrained: bool, **kwargs: Any) -> OCRPredictor:
     """End-to-end OCR architecture using a DBNet with a ResNet-50 backbone for localization, and SAR with a VGG-16BN
     backbone as text recognition architecture.
 
+    Example::
+        >>> import numpy as np
+        >>> from doctr.models import ocr_db_sar
+        >>> model = ocr_db_sar(pretrained=False)
+        >>> input_page = (255 * np.random.rand(1, 600, 800, 3)).astype(np.uint8)
+        >>> out = model([[input_page]])
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
@@ -54,6 +61,13 @@ def ocr_db_sar(pretrained: bool, **kwargs: Any) -> OCRPredictor:
 def ocr_db_crnn(pretrained: bool, **kwargs: Any) -> OCRPredictor:
     """End-to-end OCR architecture using a DBNet with a ResNet-50 backbone for localization, and CRNN with a VGG-16BN
     backbone as text recognition architecture.
+
+    Example::
+        >>> import numpy as np
+        >>> from doctr.models import ocr_db_crnn
+        >>> model = ocr_db_crnn(pretrained=True)
+        >>> input_page = (255 * np.random.rand(1, 600, 800, 3)).astype(np.uint8)
+        >>> out = model([[input_page]])
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -37,7 +37,7 @@ def _predictor(arch: str, pretrained: bool, **kwargs: Any) -> OCRPredictor:
     return OCRPredictor(det_predictor, reco_predictor)
 
 
-def ocr_db_sar(pretrained: bool, **kwargs: Any) -> OCRPredictor:
+def ocr_db_sar(pretrained: bool = False, **kwargs: Any) -> OCRPredictor:
     """End-to-end OCR architecture using a DBNet with a ResNet-50 backbone for localization, and SAR with a VGG-16BN
     backbone as text recognition architecture.
 
@@ -58,7 +58,7 @@ def ocr_db_sar(pretrained: bool, **kwargs: Any) -> OCRPredictor:
     return _predictor('ocr_db_sar', pretrained, **kwargs)
 
 
-def ocr_db_crnn(pretrained: bool, **kwargs: Any) -> OCRPredictor:
+def ocr_db_crnn(pretrained: bool = False, **kwargs: Any) -> OCRPredictor:
     """End-to-end OCR architecture using a DBNet with a ResNet-50 backbone for localization, and CRNN with a VGG-16BN
     backbone as text recognition architecture.
 

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -59,6 +59,17 @@ def visualize_page(
 ) -> None:
     """Visualize a full page with predicted blocks, lines and words
 
+    Example::
+        >>> import numpy as np
+        >>> import matplotlib.pyplot as plt
+        >>> from doctr.utils.visualization import visualize_page
+        >>> from doctr.models import ocr_db_crnn
+        >>> model = ocr_db_crnn(pretrained=True)
+        >>> input_page = (255 * np.random.rand(1, 600, 800, 3)).astype(np.uint8)
+        >>> out = model([[input_page]])
+        >>> visualize_page(out[0].pages[0].export(), input_page)
+        >>> plt.show()
+
     Args:
         page: the exported Page of a Document
         image: np array of the page, needs to have the same shape than page['dimensions']


### PR DESCRIPTION
This PR introduces the following changes:
- added examples in major functions/classes docstrings
- fixed the docstring of `doctr.models.utils.load_pretrained_params`
- added default value to `pretrained` arg in OCR predictors

Any feedback is welcome!