### PR TITLE
refactor: Changed predictor call args to list of pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ from doctr.models import ocr_model
 model = ocr_model(pretrained=True)
 # PDF
 doc = read_pdf("path/to/your/doc.pdf")
-result = model([doc])
+result = model(doc)
 # Image
 page = read_img("path/to/your/img.jpg")
-result = model([[page]])
+result = model([page])
 # Export
-json_output = result[0].export()
+json_output = result.export()
 ```
 
 For an exhaustive list of pretrained models available, please refer to the [documentation](https://mindee.github.io/doctr/models.html).

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -36,7 +36,7 @@ def ocr_predictor(
         >>> from doctr.models import ocr_predictor
         >>> model = ocr_predictor(pretrained=True)
         >>> input_page = (255 * np.random.rand(600, 800, 3)).astype(np.uint8)
-        >>> out = model([[input_page]])
+        >>> out = model([input_page])
 
     Args:
         arch: name of the architecture to use ('db_sar_vgg', 'db_sar_resnet', 'db_crnn_vgg', 'db_crnn_resnet')

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -18,9 +18,9 @@ def main(args):
 
     doc = read_pdf(args.path)
 
-    out = model([doc])
+    out = model(doc)
 
-    for page, img in zip(out[0].pages, doc):
+    for page, img in zip(out.pages, doc):
         visualize_page(page.export(), img)
         plt.show(block=not args.noblock)
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -36,7 +36,7 @@ def main(args):
             gt_labels = list(target['labels'])
 
             # Forward
-            out = model([[page]])
+            out = model([page])
             # Crop GT
             crops = extract_crops(page, gt_boxes)
             reco_out = model.reco_predictor(crops)
@@ -44,7 +44,7 @@ def main(args):
             # Unpack preds
             pred_boxes = []
             pred_labels = []
-            for page in out[0].pages:
+            for page in out.pages:
                 h, w = page.dimensions
                 for block in page.blocks:
                     for line in block.lines:

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -50,21 +50,21 @@ def test_documentbuilder():
     boxes = np.random.rand(words_per_page, 5)
     boxes[:2] *= boxes[2:4]
 
-    out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [num_pages], [(100, 200), (100, 200)])
-    assert isinstance(out, list) and all(isinstance(doc, Document) for doc in out)
-    assert len(out[0].pages) == num_pages
+    out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [(100, 200), (100, 200)])
+    assert isinstance(out, Document)
+    assert len(out.pages) == num_pages
     # 1 Block & 1 line per page
-    assert len(out[0].pages[0].blocks) == 1 and len(out[0].pages[0].blocks[0].lines) == 1
-    assert len(out[0].pages[0].blocks[0].lines[0].words) == words_per_page
+    assert len(out.pages[0].blocks) == 1 and len(out.pages[0].blocks[0].lines) == 1
+    assert len(out.pages[0].blocks[0].lines[0].words) == words_per_page
 
     # Resolve lines
     doc_builder = models.DocumentBuilder(resolve_lines=True)
-    out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [num_pages], [(100, 200), (100, 200)])
+    out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [(100, 200), (100, 200)])
 
     # No detection
     boxes = np.zeros((0, 5))
-    out = doc_builder([boxes, boxes], [], [num_pages], [(100, 200), (100, 200)])
-    assert len(out[0].pages[0].blocks) == 0
+    out = doc_builder([boxes, boxes], [], [(100, 200), (100, 200)])
+    assert len(out.pages[0].blocks) == 0
 
     # Repr
     assert repr(doc_builder) == "DocumentBuilder(resolve_lines=True, paragraph_break=0.15)"
@@ -106,24 +106,22 @@ def test_resolve_lines(input_boxes, sorted_idxs, lines):
 
 def test_ocrpredictor(mock_pdf, test_detectionpredictor, test_recognitionpredictor):  # noqa: F811
 
-    num_docs = 3
     predictor = models.OCRPredictor(
         test_detectionpredictor,
         test_recognitionpredictor
     )
 
-    docs = [read_pdf(mock_pdf) for _ in range(num_docs)]
-    out = predictor(docs)
+    doc = read_pdf(mock_pdf)
+    out = predictor(doc)
 
-    assert len(out) == num_docs
     # Document
-    assert all(isinstance(doc, Document) for doc in out)
+    assert isinstance(out, Document)
     # The input PDF has 8 pages
-    assert all(len(doc.pages) == 8 for doc in out)
+    assert len(out.pages) == 8
     # Dimension check
     with pytest.raises(ValueError):
         input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
-        _ = predictor([[input_page]])
+        _ = predictor([input_page])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces the following modifications:
- switched OCRPredictor input to a list of pages and output to a `Document`
- updated unittests, usage instructions, documentation and scripts accordingly

Resolves #168 

Any feedback is welcome!