### PR TITLE
feat: Improved error when read_pdf gets an incorrect path

### DIFF
--- a/doctr/documents/reader.py
+++ b/doctr/documents/reader.py
@@ -72,6 +72,9 @@ def read_pdf(file: AbstractFile, **kwargs: Any) -> fitz.Document:
         the list of pages decoded as numpy ndarray of shape H x W x 3
     """
 
+    if isinstance(file, (str, Path)) and not Path(file).is_file():
+        raise FileNotFoundError(f"unable to access {file}")
+
     fitz_args = {}
 
     if isinstance(file, (str, Path)):

--- a/test/test_documents_reader.py
+++ b/test/test_documents_reader.py
@@ -39,6 +39,10 @@ def test_read_pdf(mock_pdf, mock_pdf_stream):
     with pytest.raises(TypeError):
         _ = reader.read_pdf(123)
 
+    # Wrong path
+    with pytest.raises(FileNotFoundError):
+        _ = reader.read_pdf("my_imaginary_file.pdf")
+
 
 def test_read_img(tmpdir_factory, mock_pdf):
 


### PR DESCRIPTION
This PR introduces the following modifications:
- added appropriate error when read_pdf gets a path to inexisting file
- updated unittests

Any feedback is welcome!