### PR TITLE
docs: Added model zoo table in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ result = model([doc])
 json_output = result[0].export()
 ```
 
+For an exhaustive list of pretrained models available, please refer to the [documentation](https://mindee.github.io/doctr/models.html).
+
 ### Docker container
 
 If you are to deploy containerized environments, you can use the provided Dockerfile to build a docker image:

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -17,6 +17,23 @@ Text Detection
 --------------
 Localizing text elements in images
 
+.. list-table:: Text detection model zoo
+   :widths: 20 20 15 10 10 10
+   :header-rows: 1
+
+   * - Architecture
+     - Input shape
+     - # params
+     - Recall
+     - Precision
+     - FPS
+   * - db_resnet50
+     - (1024, 1024, 3)
+     -
+     -
+     -
+     -
+
 Pre-processing for detection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In DocTR, the pre-processing scheme for detection is the following:
@@ -48,6 +65,27 @@ Combining the right components around a given architecture for easier usage, pre
 Text Recognition
 ----------------
 Identifying strings in images
+
+.. list-table:: Text recognition model zoo
+   :widths: 20 20 15 10 10
+   :header-rows: 1
+
+   * - Architecture
+     - Input shape
+     - # params
+     - Accuracy
+     - FPS
+   * - crnn_vgg16_bn
+     - (32, 128, 3)
+     -
+     -
+     -
+   * - sar_vgg16_bn
+     - (64, 256, 3)
+     -
+     -
+     -
+
 
 Pre-processing for recognition
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR introduces the following modifications:
- adds a table for text detection models in the documentation (archi, input shape, num of params, recall, precision, fps)
- adds a table for text recognition models (archi, input shape, num of params, accuracy, fps)
- adds a reference to those tables in the README


Successfully merging this PR will close #94