### PR TITLE
fix: Fixed IoU computation for zero-sized inputs

### DIFF
--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -120,18 +120,22 @@ def box_iou(boxes_1: np.ndarray, boxes_2: np.ndarray) -> np.ndarray:
         the IoU matrix of shape (N, M)
     """
 
-    l1, t1, r1, b1 = np.split(boxes_1, 4, axis=1)
-    l2, t2, r2, b2 = np.split(boxes_2, 4, axis=1)
+    iou_mat = np.zeros((boxes_1.shape[0], boxes_2.shape[1]), dtype=np.float32)
 
-    left = np.maximum(l1, l2.T)
-    top = np.maximum(t1, t2.T)
-    right = np.minimum(r1, r2.T)
-    bot = np.minimum(b1, b2.T)
+    if boxes_1.shape[0] > 0 and boxes_2.shape[1] > 0:
+        l1, t1, r1, b1 = np.split(boxes_1, 4, axis=1)
+        l2, t2, r2, b2 = np.split(boxes_2, 4, axis=1)
 
-    intersection = np.clip(right - left, 0, np.Inf) * np.clip(bot - top, 0, np.Inf)
-    union = (r1 - l1) * (b1 - t1) + ((r2 - l2) * (b2 - t2)).T - intersection
+        left = np.maximum(l1, l2.T)
+        top = np.maximum(t1, t2.T)
+        right = np.minimum(r1, r2.T)
+        bot = np.minimum(b1, b2.T)
 
-    return intersection / union
+        intersection = np.clip(right - left, 0, np.Inf) * np.clip(bot - top, 0, np.Inf)
+        union = (r1 - l1) * (b1 - t1) + ((r2 - l2) * (b2 - t2)).T - intersection
+        iou_mat = intersection / union
+
+    return iou_mat
 
 
 def assign_pairs(score_mat: np.ndarray, score_threshold: float = 0.5) -> Tuple[np.ndarray, np.ndarray]:

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -120,9 +120,9 @@ def box_iou(boxes_1: np.ndarray, boxes_2: np.ndarray) -> np.ndarray:
         the IoU matrix of shape (N, M)
     """
 
-    iou_mat = np.zeros((boxes_1.shape[0], boxes_2.shape[1]), dtype=np.float32)
+    iou_mat = np.zeros((boxes_1.shape[0], boxes_2.shape[0]), dtype=np.float32)
 
-    if boxes_1.shape[0] > 0 and boxes_2.shape[1] > 0:
+    if boxes_1.shape[0] > 0 and boxes_2.shape[0] > 0:
         l1, t1, r1, b1 = np.split(boxes_1, 4, axis=1)
         l2, t2, r2, b2 = np.split(boxes_2, 4, axis=1)
 

--- a/test/test_utils_metrics.py
+++ b/test/test_utils_metrics.py
@@ -42,15 +42,19 @@ def test_assign_pairs(mat, row_indices, col_indices):
 @pytest.mark.parametrize(
     "box1, box2, iou, abs_tol",
     [
-        [[0, 0, .5, .5], [0, 0, .5, .5], 1, 0],  # Perfect match
-        [[0, 0, .5, .5], [.5, .5, 1, 1], 0, 0],  # No match
-        [[0, 0, 1, 1], [.5, .5, 1, 1], 0.25, 0],  # Partial match
-        [[.2, .2, .6, .6], [.4, .4, .8, .8], 4 / 28, 1e-7],  # Partial match
-        [[0, 0, .1, .1], [.9, .9, 1, 1], 0, 0],  # Boxes far from each other
+        [[[0, 0, .5, .5]], [[0, 0, .5, .5]], 1, 0],  # Perfect match
+        [[[0, 0, .5, .5]], [[.5, .5, 1, 1]], 0, 0],  # No match
+        [[[0, 0, 1, 1]], [[.5, .5, 1, 1]], 0.25, 0],  # Partial match
+        [[[.2, .2, .6, .6]], [[.4, .4, .8, .8]], 4 / 28, 1e-7],  # Partial match
+        [[[0, 0, .1, .1]], [[.9, .9, 1, 1]], 0, 0],  # Boxes far from each other
+        [np.zeros((0, 4)), [[0, 0, .5, .5]], 0, 0],  # Zero-sized inputs
+        [[[0, 0, .5, .5]], np.zeros((0, 4)), 0, 0],  # Zero-sized inputs
     ],
 )
 def test_box_iou(box1, box2, iou, abs_tol):
-    assert abs(metrics.box_iou(np.asarray([box1]), np.asarray([box2])) - iou) <= abs_tol
+    iou_mat = metrics.box_iou(np.asarray(box1), np.asarray(box2))
+    if iou_mat.size > 0:
+        assert abs(iou_mat - iou) <= abs_tol
 
 
 @pytest.mark.parametrize(

--- a/test/test_utils_metrics.py
+++ b/test/test_utils_metrics.py
@@ -53,6 +53,7 @@ def test_assign_pairs(mat, row_indices, col_indices):
 )
 def test_box_iou(box1, box2, iou, abs_tol):
     iou_mat = metrics.box_iou(np.asarray(box1), np.asarray(box2))
+    assert iou_mat.shape == (len(box1), len(box2))
     if iou_mat.size > 0:
         assert abs(iou_mat - iou) <= abs_tol
 


### PR DESCRIPTION
This PR introduces the following modifications:
- only performs the computation of IoU when both inputs are not zero-sized
- added unittests accordingly

Any feedback is welcome!