### PR TITLE
feat: Added repr to elements

### DIFF
--- a/doctr/documents/elements.py
+++ b/doctr/documents/elements.py
@@ -6,23 +6,12 @@
 from typing import Tuple, Dict, List, Any, Optional
 from doctr.utils.geometry import resolve_enclosing_bbox
 from doctr.utils.common_types import BoundingBox
+from doctr.utils.repr import NestedObject
 
 __all__ = ['Element', 'Word', 'Artefact', 'Line', 'Block', 'Page', 'Document']
 
 
-def _addindent(s_, num_spaces):
-    s = s_.split('\n')
-    # don't do anything for single-line stuff
-    if len(s) == 1:
-        return s_
-    first = s.pop(0)
-    s = [(num_spaces * ' ') + line for line in s]
-    s = '\n'.join(s)
-    s = first + '\n' + s
-    return s
-
-
-class Element:
+class Element(NestedObject):
     """Implements an abstract document element with exporting and text rendering capabilities"""
 
     _exported_keys: List[str] = []
@@ -44,36 +33,6 @@ class Element:
 
     def render(self) -> str:
         raise NotImplementedError
-
-    def extra_repr(self) -> str:
-        return ''
-
-    def __repr__(self):
-        # We treat the extra repr like the sub-module, one item per line
-        extra_lines = []
-        extra_repr = self.extra_repr()
-        # empty string will be split into list ['']
-        if extra_repr:
-            extra_lines = extra_repr.split('\n')
-        child_lines = []
-        for key in self._children_names:
-            children = getattr(self, key)
-            child_str = ",\n".join([repr(child) for child in children])
-            child_str = _addindent(f"\n{child_str},", 4)
-            child_str = f"[{child_str}" + _addindent("\n]", 2)
-            child_lines.append('(' + key + '): ' + child_str)
-        lines = extra_lines + child_lines
-
-        main_str = self.__class__.__name__ + '('
-        if lines:
-            # simple one-liner info, which most builtin Modules will use
-            if len(extra_lines) == 1 and not child_lines:
-                main_str += extra_lines[0]
-            else:
-                main_str += '\n  ' + '\n  '.join(lines) + '\n'
-
-        main_str += ')'
-        return main_str
 
 
 class Word(Element):

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -166,6 +166,9 @@ class DocumentBuilder:
 
         return blocks
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(resolve_lines={self.resolve_lines}, paragraph_break={self.paragraph_break})"
+
     def __call__(
         self,
         boxes: List[np.ndarray],

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -9,18 +9,21 @@ from typing import List, Any, Tuple
 from .detection import DetectionPredictor
 from .recognition import RecognitionPredictor
 from ._utils import extract_crops
-from ..documents.elements import Word, Line, Block, Page, Document
+from doctr.documents.elements import Word, Line, Block, Page, Document
+from doctr.utils.repr import NestedObject
 
 __all__ = ['OCRPredictor', 'DocumentBuilder']
 
 
-class OCRPredictor:
+class OCRPredictor(NestedObject):
     """Implements an object able to localize and identify text elements in a set of documents
 
     Args:
         det_predictor: detection module
         reco_predictor: recognition module
     """
+
+    _children_names: List[str] = ['det_predictor', 'reco_predictor', 'doc_builder']
 
     def __init__(
         self,
@@ -54,7 +57,7 @@ class OCRPredictor:
         return results
 
 
-class DocumentBuilder:
+class DocumentBuilder(NestedObject):
     """Implements a document builder
 
     Args:
@@ -166,8 +169,8 @@ class DocumentBuilder:
 
         return blocks
 
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(resolve_lines={self.resolve_lines}, paragraph_break={self.paragraph_break})"
+    def extra_repr(self) -> str:
+        return f"resolve_lines={self.resolve_lines}, paragraph_break={self.paragraph_break}"
 
     def __call__(
         self,

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -8,6 +8,7 @@ from tensorflow import keras
 import numpy as np
 from typing import Union, List, Tuple, Any, Optional, Dict
 from ..preprocessor import PreProcessor
+from doctr.utils.repr import NestedObject
 
 __all__ = ['DetectionPreProcessor', 'DetectionModel', 'DetectionPostProcessor', 'DetectionPredictor']
 
@@ -57,15 +58,12 @@ class DetectionPreProcessor(PreProcessor):
         return tf.image.resize(x, self.output_size, method=self.interpolation)
 
 
-class DetectionModel(keras.Model):
+class DetectionModel(keras.Model, NestedObject):
     """Implements abstract DetectionModel class"""
 
     def __init__(self, *args: Any, cfg: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.cfg = cfg
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}()"
 
     def call(
         self,
@@ -75,7 +73,7 @@ class DetectionModel(keras.Model):
         raise NotImplementedError
 
 
-class DetectionPostProcessor:
+class DetectionPostProcessor(NestedObject):
     """Abstract class to postprocess the raw output of the model
 
     Args:
@@ -95,8 +93,8 @@ class DetectionPostProcessor:
         self.max_candidates = max_candidates
         self.box_thresh = box_thresh
 
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(box_thresh={self.box_thresh}, max_candidates={self.max_candidates})"
+    def extra_repr(self) -> str:
+        return f"box_thresh={self.box_thresh}, max_candidates={self.max_candidates}"
 
     def __call__(
         self,
@@ -105,7 +103,7 @@ class DetectionPostProcessor:
         raise NotImplementedError
 
 
-class DetectionPredictor:
+class DetectionPredictor(NestedObject):
     """Implements an object able to localize text elements in a document
 
     Args:
@@ -113,6 +111,8 @@ class DetectionPredictor:
         model: core detection architecture
         post_processor: post process model outputs
     """
+
+    _children_names: List[str] = ['pre_processor', 'model', 'post_processor']
 
     def __init__(
         self,

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -64,6 +64,9 @@ class DetectionModel(keras.Model):
         super().__init__(*args, **kwargs)
         self.cfg = cfg
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
     def call(
         self,
         x: tf.Tensor,
@@ -91,6 +94,9 @@ class DetectionPostProcessor:
         self.min_size_box = min_size_box
         self.max_candidates = max_candidates
         self.box_thresh = box_thresh
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(box_thresh={self.box_thresh}, max_candidates={self.max_candidates})"
 
     def __call__(
         self,

--- a/doctr/models/preprocessor.py
+++ b/doctr/models/preprocessor.py
@@ -80,6 +80,9 @@ class PreProcessor:
             b_images.append(tf.stack(x[int(num_batches) * self.batch_size:], axis=0))
         return b_images
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(output_size={self.output_size}, mean={self.mean}, std={self.std})"
+
     def __call__(
         self,
         x: List[np.ndarray]

--- a/doctr/models/preprocessor.py
+++ b/doctr/models/preprocessor.py
@@ -7,11 +7,13 @@ import tensorflow as tf
 import numpy as np
 from typing import List, Tuple
 
+from doctr.utils.repr import NestedObject
+
 
 __all__ = ['PreProcessor']
 
 
-class PreProcessor:
+class PreProcessor(NestedObject):
     """Implements an abstract preprocessor object which performs casting, resizing, batching and normalization.
 
     Args:
@@ -80,8 +82,8 @@ class PreProcessor:
             b_images.append(tf.stack(x[int(num_batches) * self.batch_size:], axis=0))
         return b_images
 
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(output_size={self.output_size}, mean={self.mean}, std={self.std})"
+    def extra_repr(self) -> str:
+        return f"output_size={self.output_size}, mean={self.mean}, std={self.std}"
 
     def __call__(
         self,

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -9,6 +9,7 @@ from typing import Tuple, List, Any, Optional, Dict
 import numpy as np
 
 from ..preprocessor import PreProcessor
+from doctr.utils.repr import NestedObject
 
 __all__ = ['RecognitionPreProcessor', 'RecognitionPostProcessor', 'RecognitionModel', 'RecognitionPredictor']
 
@@ -67,15 +68,12 @@ class RecognitionPreProcessor(PreProcessor):
         return padded
 
 
-class RecognitionModel(keras.Model):
+class RecognitionModel(keras.Model, NestedObject):
     """Implements abstract RecognitionModel class"""
 
     def __init__(self, *args: Any, cfg: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.cfg = cfg
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}()"
 
     def call(
         self,
@@ -85,7 +83,7 @@ class RecognitionModel(keras.Model):
         raise NotImplementedError
 
 
-class RecognitionPostProcessor:
+class RecognitionPostProcessor(NestedObject):
     """Abstract class to postprocess the raw output of the model
 
     Args:
@@ -106,8 +104,8 @@ class RecognitionPostProcessor:
         self.ignore_case = ignore_case
         self.ignore_accents = ignore_accents
 
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(vocab_size={len(self.vocab)})"
+    def extra_repr(self) -> str:
+        return f"vocab_size={len(self.vocab)}"
 
     def __call__(
         self,
@@ -116,7 +114,7 @@ class RecognitionPostProcessor:
         raise NotImplementedError
 
 
-class RecognitionPredictor:
+class RecognitionPredictor(NestedObject):
     """Implements an object able to identify character sequences in images
 
     Args:
@@ -124,6 +122,8 @@ class RecognitionPredictor:
         model: core detection architecture
         post_processor: post process model outputs
     """
+
+    _children_names: List[str] = ['pre_processor', 'model', 'post_processor']
 
     def __init__(
         self,

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -74,6 +74,9 @@ class RecognitionModel(keras.Model):
         super().__init__(*args, **kwargs)
         self.cfg = cfg
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
     def call(
         self,
         x: tf.Tensor,
@@ -102,6 +105,9 @@ class RecognitionPostProcessor:
         self._embedding = tf.constant(list(self.vocab) + ['<eos>'], dtype=tf.string)
         self.ignore_case = ignore_case
         self.ignore_accents = ignore_accents
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(vocab_size={len(self.vocab)})"
 
     def __call__(
         self,

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -12,6 +12,7 @@ from .. import vgg
 from ..utils import load_pretrained_params
 from .core import RecognitionModel
 from .core import RecognitionPostProcessor
+from doctr.utils.repr import NestedObject
 
 __all__ = ['SAR', 'SARPostProcessor', 'sar_vgg16_bn']
 
@@ -27,7 +28,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
 }
 
 
-class AttentionModule(layers.Layer):
+class AttentionModule(layers.Layer, NestedObject):
     """Implements attention module of the SAR model
 
     Args:
@@ -77,7 +78,7 @@ class AttentionModule(layers.Layer):
         return glimpse
 
 
-class SARDecoder(layers.Layer):
+class SARDecoder(layers.Layer, NestedObject):
     """Implements decoder module of the SAR model
 
     Args:
@@ -161,6 +162,8 @@ class SAR(RecognitionModel):
         num_decoders: number of LSTM to stack in decoder layer
 
     """
+
+    _children_names: List[str] = ['feat_extractor', 'encoder', 'decoder']
     def __init__(
         self,
         feature_extractor,

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -164,6 +164,7 @@ class SAR(RecognitionModel):
     """
 
     _children_names: List[str] = ['feat_extractor', 'encoder', 'decoder']
+
     def __init__(
         self,
         feature_extractor,

--- a/doctr/models/utils.py
+++ b/doctr/models/utils.py
@@ -138,3 +138,6 @@ class IntermediateLayerGetter(Model):
     ) -> None:
         intermediate_fmaps = [model.get_layer(layer_name).output for layer_name in layer_names]
         super().__init__(model.input, outputs=intermediate_fmaps)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"

--- a/doctr/utils/__init__.py
+++ b/doctr/utils/__init__.py
@@ -1,2 +1,3 @@
 from .geometry import *
 from .common_types import *
+from .repr import NestedObject

--- a/doctr/utils/__init__.py
+++ b/doctr/utils/__init__.py
@@ -1,3 +1,2 @@
 from .geometry import *
 from .common_types import *
-from .repr import NestedObject

--- a/doctr/utils/repr.py
+++ b/doctr/utils/repr.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+# Adapted from https://github.com/pytorch/torch/blob/master/torch/nn/modules/module.py
+
+__all__ = ['NestedObject']
+
+
+def _addindent(s_, num_spaces):
+    s = s_.split('\n')
+    # don't do anything for single-line stuff
+    if len(s) == 1:
+        return s_
+    first = s.pop(0)
+    s = [(num_spaces * ' ') + line for line in s]
+    s = '\n'.join(s)
+    s = first + '\n' + s
+    return s
+
+
+class NestedObject:
+    def extra_repr(self) -> str:
+        return ''
+
+    def __repr__(self):
+        # We treat the extra repr like the sub-object, one item per line
+        extra_lines = []
+        extra_repr = self.extra_repr()
+        # empty string will be split into list ['']
+        if extra_repr:
+            extra_lines = extra_repr.split('\n')
+        child_lines = []
+        if hasattr(self, '_children_names'):
+            for key in self._children_names:
+                child = getattr(self, key)
+                if isinstance(child, list):
+                    child_str = ",\n".join([repr(subchild) for subchild in child])
+                    if len(child) > 1:
+                        child_str = _addindent(f"\n{child_str},", 2)
+                    child_str = f"[{child_str}\n]"
+                else:
+                    child_str = repr(child)
+                child_str = _addindent(child_str, 2)
+                child_lines.append('(' + key + '): ' + child_str)
+        lines = extra_lines + child_lines
+
+        main_str = self.__class__.__name__ + '('
+        if lines:
+            # simple one-liner info, which most builtin Modules will use
+            if len(extra_lines) == 1 and not child_lines:
+                main_str += extra_lines[0]
+            else:
+                main_str += '\n  ' + '\n  '.join(lines) + '\n'
+
+        main_str += ')'
+        return main_str

--- a/test/test_documents_elements.py
+++ b/test/test_documents_elements.py
@@ -76,6 +76,9 @@ def test_word():
     # Export
     assert word.export() == {"value": word_str, "confidence": conf, "geometry": geom}
 
+    # Repr
+    assert word.__repr__() == f"Word(value='hello', confidence={conf:.2})"
+
 
 def test_line():
     geom = ((0, 0), (0.5, 0.5))
@@ -92,6 +95,10 @@ def test_line():
 
     # Export
     assert line.export() == {"words": [w.export() for w in words], "geometry": geom}
+
+    # Repr
+    words_str = ' ' * 4 + ',\n    '.join(repr(word) for word in words) + ','
+    assert line.__repr__() == f"Line(\n  (words): [\n{words_str}\n  ]\n)"
 
 
 def test_artefact():
@@ -110,6 +117,9 @@ def test_artefact():
 
     # Export
     assert artefact.export() == {"type": artefact_type, "confidence": conf, "geometry": geom}
+
+    # Repr
+    assert artefact.__repr__() == f"Artefact(type='{artefact_type}', confidence={conf:.2})"
 
 
 def test_block():
@@ -156,6 +166,9 @@ def test_page():
     # Export
     assert page.export() == {"blocks": [b.export() for b in blocks], "page_idx": page_idx, "dimensions": page_size,
                              "orientation": orientation, "language": language}
+
+    # Repr
+    assert '\n'.join(repr(page).split('\n')[:2]) == f'Page(\n  dimensions={repr(page_size)}'
 
 
 def test_document():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -52,6 +52,9 @@ def test_documentbuilder():
     doc_builder = models.DocumentBuilder(resolve_lines=True)
     out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [num_pages], [(100, 200), (100, 200)])
 
+    # Repr
+    assert repr(doc_builder) == "DocumentBuilder(resolve_lines=False, paragraph_break=False)"
+
 
 @pytest.mark.parametrize(
     "input_boxes, sorted_idxs",

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -53,7 +53,7 @@ def test_documentbuilder():
     out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [num_pages], [(100, 200), (100, 200)])
 
     # Repr
-    assert repr(doc_builder) == "DocumentBuilder(resolve_lines=False, paragraph_break=False)"
+    assert repr(doc_builder) == "DocumentBuilder(resolve_lines=True, paragraph_break=0.15)"
 
 
 @pytest.mark.parametrize(

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -31,6 +31,9 @@ def test_detpreprocessor(mock_pdf):  # noqa: F811
     batched_docs = processor([page for doc in docs for page in doc])
     assert batched_docs[-1].shape[0] == (8 * num_docs) % batch_size
 
+    # Repr
+    assert repr(processor) == 'DetectionPreProcessor(output_size=(512, 512), mean=[0.5 0.5 0.5], std=[1. 1. 1.])'
+
 
 def test_dbpostprocessor():
     postprocessor = detection.DBPostProcessor()

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -46,6 +46,8 @@ def test_dbpostprocessor():
     assert all(sample.shape[1] == 5 for sample in out)
     # Relative coords
     assert all(np.all(np.logical_and(sample[:4] >= 0, sample[:4] <= 1)) for sample in out)
+    # Repr
+    assert repr(postprocessor) == 'DetectionPostProcessor(box_thresh=0.5, max_candidates=100)'
 
 
 def test_db_resnet50_training_mode():
@@ -59,6 +61,8 @@ def test_db_resnet50_training_mode():
     assert all(np.all(np.logical_and(out_map.numpy() >= 0, out_map.numpy() <= 1)) for out_map in dboutput_train)
     # batch size
     assert all(out.numpy().shape == (2, 1024, 1024, 1) for out in dboutput_train)
+    # repr
+    assert repr(model) == "DBNet()"
 
 
 @pytest.mark.parametrize(

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -61,8 +61,6 @@ def test_db_resnet50_training_mode():
     assert all(np.all(np.logical_and(out_map.numpy() >= 0, out_map.numpy() <= 1)) for out_map in dboutput_train)
     # batch size
     assert all(out.numpy().shape == (2, 1024, 1024, 1) for out in dboutput_train)
-    # repr
-    assert repr(model) == "DBNet()"
 
 
 @pytest.mark.parametrize(

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -47,7 +47,7 @@ def test_dbpostprocessor():
     # Relative coords
     assert all(np.all(np.logical_and(sample[:4] >= 0, sample[:4] <= 1)) for sample in out)
     # Repr
-    assert repr(postprocessor) == 'DetectionPostProcessor(box_thresh=0.1, max_candidates=1000)'
+    assert repr(postprocessor) == 'DBPostProcessor(box_thresh=0.1, max_candidates=1000)'
 
 
 def test_db_resnet50_training_mode():

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -47,7 +47,7 @@ def test_dbpostprocessor():
     # Relative coords
     assert all(np.all(np.logical_and(sample[:4] >= 0, sample[:4] <= 1)) for sample in out)
     # Repr
-    assert repr(postprocessor) == 'DetectionPostProcessor(box_thresh=0.5, max_candidates=100)'
+    assert repr(postprocessor) == 'DetectionPostProcessor(box_thresh=0.1, max_candidates=1000)'
 
 
 def test_db_resnet50_training_mode():

--- a/test/test_models_recognition.py
+++ b/test/test_models_recognition.py
@@ -31,6 +31,8 @@ def test_recopreprocessor(mock_pdf):  # noqa: F811
     processor = recognition.RecognitionPreProcessor(output_size=(256, 128), batch_size=batch_size)
     batched_docs = processor([page for doc in docs for page in doc])
     assert batched_docs[-1].shape[0] == (8 * num_docs) % batch_size
+    # Repr
+    assert repr(processor) == 'RecognitionPreProcessor(output_size=(256, 128), mean=[0.5 0.5 0.5], std=[1. 1. 1.])'
 
 
 @pytest.mark.parametrize(
@@ -63,6 +65,8 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
     assert isinstance(decoded, list) and all(isinstance(word, str) for word in decoded)
     assert len(decoded) == input_shape[0]
     assert all(char in mock_vocab for word in decoded for char in word)
+    # Repr
+    assert repr(postprocessor) == f'{post_processor}(vocab_size={len(mock_vocab)})'
 
 
 @pytest.fixture(scope="session")

--- a/test/test_models_recognition.py
+++ b/test/test_models_recognition.py
@@ -66,7 +66,7 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
     assert len(decoded) == input_shape[0]
     assert all(char in mock_vocab for word in decoded for char in word)
     # Repr
-    assert repr(postprocessor) == f'{post_processor}(vocab_size={len(mock_vocab)})'
+    assert repr(processor) == f'{post_processor}(vocab_size={len(mock_vocab)})'
 
 
 @pytest.fixture(scope="session")

--- a/test/test_models_utils.py
+++ b/test/test_models_utils.py
@@ -1,6 +1,9 @@
 import pytest
 import os
+import tensorflow as tf
 from tensorflow.keras import layers, Sequential
+from tensorflow.keras.applications import ResNet50
+
 
 from doctr.models import utils
 
@@ -21,3 +24,14 @@ def test_load_pretrained_params(tmpdir_factory):
     assert os.path.exists(cache_dir.join('models').join("tmp_checkpoint-4a98e492"))
     # Check that archive was deleted
     assert os.path.exists(cache_dir.join('models').join("tmp_checkpoint-4a98e492.zip"))
+
+
+def test_intermediate_layer_getter():
+    backbone = ResNet50(include_top=False, weights=None, pooling=None)
+    feat_extractor = utils.IntermediateLayerGetter(backbone, ["conv2_block3_out", "conv3_block4_out"])
+    # Check num of output features
+    input_tensor = tf.random.uniform(shape=[1, 224, 224, 3], minval=0, maxval=1)
+    assert len(feat_extractor(input_tensor)) == 2
+
+    # Repr
+    assert repr(feat_extractor) == "IntermediateLayerGetter()"


### PR DESCRIPTION
This PR introduces the following modifications:
- added repr to all Elements
- added repr to preprocessors, postprocessors and models
- added corresponding unittests

Here is the repr of `ocr_db_crnn` for illustration:
```
OCRPredictor(
  (det_predictor): DetectionPredictor(
    (pre_processor): DetectionPreProcessor(output_size=(1024, 1024), mean=[0.5 0.5 0.5], std=[1. 1. 1.])
    (model): DBNet(
      (feat_extractor): IntermediateLayerGetter()
      (fpn): FeaturePyramidNetwork(channels=128)
      (probability_head): <tensorflow.python.keras.engine.sequential.Sequential object at 0x7f9fb81ce070>
      (threshold_head): <tensorflow.python.keras.engine.sequential.Sequential object at 0x7f9fb81db100>
    )
    (post_processor): DBPostProcessor(box_thresh=0.1, max_candidates=1000)
  )
  (reco_predictor): RecognitionPredictor(
    (pre_processor): RecognitionPreProcessor(output_size=(32, 128), mean=[0.5 0.5 0.5], std=[1. 1. 1.])
    (model): CRNN()
    (post_processor): CTCPostProcessor(vocab_size=118)
  )
  (doc_builder): DocumentBuilder(resolve_lines=False, paragraph_break=0.15)
)
```

Successfully merging this PR will close #100 

Any feedback is welcome!