### PR TITLE
feat: add model perf + changed default cfgs

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -30,8 +30,8 @@ Localizing text elements in images
    * - db_resnet50
      - (1024, 1024, 3)
      -
-     -
-     -
+     - 0.45
+     - 0.64
      -
 
 Pre-processing for detection
@@ -78,12 +78,12 @@ Identifying strings in images
    * - crnn_vgg16_bn
      - (32, 128, 3)
      -
-     -
+     - 0.87
      -
    * - sar_vgg16_bn
-     - (64, 256, 3)
+     - (32, 128, 3)
      -
-     -
+     - 0.87
      -
 
 
@@ -120,6 +120,29 @@ Combining the right components around a given architecture for easier usage.
 End-to-End OCR
 --------------
 Predictors that localize and identify text elements in images
+
+.. list-table:: end-to-end model zoo
+   :widths: 20 20 15 10 10 10
+   :header-rows: 1
+
+   * - Architecture
+     - Input shape
+     - # params
+     - Recall
+     - Precision
+     - FPS
+   * - ocr_db_crnn
+     - (1024, 1024, 3)
+     -
+     - 0.39
+     - 0.56
+     -
+   * - ocr_db_sar
+     - (1024, 1024, 3)
+     -
+     - 0.40
+     - 0.56
+     -
 
 Two-stage approaches
 ^^^^^^^^^^^^^^^^^^^^

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -33,7 +33,7 @@ class RecognitionPreProcessor(PreProcessor):
     def __init__(
         self,
         output_size: Tuple[int, int],
-        batch_size: int = 1,
+        batch_size: int = 32,
         mean: Tuple[float, float, float] = (.5, .5, .5),
         std: Tuple[float, float, float] = (1., 1., 1.),
         interpolation: str = 'bilinear',

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -18,8 +18,8 @@ __all__ = ['SAR', 'SARPostProcessor', 'sar_vgg16_bn', 'sar_resnet31']
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
     'sar_vgg16_bn': {
-        'backbone': 'vgg16_bn', 'rnn_units': 512, 'max_length': 40, 'num_decoders': 2,
-        'input_shape': (64, 256, 3),
+        'backbone': 'vgg16_bn', 'rnn_units': 512, 'max_length': 30, 'num_decoders': 2,
+        'input_shape': (32, 128, 3),
         'post_processor': 'SARPostProcessor',
         'vocab': ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-'
                   'kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l'),

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -17,7 +17,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
 }
 
 
-def _predictor(arch: str, pretrained: bool, det_bs=2, reco_bs=16, **kwargs: Any) -> OCRPredictor:
+def _predictor(arch: str, pretrained: bool, det_bs=2, reco_bs=32, **kwargs: Any) -> OCRPredictor:
 
     # Detection
     det_predictor = det_zoo.__dict__[default_cfgs[arch]['detection']](pretrained=pretrained, batch_size=det_bs)

--- a/test/test_models_recognition.py
+++ b/test/test_models_recognition.py
@@ -39,7 +39,7 @@ def test_recopreprocessor(mock_pdf):  # noqa: F811
     "arch_name, input_shape, output_size",
     [
         ["crnn_vgg16_bn", (32, 128, 3), (32, 119)],
-        ["sar_vgg16_bn", (64, 256, 3), (41, 119)],
+        ["sar_vgg16_bn", (32, 128, 3), (31, 119)],
         ["sar_resnet31", (32, 128, 3), (31, 119)],
     ],
 )
@@ -55,8 +55,8 @@ def test_recognition_models(arch_name, input_shape, output_size):
 
 def test_sar_training():
     batch_size = 4
-    input_shape = (64, 256, 3)
-    output_size = (41, 119)
+    input_shape = (32, 128, 3)
+    output_size = (31, 119)
     reco_model = recognition.sar_vgg16_bn(input_shape=input_shape)
     input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
     # input_labels: sparse_tensor of shape batch_size x max_len, encoding the labels
@@ -64,7 +64,7 @@ def test_sar_training():
     indices = [[0, 0], [0, 1], [1, 0], [1, 1], [1, 2], [2, 0], [3, 0], [3, 1], [3, 2], [3, 3], [3, 4]]
     values = tf.random.uniform(shape=[11], minval=0, maxval=118, dtype=tf.dtypes.int64)
     input_labels = tf.sparse.reorder(
-        tf.sparse.SparseTensor(indices=indices, values=values, dense_shape=[batch_size, 41])
+        tf.sparse.SparseTensor(indices=indices, values=values, dense_shape=[batch_size, 31])
     )
     out = reco_model(input_tensor, labels=input_labels, training=True)
     assert isinstance(out, tf.Tensor)


### PR DESCRIPTION
This PR implements the following:
- Benchmark results for 2 end to end models, 2 recognition models and 1 detection model
- set default input size for SAR to 32x128
- set default batch size for recognition task to 32
Any Feedback is welcome!


![Screenshot_2021-03-15 doctr models — doctr 0 1 1a0-git documentation(2)](https://user-images.githubusercontent.com/70526046/111167548-873bbc80-85a1-11eb-9282-17918f5eec40.png)
![Screenshot_2021-03-15 doctr models — doctr 0 1 1a0-git documentation(1)](https://user-images.githubusercontent.com/70526046/111167550-87d45300-85a1-11eb-9d55-db775da0e213.png)
![Screenshot_2021-03-15 doctr models — doctr 0 1 1a0-git documentation](https://user-images.githubusercontent.com/70526046/111167552-87d45300-85a1-11eb-9b36-4fe7a810aede.png)
