### PR TITLE
feat: Added figure scale while preserving aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ docker build . -t <YOUR_IMAGE_TAG>
 
 ### Example script
 
+![DocTR example](https://github.com/mindee/doctr/releases/download/v0.1.1/doctr_example_script.gif)
+
 An example script is provided for a simple documentation analysis of a PDF file:
 
 ```shell

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -56,7 +56,7 @@ def visualize_page(
     page: Dict[str, Any],
     image: np.ndarray,
     words_only: bool = True,
-    scale: float = 12,
+    scale: float = 10,
 ) -> None:
     """Visualize a full page with predicted blocks, lines and words
 

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -56,6 +56,7 @@ def visualize_page(
     page: Dict[str, Any],
     image: np.ndarray,
     words_only: bool = True,
+    scale: float = 12,
 ) -> None:
     """Visualize a full page with predicted blocks, lines and words
 
@@ -74,9 +75,13 @@ def visualize_page(
         page: the exported Page of a Document
         image: np array of the page, needs to have the same shape than page['dimensions']
         words_only: whether only words should be displayed
+        scale: figsize of the largest windows side
     """
+    # Get proper scale and aspect ratio
+    h, w = image.shape[:2]
+    size = (scale * w / h, scale) if h > w else (scale, h / w * scale)
+    fig, ax = plt.subplots(figsize=size)
     # Display the image
-    _, ax = plt.subplots()
     ax.imshow(image)
     # hide both axis
     ax.axis('off')
@@ -111,3 +116,4 @@ def visualize_page(
 
     # Create mlp Cursor to hover patches in artists
     mplcursors.Cursor(artists, hover=2).connect("add", lambda sel: sel.annotation.set_text(sel.artist.get_label()))
+    fig.tight_layout()


### PR DESCRIPTION
This PR introduces the following modifications:
- added a scale arg in `visualize_page` that defines the longest side of the figure while preserving aspect ratio
- increased default value for better visual UX
- added analysis script visualization GIF in README

Here is how it renders now:
![doctr_example_script](https://user-images.githubusercontent.com/76527547/112627416-e0bdaa00-8e31-11eb-81c0-0f62551b6d8e.gif)

Resolves #167

Any feedback is welcome