### PR TITLE
fix: Added default TF gpu memory growth

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -10,6 +10,12 @@ import matplotlib.pyplot as plt
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
 from doctr.documents import read_pdf_from_stream
+import tensorflow as tf
+
+gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+if any(gpu_devices):
+    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
+
 from doctr.models import detection_predictor
 
 

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -3,6 +3,13 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
+
+import tensorflow as tf
+
+gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+if any(gpu_devices):
+    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
+
 import matplotlib.pyplot as plt
 from doctr.models import ocr_predictor
 from doctr.documents import DocumentFile

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -4,6 +4,10 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 
+import os
+
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+
 import tensorflow as tf
 
 gpu_devices = tf.config.experimental.list_physical_devices('GPU')

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -9,6 +9,12 @@ from tqdm import tqdm
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
+import tensorflow as tf
+
+gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+if any(gpu_devices):
+    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
+
 from doctr.utils.metrics import LocalizationConfusion, ExactMatch, OCRMetric
 from doctr.datasets import FUNSD
 from doctr.models import ocr_predictor, extract_crops


### PR DESCRIPTION
When available GPU RAM memory is not available, and other edge cases, tensorflow raises a mysterious error `CUBLAS_STATUS_NOT_INITIALIZED`. To tackle this, this PR introduces the following modifications:
- added gpu memory growth for tensorflow in scripts and demo
- silenced tensorflow warning in `scripts/analyze.py`

Any feedback is welcome!