### PR TITLE
docs: Fixed multi-versions doc build

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -29,6 +29,7 @@ function deploy_doc(){
 # You can find the commit for each tag on https://github.com/mindee/doctr/tags
 if [ -d build ]; then rm -Rf build; fi
 cp -r source/_static .
+git fetch
 deploy_doc "" latest
 deploy_doc "571af3dc" # v0.1.0 Latest stable release
 rm -rf _build _static

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -29,7 +29,7 @@ function deploy_doc(){
 # You can find the commit for each tag on https://github.com/mindee/doctr/tags
 if [ -d build ]; then rm -Rf build; fi
 cp -r source/_static .
-git fetch
+git fetch --all --tags --unshallow
 deploy_doc "" latest
 deploy_doc "571af3dc" # v0.1.0 Latest stable release
 rm -rf _build _static

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -11,24 +11,25 @@ function deploy_doc(){
         if [ "$2" == "latest" ]; then
             echo "Pushing main"
             sphinx-build source _build -a && mkdir build && mkdir build/$2 && cp -a _build/* build/$2/
-        elif ssh -oStrictHostKeyChecking=no $doc "[ -d build/$2 ]"; then
+        elif [ -d build/$2 ]; then
             echo "Directory" $2 "already exists"
         else
             echo "Pushing version" $2
-            cp -r _static source/
+            cp -r _static source/ && cp _conf.py source/conf.py
             sphinx-build source _build -a
-            mkdir build/$2 && cp -a _build/* build/$2/
+            mkdir build/$2 && cp -a _build/* build/$2/ && git checkout source/
         fi
     else
         echo "Pushing stable"
-        cp -r _static source/
-        sphinx-build source build -a
+        cp -r _static source/ && cp _conf.py source/conf.py
+        sphinx-build source build -a && git checkout source/
     fi
 }
 
 # You can find the commit for each tag on https://github.com/mindee/doctr/tags
 if [ -d build ]; then rm -Rf build; fi
 cp -r source/_static .
+cp source/conf.py _conf.py
 git fetch --all --tags --unshallow
 deploy_doc "" latest
 deploy_doc "571af3dc" # v0.1.0 Latest stable release


### PR DESCRIPTION
This PR fixes multi-version documentation build from CI. 

Currently, the CI has a shallow view of git history, so a `git checkout <HASH>` fails as the history is shallow. 
You can notice the `error: pathspec '571af3dc' did not match any file(s) known to git` error message in the doc deployment [action](https://github.com/mindee/doctr/runs/2096643999?check_suite_focus=true). The consequence of that, is that all versions of the doc that are deployed are the same: cf. https://mindee.github.io/doctr/

I added a `git fetch` to fix this.

Any feedback is welcome!