### PR TITLE
fix: dtype target["boxes"] for CORD and FUNSD

### DIFF
--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -68,7 +68,7 @@ class CORD(VisionDataset):
 
             text_targets, box_targets = zip(*_targets)
 
-            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=np.float32), labels=text_targets)))
+            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=np.int), labels=text_targets)))
 
     def extra_repr(self) -> str:
         return f"train={self.train}"
@@ -79,6 +79,8 @@ class CORD(VisionDataset):
         img = tf.io.read_file(os.path.join(self.root, img_name))
         img = tf.image.decode_jpeg(img, channels=3)
         img = self.sample_transforms(img)
+        # Cast to boxes to int to avoid confusion with relative boxes
+        target['boxes'] = [[int(p) for p in box] for box in target['boxes']]
 
         return img, target
 

--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -79,8 +79,6 @@ class CORD(VisionDataset):
         img = tf.io.read_file(os.path.join(self.root, img_name))
         img = tf.image.decode_jpeg(img, channels=3)
         img = self.sample_transforms(img)
-        # Cast to boxes to int to avoid confusion with relative boxes
-        target['boxes'] = [[int(p) for p in box] for box in target['boxes']]
 
         return img, target
 

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -62,7 +62,7 @@ class FUNSD(VisionDataset):
 
             text_targets, box_targets = zip(*_targets)
 
-            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=np.float32), labels=text_targets)))
+            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=np.int), labels=text_targets)))
 
     def extra_repr(self) -> str:
         return f"train={self.train}"

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -34,8 +34,8 @@ def main(args):
     for dataset in (train_set, test_set):
         for page, target in tqdm(dataset):
             # GT
-            gt_boxes = np.asarray(target['boxes'])
-            gt_labels = list(target['labels'])
+            gt_boxes = target['boxes']
+            gt_labels = target['labels']
 
             # Forward
             out = model([page])


### PR DESCRIPTION
This PR fixes dtype (float --> int) for target["boxes"] of CORD and FUNSD, to avoid confusion between relative and absolute boxes.