### PR TITLE
docs: improved landing page of documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,20 +1,68 @@
 DocTR: Document Text Recognition
 ================================
 
+State-of-the-art Optical Character Recognition made seamless & accessible to anyone, powered by TensorFlow 2
+
 DocTR provides an easy and powerful way to extract valuable information from your documents:
 
-* |:receipt:| **for automation**: seemlessly process documents for Natural Language Understanding tasks
-* |:woman_scientist:| **for research**: quickly compare your own architectures performances with state-of-art models
+* |:receipt:| **for automation**: seemlessly process documents for Natural Language Understanding tasks: we provide OCR predictors to parse textual information (localize and identify each word) from your documents.
+* |:woman_scientist:| **for research**: quickly compare your own architectures speed & performances with state-of-art models on public datasets.
+
+This is the documentation of our repository `doctr <https://github.com/mindee/doctr>`_.
+
+
+Features
+--------
+
+* |:robot:| Robust 2-stages (detection + recognition) OCR predictors fully trained
+* |:zap:| user-friendly, 3 lines of code to load a document and extract text with a predictor
+* |:rocket:| state-of-the-art performances on public document datasets, comparable with GoogleVision/AWS Textract
+* |:zap:| predictors optimized to be very fast on both CPU & GPU
+* |:bird:| Light package, small dependencies
+* |:tools:| daily maintained
+* |:factory:| Easily integrable
+
+
+|:scientist:| Build & train your predictor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* |:construction_worker:| Compose your own end-to-end OCR predictor: mix and match detection & recognition predictors (all-pretrained)
+* |:construction_worker:| Fine-tune or train from scratch any detection or recognition model to specialize on your data
+
+
+|:toolbox:| Implemented models
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+   Detection models
+   """"""""""""""""
+   * DB (Differentiable Binarization), `"Real-time Scene Text Detection with Differentiable Binarization" <https://arxiv.org/pdf/1911.08947.pdf>`_.
+   * LinkNet, `"LinkNet: Exploiting Encoder Representations for Efficient Semantic Segmentation" <https://arxiv.org/pdf/1707.03718.pdf>`_.
+
+   Recognition models
+   """"""""""""""""""
+   * SAR (Show, Attend and Read), `"Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition" <https://arxiv.org/pdf/1811.00751.pdf>`_.
+   * CRNN (Convolutional Recurrent Neural Network), `"An End-to-End Trainable Neural Network for Image-based Sequence Recognition and Its Application to Scene Text Recognition" <https://arxiv.org/pdf/1507.05717.pdf>`_.
+
+
+|:receipt:| Integrated datasets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   * FUNSD from `"FUNSD: A Dataset for Form Understanding in Noisy Scanned Documents" <https://arxiv.org/pdf/1905.13538.pdf>`_.
+   * CORD from `"CORD: A Consolidated Receipt Dataset forPost-OCR Parsing" <https://openreview.net/pdf?id=SJl3z659UH>`_.
+
+
+Getting Started
+---------------
 
 .. toctree::
    :maxdepth: 2
-   :caption: Getting Started
 
    installing
 
+
+Contents
+--------
+
 .. toctree::
    :maxdepth: 1
-   :caption: Package Documentation
 
    datasets
    documents

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,11 +15,11 @@ Features
 --------
 
 * |:robot:| Robust 2-stages (detection + recognition) OCR predictors fully trained
-* |:zap:| user-friendly, 3 lines of code to load a document and extract text with a predictor
-* |:rocket:| state-of-the-art performances on public document datasets, comparable with GoogleVision/AWS Textract
-* |:zap:| predictors optimized to be very fast on both CPU & GPU
+* |:zap:| User-friendly, 3 lines of code to load a document and extract text with a predictor
+* |:rocket:| State-of-the-art performances on public document datasets, comparable with GoogleVision/AWS Textract
+* |:zap:| Predictors optimized to be very fast on both CPU & GPU
 * |:bird:| Light package, small dependencies
-* |:tools:| daily maintained
+* |:tools:| Daily maintained
 * |:factory:| Easily integrable
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,13 +32,13 @@ Features
 |:toolbox:| Implemented models
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   Detection models
-   """"""""""""""""
+Detection models
+""""""""""""""""
    * DB (Differentiable Binarization), `"Real-time Scene Text Detection with Differentiable Binarization" <https://arxiv.org/pdf/1911.08947.pdf>`_.
    * LinkNet, `"LinkNet: Exploiting Encoder Representations for Efficient Semantic Segmentation" <https://arxiv.org/pdf/1707.03718.pdf>`_.
 
-   Recognition models
-   """"""""""""""""""
+Recognition models
+""""""""""""""""""
    * SAR (Show, Attend and Read), `"Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition" <https://arxiv.org/pdf/1811.00751.pdf>`_.
    * CRNN (Convolutional Recurrent Neural Network), `"An End-to-End Trainable Neural Network for Image-based Sequence Recognition and Its Application to Scene Text Recognition" <https://arxiv.org/pdf/1507.05717.pdf>`_.
 


### PR DESCRIPTION
This PR makes the landing page of the documentation more user-friendly, describing features and models/datasets provided in the package.
Any feedback is welcome!

Before:
![image](https://user-images.githubusercontent.com/70526046/117119275-1b502600-ad92-11eb-9ad5-e9f67010620a.png)

Now:
![image](https://user-images.githubusercontent.com/70526046/117119616-9d404f00-ad92-11eb-9fc7-783a500b6a94.png)


closes #236 