### PR TITLE
fix: Fixed docstring examples and added predictor dimension checks

### DIFF
--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -41,6 +41,10 @@ class OCRPredictor(NestedObject):
         **kwargs: Any,
     ) -> List[Document]:
 
+        # Dimension check
+        if any(page.ndim != 3 for doc in documents for page in doc):
+            raise ValueError("incorrect input shape: all documents are expected to be list of multi-channel 2D images.")
+
         pages = [page for doc in documents for page in doc]
 
         # Localize text elements

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -131,6 +131,10 @@ class DetectionPredictor(NestedObject):
         **kwargs: Any,
     ) -> List[np.ndarray]:
 
+        # Dimension check
+        if any(page.ndim != 3 for page in pages):
+            raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")
+
         processed_batches = self.pre_processor(pages)
         out = [self.model(batch, **kwargs) for batch in processed_batches]
         out = [self.post_processor(batch) for batch in out]

--- a/doctr/models/detection/zoo.py
+++ b/doctr/models/detection/zoo.py
@@ -35,7 +35,7 @@ def db_resnet50_predictor(pretrained: bool = False, **kwargs: Any) -> DetectionP
         >>> import numpy as np
         >>> from doctr.models import db_resnet50_predictor
         >>> model = db_resnet50_predictor(pretrained=True)
-        >>> input_page = (255 * np.random.rand(1, 600, 800, 3)).astype(np.uint8)
+        >>> input_page = (255 * np.random.rand(600, 800, 3)).astype(np.uint8)
         >>> out = model([input_page])
 
     Args:

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -144,6 +144,10 @@ class RecognitionPredictor(NestedObject):
 
         out = []
         if len(crops) > 0:
+            # Dimension check
+            if any(crop.ndim != 3 for crop in crops):
+                raise ValueError("incorrect input shape: all crops are expected to be multi-channel 2D images.")
+
             # Resize & batch them
             processed_batches = self.pre_processor(crops)
 

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -35,7 +35,7 @@ def crnn_vgg16_bn_predictor(pretrained: bool = False, **kwargs: Any) -> Recognit
         >>> import numpy as np
         >>> from doctr.models import crnn_vgg16_bn_predictor
         >>> model = crnn_vgg16_bn_predictor(pretrained=True)
-        >>> input_page = (255 * np.random.rand(1, 512, 128, 3)).astype(np.uint8)
+        >>> input_page = (255 * np.random.rand(512, 128, 3)).astype(np.uint8)
         >>> out = model([input_page])
 
     Args:
@@ -55,7 +55,7 @@ def sar_vgg16_bn_predictor(pretrained: bool = False, **kwargs: Any) -> Recogniti
         >>> import numpy as np
         >>> from doctr.models import sar_vgg16_bn_predictor
         >>> model = sar_vgg16_bn_predictor(pretrained=False)
-        >>> input_page = (255 * np.random.rand(1, 512, 128, 3)).astype(np.uint8)
+        >>> input_page = (255 * np.random.rand(512, 128, 3)).astype(np.uint8)
         >>> out = model([input_page])
 
     Args:

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -36,7 +36,7 @@ def ocr_db_sar(pretrained: bool = False, **kwargs: Any) -> OCRPredictor:
         >>> import numpy as np
         >>> from doctr.models import ocr_db_sar
         >>> model = ocr_db_sar(pretrained=True)
-        >>> input_page = (255 * np.random.rand(1, 600, 800, 3)).astype(np.uint8)
+        >>> input_page = (255 * np.random.rand(600, 800, 3)).astype(np.uint8)
         >>> out = model([[input_page]])
 
     Args:
@@ -57,7 +57,7 @@ def ocr_db_crnn(pretrained: bool = False, **kwargs: Any) -> OCRPredictor:
         >>> import numpy as np
         >>> from doctr.models import ocr_db_crnn
         >>> model = ocr_db_crnn(pretrained=True)
-        >>> input_page = (255 * np.random.rand(1, 600, 800, 3)).astype(np.uint8)
+        >>> input_page = (255 * np.random.rand(600, 800, 3)).astype(np.uint8)
         >>> out = model([[input_page]])
 
     Args:

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -114,6 +114,11 @@ def test_ocrpredictor(mock_pdf, test_detectionpredictor, test_recognitionpredict
     assert all(isinstance(doc, Document) for doc in out)
     # The input PDF has 8 pages
     assert all(len(doc.pages) == 8 for doc in out)
+    # Dimension check
+    with pytest.raises(ValueError):
+        input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
+        _ = predictor([[input_shape]])
+
 
 
 @pytest.mark.parametrize(
@@ -148,6 +153,6 @@ def test_classification_architectures(arch_name, top_implemented, input_shape, o
 )
 def test_zoo_models(arch_name):
     # Model
-    model = models.__dict__[arch_name](pretrained=True)
+    predictor = models.__dict__[arch_name](pretrained=True)
     # Output checks
-    assert isinstance(model, models.OCRPredictor)
+    assert isinstance(predictor, models.OCRPredictor)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -117,8 +117,7 @@ def test_ocrpredictor(mock_pdf, test_detectionpredictor, test_recognitionpredict
     # Dimension check
     with pytest.raises(ValueError):
         input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
-        _ = predictor([[input_shape]])
-
+        _ = predictor([[input_page]])
 
 
 @pytest.mark.parametrize(

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -100,6 +100,11 @@ def test_detectionpredictor(mock_pdf):  # noqa: F811
     # The input PDF has 8 pages
     assert len(out) == 8
 
+    # Dimension check
+    with pytest.raises(ValueError):
+        input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
+        _ = predictor([input_shape])
+
     return predictor
 
 

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -103,7 +103,7 @@ def test_detectionpredictor(mock_pdf):  # noqa: F811
     # Dimension check
     with pytest.raises(ValueError):
         input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
-        _ = predictor([input_shape])
+        _ = predictor([input_page])
 
     return predictor
 

--- a/test/test_models_recognition.py
+++ b/test/test_models_recognition.py
@@ -109,6 +109,11 @@ def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
     assert len(out) == boxes.shape[0]
     assert all(isinstance(charseq, str) for charseq in out)
 
+    # Dimension check
+    with pytest.raises(ValueError):
+        input_crop = (255 * np.random.rand(1, 128, 64, 3)).astype(np.uint8)
+        _ = predictor([input_crop])
+
     return predictor
 
 


### PR DESCRIPTION
This PR introduces the following modifications:
- fixed docstring examples for predictors
- added a dimension check in predictor's call method
- added unittest for this check

Any feedback is welcome!