### PR TITLE
feat: add blocks detection

### DIFF
--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -208,7 +208,7 @@ class DocumentBuilder(NestedObject):
         )
         # Compute clusters
         clusters = fclusterdata(box_features, t=0.1, depth=4, criterion='distance', metric='euclidean')
-        
+
         _blocks = dict()
         # Form clusters
         for line_idx, cluster_idx in enumerate(clusters):

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -265,7 +265,8 @@ class DocumentBuilder(NestedObject):
         return blocks
 
     def extra_repr(self) -> str:
-        return f"resolve_lines={self.resolve_lines}, paragraph_break={self.paragraph_break}"
+        return (f"resolve_lines={self.resolve_lines}, resolve_blocks={self.resolve_blocks}, "
+                f"paragraph_break={self.paragraph_break}")
 
     def __call__(
         self,

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -245,6 +245,8 @@ class DocumentBuilder(NestedObject):
             # Decide whether we try to form blocks
             if self.resolve_blocks:
                 blocks = self._resolve_blocks(boxes[:, :4], lines)
+            else:
+                blocks = [lines]
         else:
             # Sort bounding boxes, one line for all boxes, one block for the line
             lines = [self._sort_boxes(boxes[:, :4])]

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -39,9 +39,6 @@ def test_extract_crops(mock_pdf):  # noqa: F811
 
 def test_documentbuilder():
 
-    with pytest.raises(NotImplementedError):
-        models.DocumentBuilder(resolve_blocks=True)
-
     words_per_page = 10
     num_pages = 2
 
@@ -58,7 +55,7 @@ def test_documentbuilder():
     assert len(out.pages[0].blocks[0].lines[0].words) == words_per_page
 
     # Resolve lines
-    doc_builder = models.DocumentBuilder(resolve_lines=True)
+    doc_builder = models.DocumentBuilder(resolve_lines=True, resolve_blocks=True)
     out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [(100, 200), (100, 200)])
 
     # No detection
@@ -67,7 +64,7 @@ def test_documentbuilder():
     assert len(out.pages[0].blocks) == 0
 
     # Repr
-    assert repr(doc_builder) == "DocumentBuilder(resolve_lines=True, paragraph_break=0.035)"
+    assert repr(doc_builder) == "DocumentBuilder(resolve_lines=True, resolve_blocks=True, paragraph_break=0.035)"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR implements resolve_blocks inside DocumentBuilder:
Each document can be built using resolve_block=True (only works if resolve_line=True and both are set to False by default to lighten postprocessing), which will determine the blocks of the pages with a hierarchical clustering on the lines.
Any feedback is welcome!

Computation time: highly insignificant, less than 0.01% of the prediction time for a light page and 0.1% for a dense page on GPU

Examples of detected blocks:
![invoice](https://user-images.githubusercontent.com/70526046/116439139-81e3ba00-a84f-11eb-8beb-72379d28c407.png)
![receipt](https://user-images.githubusercontent.com/70526046/116439148-8314e700-a84f-11eb-9825-9302516b09b9.png)
![visit](https://user-images.githubusercontent.com/70526046/116439130-8019f680-a84f-11eb-918d-f2b0ecad3052.png)
