### PR TITLE
fix: edge case intersection iou metric

### DIFF
--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -98,8 +98,7 @@ def box_iou(boxes_1: np.ndarray, boxes_2: np.ndarray) -> np.ndarray:
     right = np.minimum(r1, r2.T)
     bot = np.minimum(b1, b2.T)
 
-    intersection = np.abs(right - left) * np.abs(bot - top)
-
+    intersection = np.clip(right - left, 0, np.Inf) * np.clip(bot - top, 0, np.Inf)
     union = (r1 - l1) * (b1 - t1) + ((r2 - l2) * (b2 - t2)).T - intersection
 
     return intersection / union
@@ -114,7 +113,6 @@ def assign_pairs(score_mat: np.ndarray, score_threshold: float = 0.5) -> Tuple[n
     Returns:
         a tuple of two lists: the list of assigned row candidates indices, and the list of their column counterparts
     """
-
     row_ind, col_ind = linear_sum_assignment(-score_mat)
     is_kept = score_mat[row_ind, col_ind] >= score_threshold
     return row_ind[is_kept], col_ind[is_kept]

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -113,6 +113,7 @@ def assign_pairs(score_mat: np.ndarray, score_threshold: float = 0.5) -> Tuple[n
     Returns:
         a tuple of two lists: the list of assigned row candidates indices, and the list of their column counterparts
     """
+
     row_ind, col_ind = linear_sum_assignment(-score_mat)
     is_kept = score_mat[row_ind, col_ind] >= score_threshold
     return row_ind[is_kept], col_ind[is_kept]

--- a/test/test_utils_metrics.py
+++ b/test/test_utils_metrics.py
@@ -56,6 +56,7 @@ def test_box_iou(box1, box2, iou, abs_tol):
         [[[0, 0, .5, .5]], [[0, 0, .5, .5]], 0.5, 1, 1, 1],  # Perfect match
         [[[0, 0, 1, 1]], [[0, 0, .5, .5], [.6, .6, .7, .7]], 0.2, 1, 0.5, 0.125],  # Bad match
         [[[0, 0, 1, 1]], [[0, 0, .5, .5], [.6, .6, .7, .7]], 0.5, 0, 0, 0.125],  # Bad match
+        [[0, 0, .1, .1], [.9, .9, 1, 1], 0, 0],  # Boxes far from each other
     ],
 )
 def test_localization_confusion(gts, preds, iou_thresh, recall, precision, mean_iou):

--- a/test/test_utils_metrics.py
+++ b/test/test_utils_metrics.py
@@ -44,6 +44,7 @@ def test_assign_pairs(mat, row_indices, col_indices):
         [[0, 0, .5, .5], [.5, .5, 1, 1], 0, 0],  # No match
         [[0, 0, 1, 1], [.5, .5, 1, 1], 0.25, 0],  # Partial match
         [[.2, .2, .6, .6], [.4, .4, .8, .8], 4 / 28, 1e-7],  # Partial match
+        [[0, 0, .1, .1], [.9, .9, 1, 1], 0, 0],  # Boxes far from each other
     ],
 )
 def test_box_iou(box1, box2, iou, abs_tol):
@@ -56,7 +57,6 @@ def test_box_iou(box1, box2, iou, abs_tol):
         [[[0, 0, .5, .5]], [[0, 0, .5, .5]], 0.5, 1, 1, 1],  # Perfect match
         [[[0, 0, 1, 1]], [[0, 0, .5, .5], [.6, .6, .7, .7]], 0.2, 1, 0.5, 0.125],  # Bad match
         [[[0, 0, 1, 1]], [[0, 0, .5, .5], [.6, .6, .7, .7]], 0.5, 0, 0, 0.125],  # Bad match
-        [[0, 0, .1, .1], [.9, .9, 1, 1], 0, 0],  # Boxes far from each other
     ],
 )
 def test_localization_confusion(gts, preds, iou_thresh, recall, precision, mean_iou):


### PR DESCRIPTION
This PR fixes iou intersection computation for edge cases (clipping by (0, inf) the right-left and bot-top arrays to ensure that intersection will be set to 0 when boxes are not overlapping)