### PR TITLE
fix: pad teacher forcing

### DIFF
--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -145,10 +145,11 @@ class SARDecoder(layers.Layer, NestedObject):
                 dense_labels = tf.sparse.to_dense(
                     labels, default_value=self.vocab_size
                 )
-                # padding function
+                # padding dense_labels: shape (N, sequence_length) -> (N, max_length + 1)
+                # with constant values: eos symbol = vocab_size
                 batch_size = dense_labels.shape[0]
                 s = tf.shape(dense_labels)
-                paddings = [[0, m-s[i]] for (i,m) in enumerate([batch_size, self.max_length + 1])]
+                paddings = [[0, m - s[i]] for (i, m) in enumerate([batch_size, self.max_length + 1])]
                 dense_labels = tf.pad(dense_labels, paddings, 'CONSTANT', constant_values=self.vocab_size)
                 symbol = dense_labels[:, t]
             else:

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -145,6 +145,11 @@ class SARDecoder(layers.Layer, NestedObject):
                 dense_labels = tf.sparse.to_dense(
                     labels, default_value=self.vocab_size
                 )
+                # padding function
+                batch_size = dense_labels.shape[0]
+                s = tf.shape(dense_labels)
+                paddings = [[0, m-s[i]] for (i,m) in enumerate([batch_size, self.max_length + 1])]
+                dense_labels = tf.pad(dense_labels, paddings, 'CONSTANT', constant_values=self.vocab_size)
                 symbol = dense_labels[:, t]
             else:
                 symbol = tf.argmax(logits, axis=-1)


### PR DESCRIPTION
This is a fix for the PR #107: dense labels for teacher forcing were not padded to the length (max_lentgh + 1), and it was crashing the model. SAR is now operational for training. Any feedback is welcome !