### PR TITLE
docs: add vocabs in doc

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -30,10 +30,38 @@ Each dataset has its specific way to load a sample, but handling batch aggregati
 .. autoclass:: doctr.datasets.loader.DataLoader
 
 
+.. _vocabs:
+
 Supported Vocabs
 ----------------
 
 Since textual content has to be encoded properly for models to interpret them efficiently, DocTR supports multiple sets
 of vocabs.
+
+.. list-table:: DocTR Vocabs
+   :widths: 20 5 50
+   :header-rows: 1
+
+   * - Name
+     - size
+     - characters
+   * - digits
+     - 10
+     - 0123456789
+   * - ascii_letters
+     - 52
+     - abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+   * - punctuation
+     - 32
+     - !"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~
+   * - currency
+     - 5
+     - £€¥¢฿
+   * - latin
+     - 96
+     - 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~°
+   * - french
+     - 154
+     - 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~°àâéèêëîïôùûçÀÂÉÈËÎÏÔÙÛÇ£€¥¢฿
 
 .. autofunction:: encode_sequences

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -98,6 +98,8 @@ Identifying strings in images
 All text recognition models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
 Explanations about the metrics being used are available in :ref:`metrics`.
 
+All these recognition models are trained with our french vocab (cf. :ref:`vocabs`).
+
 *Disclaimer: both FUNSD subsets combine have 30595 word-level crops which might not be representative enough of the model capabilities*
 
 FPS (Frames per second) is computed this way: we instantiate the model, we feed the model with 100 random tensors of shape [1, 32, 128, 3] as a warm-up. Then, we measure the average speed of the model on 1000 batches of 1 frame (random tensors of shape [1, 32, 128, 3]).
@@ -156,6 +158,8 @@ Predictors that localize and identify text elements in images
 
 All OCR models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
 Explanations about the metrics being used are available in :ref:`metrics`.
+
+All recognition models of predictors are trained with our french vocab (cf. :ref:`vocabs`).
 
 *Disclaimer: both FUNSD subsets combine have 199 pages which might not be representative enough of the model capabilities*
 


### PR DESCRIPTION
This PR adds:
- tab of supported vocabs in doc (dataset)
- vocab to use for each model (models)

Any feedback is welcome!

closes #235 