### PR TITLE
feat: Added minimal API template for text recognition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,3 +177,17 @@ jobs:
         run: |
           wget https://github.com/mindee/doctr/releases/download/v0.1.0/sample.pdf
           python scripts/analyze.py sample.pdf --noblock
+
+  api-ready:
+    runs-on: ubuntu-latest
+    needs: pkg-install
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build & run docker
+        run: PORT=8002 docker-compose up -d --build
+      - name: Install dependencies in docker
+        run: |
+          PORT=8002 docker-compose exec -T web python -m pip install --upgrade pip
+          PORT=8002 docker-compose exec -T web pip install -r requirements-dev.txt
+      - name: Run docker test
+        run: PORT=8002 docker-compose exec -T web pytest .

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,0 +1,30 @@
+FROM python:3.8.1-slim
+
+# set work directory
+WORKDIR /usr/src/app
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONPATH "${PYTHONPATH}:/app"
+
+# copy requirements file
+COPY api/requirements.txt /usr/src/app/api-requirements.txt
+COPY ./requirements.txt /tmp/requirements.txt
+COPY ./README.md /tmp/README.md
+COPY ./setup.py /tmp/setup.py
+COPY ./doctr /tmp/doctr
+
+# install dependencies
+RUN apt-get update \
+    && apt-get install --no-install-recommends ffmpeg libsm6 libxext6 -y \
+    && pip install --upgrade pip setuptools wheel \
+    && pip install -e /tmp/. \
+    && pip install -r /usr/src/app/api-requirements.txt \
+    && pip cache purge \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /root/.cache/pip
+
+# copy project
+COPY api/ /usr/src/app/

--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ python scripts/analyze.py path/to/your/doc.pdf
 All script arguments can be checked using `python scripts/analyze.py --help`
 
 
+### Minimal API integration
+
+Looking to integrate DocTR into your API? Here is a template to get you started with a fully working API.
+
+#### Manual setup
+Specific dependencies are required to run the API template, which you can install as follows:
+```shell
+pip install -r api/requirements.txt
+```
+You can now run your API locally:
+
+```shell
+uvicorn --reload --workers 1 --host 0.0.0.0 --port=8050 --app-dir api/ app.main:app
+```
+
+#### Docker setup
+You can run the same server on a docker container if you prefer using:
+```shell
+PORT=8050 docker-compose up -d --build
+```
+
 
 ## Contributing
 

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -4,7 +4,6 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
-import secrets
 import doctr
 
 

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -12,9 +12,3 @@ PROJECT_NAME: str = 'DocTR API'
 PROJECT_DESCRIPTION: str = 'Template API for Optical Character Recognition'
 VERSION: str = doctr.__version__
 DEBUG: bool = os.environ.get('DEBUG', '') != 'False'
-
-SECRET_KEY: str = secrets.token_urlsafe(32)
-if DEBUG:
-    # To keep the same Auth at every app loading in debug mode and not having to redo the auth.
-    debug_secret_key = "000000000000000000000000000000000000"
-    SECRET_KEY = debug_secret_key

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -5,11 +5,12 @@
 
 import os
 import secrets
+import doctr
 
 
 PROJECT_NAME: str = 'DocTR API'
 PROJECT_DESCRIPTION: str = 'Template API for Optical Character Recognition'
-VERSION: str = "0.1.2a0"
+VERSION: str = doctr.__version__
 DEBUG: bool = os.environ.get('DEBUG', '') != 'False'
 
 SECRET_KEY: str = secrets.token_urlsafe(32)

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import os
+import secrets
+
+
+PROJECT_NAME: str = 'DocTR API'
+PROJECT_DESCRIPTION: str = 'Template API for Optical Character Recognition'
+VERSION: str = "0.1.2a0"
+DEBUG: bool = os.environ.get('DEBUG', '') != 'False'
+
+SECRET_KEY: str = secrets.token_urlsafe(32)
+if DEBUG:
+    # To keep the same Auth at every app loading in debug mode and not having to redo the auth.
+    debug_secret_key = "000000000000000000000000000000000000"
+    SECRET_KEY = debug_secret_key

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import time
+from fastapi import FastAPI, Request
+from fastapi.openapi.utils import get_openapi
+
+from app import config as cfg
+from app.routes import recognition
+
+
+app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, debug=cfg.DEBUG, version=cfg.VERSION)
+
+
+# Routing
+app.include_router(recognition.router, prefix="/recognition", tags=["recognition"])
+
+
+# Middleware
+@app.middleware("http")
+async def add_process_time_header(request: Request, call_next):
+    start_time = time.time()
+    response = await call_next(request)
+    process_time = time.time() - start_time
+    response.headers["X-Process-Time"] = str(process_time)
+    return response
+
+
+# Docs
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title=cfg.PROJECT_NAME,
+        version=cfg.VERSION,
+        description=cfg.PROJECT_DESCRIPTION,
+        routes=app.routes,
+    )
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi

--- a/api/app/routes/recognition.py
+++ b/api/app/routes/recognition.py
@@ -3,8 +3,7 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-from typing import List
-from fastapi import APIRouter, UploadFile, File, HTTPException, status
+from fastapi import APIRouter, UploadFile, File
 
 import tensorflow as tf
 

--- a/api/app/routes/recognition.py
+++ b/api/app/routes/recognition.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+from typing import List
+from fastapi import APIRouter, UploadFile, File, HTTPException, status
+
+import tensorflow as tf
+
+gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+if any(gpu_devices):
+    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
+
+from doctr.models import recognition_predictor
+
+from app.schemas import RecognitionOut
+
+
+reco_predictor = recognition_predictor(pretrained=True)
+
+router = APIRouter()
+
+
+@router.post("/", response_model=RecognitionOut, status_code=200, summary="Perform text recognition")
+async def text_recognition(file: UploadFile = File(...)):
+    """Runs DocTR text recognition model to analyze the input"""
+    img = tf.io.decode_image(file.file.read())
+    out = reco_predictor(img[None, ...], training=False)
+    return RecognitionOut(value=out[0])

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+from pydantic import BaseModel, Field
+
+
+# Recognition output
+class RecognitionOut(BaseModel):
+    value: str = Field(..., example="Hello")

--- a/api/requirements-dev.txt
+++ b/api/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest>=5.3.2
+pytest-asyncio>=0.14.0
+asyncpg>=0.20.0
+httpx>=0.16.1

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.61.1
+uvicorn>=0.11.1
+python-multipart==0.0.5
+doctr>=0.1.1

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import pytest
+import requests
+from httpx import AsyncClient
+
+from app.main import app
+
+
+@pytest.fixture(scope="session")
+def mock_recognition_image(tmpdir_factory):
+    url = 'https://user-images.githubusercontent.com/76527547/117133599-c073fa00-ada4-11eb-831b-412de4d28341.jpeg'
+    return requests.get(url).content
+
+
+@pytest.fixture(scope="function")
+async def test_app_asyncio():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac  # testing happens here

--- a/api/tests/routes/test_recognition.py
+++ b/api/tests/routes/test_recognition.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import io
+import pytest
+
+@pytest.mark.asyncio
+async def test_text_recognition(test_app_asyncio, mock_recognition_image):
+
+    response = await test_app_asyncio.post("/recognition", files={'file': mock_recognition_image})
+    assert response.status_code == 200
+
+    assert response.json() == {"value": "invite"}

--- a/api/tests/routes/test_recognition.py
+++ b/api/tests/routes/test_recognition.py
@@ -6,6 +6,7 @@
 import io
 import pytest
 
+
 @pytest.mark.asyncio
 async def test_text_recognition(test_app_asyncio, mock_recognition_image):
 

--- a/api/tests/routes/test_recognition.py
+++ b/api/tests/routes/test_recognition.py
@@ -3,7 +3,6 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-import io
 import pytest
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.7'
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile-api
+    command: uvicorn app.main:app --reload --workers 1 --host 0.0.0.0 --port 8000
+    volumes:
+      - ./api/:/usr/src/app/
+    ports:
+      - ${PORT}:8000


### PR DESCRIPTION
Following up on #233, this PR introduces the following modifications:
- adds a minimal FastAPI-based implementation of a text recognition route
- added Docker orchestration
- added API unittests
- added CI job to ensure it runs correctly & that corresponding unittests are run correctly

Here is how the API documentation renders:
![doctr_api_doc](https://user-images.githubusercontent.com/76527547/117133559-b225de00-ada4-11eb-96ba-bd56c1e8d3f3.png)

I made a test on my own with the following image:
![invite](https://user-images.githubusercontent.com/76527547/117133599-c073fa00-ada4-11eb-831b-412de4d28341.jpeg)
Once the API is running locally on port 8050, with this piece of code:
```
import requests
import io
with open('/home/fg/Downloads/invite.jpeg', 'rb') as f:
    data = f.read()
response = requests.post("http://localhost:8050/recognition", files={'file': io.BytesIO(data)})
```
I get the following result
```
In [10]: response.json()
Out[10]: {'value': 'invite'}
```

Any feedback is welcome!