### PR TITLE
feat: Simplified repr of NestedObject when they have an empty list of children

### DIFF
--- a/doctr/utils/repr.py
+++ b/doctr/utils/repr.py
@@ -35,7 +35,7 @@ class NestedObject:
         if hasattr(self, '_children_names'):
             for key in self._children_names:
                 child = getattr(self, key)
-                if isinstance(child, list):
+                if isinstance(child, list) and len(child) > 0:
                     child_str = ",\n".join([repr(subchild) for subchild in child])
                     if len(child) > 1:
                         child_str = _addindent(f"\n{child_str},", 2)

--- a/test/test_documents_elements.py
+++ b/test/test_documents_elements.py
@@ -101,7 +101,7 @@ def test_line():
     assert line.__repr__() == f"Line(\n  (words): [\n{words_str}\n  ]\n)"
 
     # Ensure that words repr does't span on several lines when there are none
-    assert repr(elements.Line([], ((0, 0), (1, 1)))) == f"Line(\n  (words): []\n)"
+    assert repr(elements.Line([], ((0, 0), (1, 1)))) == "Line(\n  (words): []\n)"
 
 
 def test_artefact():

--- a/test/test_documents_elements.py
+++ b/test/test_documents_elements.py
@@ -100,6 +100,9 @@ def test_line():
     words_str = ' ' * 4 + ',\n    '.join(repr(word) for word in words) + ','
     assert line.__repr__() == f"Line(\n  (words): [\n{words_str}\n  ]\n)"
 
+    # Ensure that words repr does't span on several lines when there are none
+    assert repr(elements.Line([], ((0, 0), (1, 1)))) == f"Line(\n  (words): []\n)"
+
 
 def test_artefact():
     artefact_type = "qr_code"


### PR DESCRIPTION
This PR introduces the following modifications:
- simplified empty child list repr of NestedObject
- adding a unittest to check this

Before this PR, the following snippet:
```
from doctr.documents.elements import Line
# Pass empty list of words
print(Line([], ((0, 0), (1, 1))))
```

would yield
```
Line(
  (words): [
  ]
)

```
while now it yields
```
Line(
  (words): []
)
```

Any feedback is welcome!