### PR TITLE
fix: Fixed edge case of result export when there is no detection

### DIFF
--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -144,6 +144,9 @@ class DocumentBuilder(NestedObject):
         if boxes.shape[0] != len(char_sequences):
             raise ValueError(f"Incompatible argument lengths: {boxes.shape[0]}, {len(char_sequences)}")
 
+        if boxes.shape[0] == 0:
+            return []
+
         # Sort bounding boxes from top to bottom, left to right
         idxs = self._sort_boxes(boxes[:, :4])
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -55,6 +55,11 @@ def test_documentbuilder():
     doc_builder = models.DocumentBuilder(resolve_lines=True)
     out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [num_pages], [(100, 200), (100, 200)])
 
+    # No detection
+    boxes = np.zeros((0, 5))
+    out = doc_builder([boxes, boxes], [], [num_pages], [(100, 200), (100, 200)])
+    assert len(out[0].pages[0].blocks) == 0
+
     # Repr
     assert repr(doc_builder) == "DocumentBuilder(resolve_lines=True, paragraph_break=0.15)"
 


### PR DESCRIPTION
Following up on #118, this PR introduces the following modifications:
- fixed block building when there is no detection in the page
- added a corresponding unittest

Any feedback is welcome!