### PR TITLE
feat: set default image resolution to 1024 in read_pdf

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -48,7 +48,7 @@ def main():
     uploaded_file = st.sidebar.file_uploader("Upload files", type=['pdf', 'png', 'jpeg', 'jpg'])
     if uploaded_file is not None:
         if uploaded_file.name.endswith('.pdf'):
-            doc = DocumentFile.from_pdf(uploaded_file.read()).as_images()
+            doc = DocumentFile.from_pdf(uploaded_file.read()).as_images(output_size=(1024, 1024))
         else:
             doc = DocumentFile.from_images(uploaded_file.read())
         cols[0].image(doc[0], "First page", use_column_width=True)

--- a/doctr/documents/reader.py
+++ b/doctr/documents/reader.py
@@ -90,7 +90,7 @@ def read_pdf(file: AbstractFile, **kwargs: Any) -> fitz.Document:
 
 def convert_page_to_numpy(
     page: fitz.fitz.Page,
-    output_size: Optional[Tuple[int, int]] = None,
+    output_size: Optional[Tuple[int, int]] = (1024, 1024),
     rgb_output: bool = True,
 ) -> np.ndarray:
     """Convert a fitz page to a numpy-formatted image

--- a/doctr/documents/reader.py
+++ b/doctr/documents/reader.py
@@ -90,14 +90,15 @@ def read_pdf(file: AbstractFile, **kwargs: Any) -> fitz.Document:
 
 def convert_page_to_numpy(
     page: fitz.fitz.Page,
-    output_size: Optional[Tuple[int, int]] = (1024, 1024),
+    output_size: Optional[Tuple[int, int]] = None,
     rgb_output: bool = True,
 ) -> np.ndarray:
     """Convert a fitz page to a numpy-formatted image
 
     Args:
         page: the page of a file read with PyMuPDF
-        output_size: the expected output size of each page in format H x W
+        output_size: the expected output size of each page in format H x W. Default goes to 840 x 595 for A4 pdf,
+        if you want to increase the resolution while preserving the original A4 aspect ratio can pass (1024, 726)
         rgb_output: whether the output ndarray channel order should be RGB instead of BGR.
 
     Returns:

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -21,9 +21,8 @@ from doctr.documents import DocumentFile
 def main(args):
 
     model = ocr_predictor(args.detection, args.recognition, pretrained=True)
-
     if args.path.endswith(".pdf"):
-        doc = DocumentFile.from_pdf(args.path).as_images()
+        doc = DocumentFile.from_pdf(args.path).as_images(output_size=(1024, 1024))
     else:
         doc = DocumentFile.from_images(args.path)
 

--- a/test/test_documents_reader.py
+++ b/test/test_documents_reader.py
@@ -12,7 +12,7 @@ def test_convert_page_to_numpy(mock_pdf):
     # Check correct read
     rgb_page = reader.convert_page_to_numpy(pdf[0])
     assert isinstance(rgb_page, np.ndarray)
-    assert rgb_page.shape == (792, 612, 3)
+    assert rgb_page.shape == (1024, 1024, 3)
 
     # Check channel order
     bgr_page = reader.convert_page_to_numpy(pdf[0], rgb_output=False)

--- a/test/test_documents_reader.py
+++ b/test/test_documents_reader.py
@@ -12,7 +12,7 @@ def test_convert_page_to_numpy(mock_pdf):
     # Check correct read
     rgb_page = reader.convert_page_to_numpy(pdf[0])
     assert isinstance(rgb_page, np.ndarray)
-    assert rgb_page.shape == (1024, 1024, 3)
+    assert rgb_page.shape == (792, 612, 3)
 
     # Check channel order
     bgr_page = reader.convert_page_to_numpy(pdf[0], rgb_output=False)


### PR DESCRIPTION
Before this PR, the image resolution was computed by default this way in `read_pdf`:
Find pdf dimension, scale by 72 DPI to obtain image dimension.

This raises 2 issues:
- Different document sizes yield to different resolutions (constant DPI)
- For A4 sizes (a huge amount of docs), this method was re-scaling to 840 x 595 pixels which is way to low for very dense docs.

Now we have a constant resolution of 1024 x 1024 by default.
Any feedback is welcome!

closes #232 
