### PR TITLE
chore: Fixed CI pypi automatic publish upon release

### DIFF
--- a/.github/workflows/pkg-upload.yaml
+++ b/.github/workflows/pkg-upload.yaml
@@ -2,7 +2,7 @@ name: pypi-publish
 
 on:
   release:
-    types: [published, edited]
+    types: [published]
 
 jobs:
 
@@ -40,6 +40,7 @@ jobs:
         run: |
           VERSION="${VERSION:1}"
           BUILD_VERSION=$VERSION python setup.py sdist bdist_wheel
+          cd dist && for f in doctr-*; do mv "$f" "python-$f"; done && cd ..
           twine check dist/*
           twine upload dist/*
 
@@ -57,53 +58,5 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install torchcam
-          python -c "import torchcam; print(torchcam.__version__)"
-
-  conda-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Miniconda setup
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: 3.7
-      - name: Install dependencies
-        run: |
-          conda install -y conda-build conda-verify anaconda-client
-      - name: Get release tag
-        id: release_tag
-        run: |
-          echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - name: Anaconda login
-        run: |
-          conda install -y conda-build conda-verify anaconda-client
-      - name: Build and publish
-        env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          VERSION: ${{ steps.release_tag.outputs.VERSION }}
-        run: |
-          VERSION="${VERSION:1}"
-          export BUILD_VERSION=$VERSION
-          python setup.py sdist
-          mkdir conda-dist
-          conda-build .conda/ -c pytorch --output-folder conda-dist
-          ls -l conda-dist/noarch/*tar.bz2
-          anaconda upload conda-dist/noarch/*tar.bz2 -u frgfm
-
-  conda-check:
-    if: "!github.event.release.prerelease"
-    runs-on: ubuntu-latest
-    needs: conda-publish
-    steps:
-      - uses: actions/checkout@v2
-      - name: Miniconda setup
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: 3.7
-      - name: Install package
-        run: |
-          conda install -c frgfm torchcam
-          python -c "import torchcam; print(torchcam.__version__)"
+          pip install python-doctr
+          python -c "import doctr; print(doctr.__version__)"


### PR DESCRIPTION
This PR introduces the following modifications:
- removed CI to build conda since it cannot work for now as per #113
- fixed pypi upload job (renamed doctr to python-doctr before upload): each new release created on Github will trigger the publishing on pypi automatically

Any feedback is welcome!