### PR TITLE
feat: Added pretrained weights for SAR

### DIFF
--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -23,7 +23,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'post_processor': 'SARPostProcessor',
         'vocab': ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-'
                   'kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l'),
-        'url': None,
+        'url': 'https://github.com/mindee/doctr/releases/download/v0.1-models/sar_vgg16bn-0d7e2c26.zip',
     },
 }
 


### PR DESCRIPTION
This PR repaces the url of the SAR pretrained model in the default cfgs