### PR TITLE
fix: adjust detection postprocessing parameters to img size

### DIFF
--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -85,12 +85,10 @@ class DetectionPostProcessor(NestedObject):
 
     def __init__(
         self,
-        min_size_box: int = 5,
         box_thresh: float = 0.5,
         bin_thresh: float = 0.5
     ) -> None:
 
-        self.min_size_box = min_size_box
         self.box_thresh = box_thresh
         self.bin_thresh = bin_thresh
 
@@ -145,15 +143,15 @@ class DetectionPostProcessor(NestedObject):
         bitmap = tf.unstack(bitmap, axis=0)
 
         boxes_batch = []
-        # kernel for opening
-        kernel = np.ones((3, 3), np.uint8)
+        # Kernel for opening, empirical law for ksize
+        k_size = 1 + int(p[0].shape[0] / 512)
+        kernel = np.ones((k_size, k_size), np.uint8)
 
         for p_, bitmap_ in zip(p, bitmap):
             p_ = p_.numpy()
             bitmap_ = bitmap_.numpy()
-            if p_.shape[0] > 1000:
-                # perform opening (erosion + dilatation) if input is large enough
-                bitmap_ = cv2.morphologyEx(bitmap_, cv2.MORPH_OPEN, kernel)
+            # perform opening (erosion + dilatation)
+            bitmap_ = cv2.morphologyEx(bitmap_, cv2.MORPH_OPEN, kernel)
             boxes = self.bitmap_to_boxes(pred=p_, bitmap=bitmap_)
             boxes_batch.append(boxes)
 

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -145,13 +145,15 @@ class DetectionPostProcessor(NestedObject):
         bitmap = tf.unstack(bitmap, axis=0)
 
         boxes_batch = []
+        # kernel for opening
+        kernel = np.ones((3, 3), np.uint8)
 
         for p_, bitmap_ in zip(p, bitmap):
             p_ = p_.numpy()
             bitmap_ = bitmap_.numpy()
-            # perform opening (erosion + dilatation)
-            kernel = np.ones((3, 3), np.uint8)
-            bitmap_ = cv2.morphologyEx(bitmap_, cv2.MORPH_OPEN, kernel)
+            if p_.shape[0] > 1000:
+                # perform opening (erosion + dilatation) if input is large enough
+                bitmap_ = cv2.morphologyEx(bitmap_, cv2.MORPH_OPEN, kernel)
             boxes = self.bitmap_to_boxes(pred=p_, bitmap=bitmap_)
             boxes_batch.append(boxes)
 

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -31,7 +31,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'fpn_channels': 128,
         'input_shape': (1024, 1024, 3),
         'post_processor': 'DBPostProcessor',
-        'url': 'file:///home/laptopmindee/Téléchargements/ckpts.zip',
+        'url': 'https://github.com/mindee/doctr/releases/download/v0.1.1/db_resnet50-98ba765d.zip',
     },
 }
 

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -119,7 +119,7 @@ class DBPostProcessor(DetectionPostProcessor):
         contours, _ = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
         for contour in contours[:self.max_candidates]:
             # Check whether smallest enclosing bounding box is not too small
-            if np.any(contour[:, 0].max(axis=0) - contour[:, 0].min(axis=0) <= self.min_size_box):
+            if np.any(contour[:, 0].max(axis=0) - contour[:, 0].min(axis=0) < self.min_size_box):
                 continue
             epsilon = 0.01 * cv2.arcLength(contour, True)
             approx = cv2.approxPolyDP(contour, epsilon, True)  # approximate contour by a polygon

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -31,7 +31,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'fpn_channels': 128,
         'input_shape': (1024, 1024, 3),
         'post_processor': 'DBPostProcessor',
-        'url': 'https://github.com/mindee/doctr/releases/download/v0.1.1/db_resnet50-98ba765d.zip',
+        'url': 'file:///home/laptopmindee/Téléchargements/ckpts.zip',
     },
 }
 
@@ -51,14 +51,12 @@ class DBPostProcessor(DetectionPostProcessor):
     def __init__(
         self,
         unclip_ratio: Union[float, int] = 1.5,
-        min_size_box: int = 3,
         max_candidates: int = 1000,
         box_thresh: float = 0.1,
-        bin_thresh: float = 0.15,
+        bin_thresh: float = 0.3,
     ) -> None:
 
         super().__init__(
-            min_size_box,
             box_thresh,
             bin_thresh
         )
@@ -114,12 +112,13 @@ class DBPostProcessor(DetectionPostProcessor):
                 containing x, y, w, h, score for the box
         """
         height, width = bitmap.shape[:2]
+        min_size_box = 1 + int(height / 512)
         boxes = []
         # get contours from connected components on the bitmap
         contours, _ = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
         for contour in contours[:self.max_candidates]:
             # Check whether smallest enclosing bounding box is not too small
-            if np.any(contour[:, 0].max(axis=0) - contour[:, 0].min(axis=0) < self.min_size_box):
+            if np.any(contour[:, 0].max(axis=0) - contour[:, 0].min(axis=0) < min_size_box):
                 continue
             epsilon = 0.01 * cv2.arcLength(contour, True)
             approx = cv2.approxPolyDP(contour, epsilon, True)  # approximate contour by a polygon
@@ -131,7 +130,7 @@ class DBPostProcessor(DetectionPostProcessor):
                 continue
             _box = self.polygon_to_box(points)
 
-            if _box is None or _box[2] < self.min_size_box or _box[3] < self.min_size_box:  # remove to small boxes
+            if _box is None or _box[2] < min_size_box or _box[3] < min_size_box:  # remove to small boxes
                 continue
             x, y, w, h = _box
             # compute relative polygon to get rid of img shape

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -48,7 +48,6 @@ class LinkNetPostProcessor(DetectionPostProcessor):
         box_thresh: float = 0.1,
     ) -> None:
         super().__init__(
-            min_size_box,
             box_thresh,
             bin_thresh
         )
@@ -70,6 +69,7 @@ class LinkNetPostProcessor(DetectionPostProcessor):
         """
         label_num, labelimage = cv2.connectedComponents(bitmap.astype(np.uint8), connectivity=4)
         height, width = bitmap.shape[:2]
+        min_size_box = 1 + int(height / 512)
         boxes = []
         for label in range(1, label_num + 1):
             points = np.array(np.where(labelimage == label)[::-1]).T
@@ -79,7 +79,7 @@ class LinkNetPostProcessor(DetectionPostProcessor):
             if self.box_thresh > score:   # remove polygons with a weak objectness
                 continue
             x, y, w, h = cv2.boundingRect(points)
-            if min(w, h) < self.min_size_box:  # filter too small boxes
+            if min(w, h) < min_size_box:  # filter too small boxes
                 continue
             # compute relative polygon to get rid of img shape
             xmin, ymin, xmax, ymax = x / width, y / height, (x + w) / width, (y + h) / height

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -88,8 +88,8 @@ def main(args):
     st = time.time()
     # Load both train and val data generators
     train_set = DetectionDataset(
-        img_folder=os.path.join(args.data_path, 'sample_img'),
-        label_folder=os.path.join(args.data_path, 'sample_label'),
+        img_folder=os.path.join(args.data_path, 'train'),
+        label_folder=os.path.join(args.data_path, 'train_labels'),
         sample_transforms=T.Compose([
             T.LambdaTransformation(lambda x: x / 255),
             T.Resize((args.input_size, args.input_size)),
@@ -107,8 +107,8 @@ def main(args):
 
     st = time.time()
     val_set = DetectionDataset(
-        img_folder=os.path.join(args.data_path, 'sample_img'),
-        label_folder=os.path.join(args.data_path, 'sample_label'),
+        img_folder=os.path.join(args.data_path, 'val'),
+        label_folder=os.path.join(args.data_path, 'val_labels'),
         sample_transforms=T.Compose([
             T.LambdaTransformation(lambda x: x / 255),
             T.Resize((args.input_size, args.input_size)),

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -88,8 +88,8 @@ def main(args):
     st = time.time()
     # Load both train and val data generators
     train_set = DetectionDataset(
-        img_folder=os.path.join(args.data_path, 'train'),
-        label_folder=os.path.join(args.data_path, 'train_labels'),
+        img_folder=os.path.join(args.data_path, 'sample_img'),
+        label_folder=os.path.join(args.data_path, 'sample_label'),
         sample_transforms=T.Compose([
             T.LambdaTransformation(lambda x: x / 255),
             T.Resize((args.input_size, args.input_size)),
@@ -107,8 +107,8 @@ def main(args):
 
     st = time.time()
     val_set = DetectionDataset(
-        img_folder=os.path.join(args.data_path, 'val'),
-        label_folder=os.path.join(args.data_path, 'val_labels'),
+        img_folder=os.path.join(args.data_path, 'sample_img'),
+        label_folder=os.path.join(args.data_path, 'sample_label'),
         sample_transforms=T.Compose([
             T.LambdaTransformation(lambda x: x / 255),
             T.Resize((args.input_size, args.input_size)),


### PR DESCRIPTION
This PR adjusts detection postprocessing to img size: If input is smaller than 1000 x 1000, don't perform opening (erosion + dilatation of boxes) because boxes can be too small. The others parameters don't depend on the size of the input (we could reduce min_size_box but this doesn't make sense because a box smaller than 2 pixels would be impossible to read, no matter the size of the input image).
Any feedback is welcome!