### PR TITLE
docs: Added documentation about model evaluation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
 	'sphinx.ext.viewcode',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
+    'sphinx.ext.autosectionlabel',
     'sphinxemoji.sphinxemoji',  # cf. https://sphinxemojicodes.readthedocs.io/en/stable/
     'sphinx_copybutton',
 ]

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -7,6 +7,8 @@ Whether it is for training or for evaluation, having predefined objects to acces
 can be a significant save of time.
 
 
+.. _datasets:
+
 Available Datasets
 ------------------
 The datasets from DocTR inherit from an abstract class that handles verified downloading from a given URL.

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -34,6 +34,12 @@ Localizing text elements in images
      - 0.854
      -
 
+
+All text detection models above have been evaluated using both the training and evaluation sets of FUNSD (cf. :ref:`datasets`).
+Explanations about the metrics being used are available in :ref:`metrics`.
+
+*Disclaimer: both subsets combine have 199 pages which might not be representative enough of the model capabilities*
+
 Pre-processing for detection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In DocTR, the pre-processing scheme for detection is the following:
@@ -50,8 +56,8 @@ Models expect a TensorFlow tensor as input and produces one in return. DocTR inc
 .. autofunction:: doctr.models.detection.db_resnet50
 
 
-Post-processing outputs
-^^^^^^^^^^^^^^^^^^^^^^^
+Post-processing detections
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 The purpose of this block is to turn the model output (binary segmentation map for instance), into a set of bounding boxes.
 
 
@@ -90,6 +96,11 @@ Identifying strings in images
      -
      - 0.863
      -
+
+All text recognition models above have been evaluated using both the training and evaluation sets of FUNSD (cf. :ref:`datasets`).
+Explanations about the metrics being used are available in :ref:`metrics`.
+
+*Disclaimer: both subsets combine have 30595 word-level crops which might not be representative enough of the model capabilities*
 
 
 Pre-processing for recognition
@@ -167,6 +178,11 @@ Predictors that localize and identify text elements in images
      - 0.781
      - 0.830
      -
+
+All OCR models above have been evaluated using both the training and evaluation sets of FUNSD (cf. :ref:`datasets`).
+Explanations about the metrics being used are available in :ref:`metrics`.
+
+*Disclaimer: both subsets combine have 199 pages which might not be representative enough of the model capabilities*
 
 
 Two-stage approaches

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -15,6 +15,8 @@ Easy-to-use functions to make sense of your model's predictions.
 .. autofunction:: visualize_page
 
 
+.. _metrics:
+
 Task evaluation
 ---------------
 Implementations of task-specific metrics to easily assess your model performances.

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -20,7 +20,7 @@ class ExactMatch:
         \\forall X, Y \\in \\mathcal{W}^N,
         ExactMatch(X, Y) = \\frac{1}{N} \\sum\\limits_{i=1}^N f_{Y_i}(X_i)
 
-    with the function :math:`f_{a}` is the indicator function for :math`a`, defined as:
+    with the indicator function :math:`f_{a}` defined as:
 
     .. math::
         \\forall a, x \\in \\mathcal{W},
@@ -146,7 +146,30 @@ def assign_pairs(score_mat: np.ndarray, score_threshold: float = 0.5) -> Tuple[n
 
 
 class LocalizationConfusion:
-    """Implements common confusion metrics and mean IoU for localization evaluation
+    """Implements common confusion metrics and mean IoU for localization evaluation.
+
+    The aggregated metrics are computed as follows:
+
+    .. math::
+        \\forall Y \\in \\mathcal{B}^N, \\forall X \\in \\mathcal{B}^M, \\\\
+        Recall(X, Y) = \\frac{1}{N} \\sum\\limits_{i=1}^N g_{X}(Y_i) \\\\
+        Precision(X, Y) = \\frac{1}{M} \\sum\\limits_{i=1}^N g_{X}(Y_i) \\\\
+        meanIoU(X, Y) = \\frac{1}{M} \\sum\\limits_{i=1}^M \\max\\limits_{j \\in [1, N]}  IoU(X_i, Y_j)
+
+    with the function :math:`IoU(x, y)` being the Intersection over Union between bounding boxes :math:`x` and
+    :math:`y`, and the function :math:`g_{X}` defined as:
+
+    .. math::
+        \\forall y \\in \\mathcal{B},
+        g_X(y) = \\left\\{
+            \\begin{array}{ll}
+                1 & \\mbox{if } y\\mbox{ has been assigned to any }(X_i)_i\\mbox{ with an }IoU \\geq 0.5 \\\\
+                0 & \\mbox{otherwise.}
+            \\end{array}
+        \\right.
+
+    where :math:`\\mathcal{B}` is the set of possible bounding boxes,
+    :math:`N` (number of ground truths) and :math:`M` (number of predictions) are strictly positive integers.
 
     Example::
         >>> import numpy as np
@@ -196,7 +219,33 @@ class LocalizationConfusion:
 
 
 class OCRMetric:
-    """Implements end-to-end OCR metric
+    """Implements end-to-end OCR metric.
+
+    The aggregated metrics are computed as follows:
+
+    .. math::
+        \\forall (B, L) \\in \\mathcal{B}^N \\times \\mathcal{L}^N,
+        \\forall (\\hat{B}, \\hat{L}) \\in \\mathcal{B}^M \\times \\mathcal{L}^M, \\\\
+        Recall(B, \\hat{B}, L, \\hat{L}) = \\frac{1}{N} \\sum\\limits_{i=1}^N h_{B,L}(\\hat{B}_i, \\hat{L}_i) \\\\
+        Precision(B, \\hat{B}, L, \\hat{L}) = \\frac{1}{M} \\sum\\limits_{i=1}^N h_{B,L}(\\hat{B}_i, \\hat{L}_i) \\\\
+        meanIoU(B, \\hat{B}) = \\frac{1}{M} \\sum\\limits_{i=1}^M \\max\\limits_{j \\in [1, N]}  IoU(\\hat{B}_i, B_j)
+
+    with the function :math:`IoU(x, y)` being the Intersection over Union between bounding boxes :math:`x` and
+    :math:`y`, and the function :math:`h_{B, L}` defined as:
+
+    .. math::
+        \\forall (b, l) \\in \\mathcal{B} \\times \\mathcal{L},
+        h_{B,L}(b, l) = \\left\\{
+            \\begin{array}{ll}
+                1 & \\mbox{if } b\\mbox{ has been assigned to a given }B_j\\mbox{ with an } \\\\
+                & IoU \\geq 0.5 \\mbox{ and that for this assignment, } l = L_j\\\\
+                0 & \\mbox{otherwise.}
+            \\end{array}
+        \\right.
+
+    where :math:`\\mathcal{B}` is the set of possible bounding boxes,
+    :math:`\\mathcal{L}` is the set of possible character sequences,
+    :math:`N` (number of ground truths) and :math:`M` (number of predictions) are strictly positive integers.
 
     Example::
         >>> import numpy as np

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -12,7 +12,27 @@ __all__ = ['ExactMatch', 'box_iou', 'assign_pairs', 'LocalizationConfusion', 'OC
 
 
 class ExactMatch:
-    """Implements exact match metric (word-level accuracy) for recognition task
+    """Implements exact match metric (word-level accuracy) for recognition task.
+
+    The aggregated metric is computed as follows:
+
+    .. math::
+        \\forall X, Y \\in \\mathcal{W}^N,
+        ExactMatch(X, Y) = \\frac{1}{N} \\sum\\limits_{i=1}^N f_{Y_i}(X_i)
+
+    with the function :math:`f_{a}` is the indicator function for :math`a`, defined as:
+
+    .. math::
+        \\forall a, x \\in \\mathcal{W},
+        f_a(x) = \\left\\{
+            \\begin{array}{ll}
+                1 & \\mbox{if } x = a \\\\
+                0 & \\mbox{otherwise.}
+            \\end{array}
+        \\right.
+
+    where :math:`\\mathcal{W}` is the set of all possible character sequences,
+    :math:`N` is a strictly positive integer.
 
     Example::
         >>> from doctr.utils import ExactMatch


### PR DESCRIPTION
This PR introduces the following modifications:
- specified on which dataset the evaluation runs were conducted
- added disclaimer about the low dataset size
- added detailed explanation about metric computation for each task

Here is how the documentation renders for `OCRMetric`:
![image](https://user-images.githubusercontent.com/76527547/111629061-2f939000-87f1-11eb-93d7-5565bd287d32.png)


Any feedback is welcome!