### PR TITLE
feat: Added text detection route to API template

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 
 from app import config as cfg
-from app.routes import recognition
+from app.routes import recognition, detection
 
 
 app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, debug=cfg.DEBUG, version=cfg.VERSION)
@@ -16,6 +16,7 @@ app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, debug
 
 # Routing
 app.include_router(recognition.router, prefix="/recognition", tags=["recognition"])
+app.include_router(detection.router, prefix="/detection", tags=["detection"])
 
 
 # Middleware

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from fastapi import APIRouter, UploadFile, File
+from typing import List
 
 import tensorflow as tf
 
@@ -26,4 +27,4 @@ async def text_detection(file: UploadFile = File(...)):
     """Runs DocTR text recognition model to analyze the input"""
     img = tf.io.decode_image(file.file.read())
     out = det_predictor(img[None, ...], training=False)
-    return [DetectionOut(box=box.tolist()) for box in out[0]]
+    return [DetectionOut(box=box.tolist()) for box in out[0][:, :4]]

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+from fastapi import APIRouter, UploadFile, File
+
+import tensorflow as tf
+
+gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+if any(gpu_devices):
+    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
+
+from doctr.models import detection_predictor
+
+from app.schemas import DetectionOut
+
+
+det_predictor = detection_predictor(pretrained=True)
+
+router = APIRouter()
+
+
+@router.post("/", response_model=List[DetectionOut], status_code=200, summary="Perform text detection")
+async def text_detection(file: UploadFile = File(...)):
+    """Runs DocTR text recognition model to analyze the input"""
+    img = tf.io.decode_image(file.file.read())
+    out = det_predictor(img[None, ...], training=False)
+    return [DetectionOut(box=box.tolist()) for box in out[0]]

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -9,3 +9,7 @@ from pydantic import BaseModel, Field
 # Recognition output
 class RecognitionOut(BaseModel):
     value: str = Field(..., example="Hello")
+
+
+class DetectionOut(BaseModel):
+    box: Tuple[float, float, float, float]

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from pydantic import BaseModel, Field
+from typing import Tuple
 
 
 # Recognition output

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -16,6 +16,12 @@ def mock_recognition_image(tmpdir_factory):
     return requests.get(url).content
 
 
+@pytest.fixture(scope="session")
+def mock_detection_image(tmpdir_factory):
+    url = 'https://user-images.githubusercontent.com/76527547/117319856-fc35bf00-ae8b-11eb-9b51-ca5aba673466.jpg'
+    return requests.get(url).content
+
+
 @pytest.fixture(scope="function")
 async def test_app_asyncio():
     async with AsyncClient(app=app, base_url="http://test") as ac:

--- a/api/tests/routes/test_detection.py
+++ b/api/tests/routes/test_detection.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import pytest
+import numpy as np
+from doctr.utils.metrics import box_iou, assign_pairs
+
+
+@pytest.mark.asyncio
+async def test_text_detection(test_app_asyncio, mock_detection_image):
+
+    response = await test_app_asyncio.post("/detection", files={'file': mock_detection_image})
+    assert response.status_code == 200
+    json_response = response.json()
+
+    gt_boxes = np.array([[1240, 430, 1355, 470], [1360, 430, 1495, 470]], dtype=np.float32)
+    gt_boxes[:, [0, 2]] = gt_boxes[:, [0, 2]] / 1654
+    gt_boxes[:, [1, 3]] = gt_boxes[:, [1, 3]] / 2339
+
+    # Check that IoU with GT if reasonable
+    assert isinstance(json_response, list) and len(json_response) == gt_boxes.shape[0]
+    pred_boxes = np.array([elt['box'] for elt in json_response])
+    iou_mat = box_iou(gt_boxes, pred_boxes)
+    gt_idxs, _ = assign_pairs(iou_mat, 0.8)
+    assert gt_idxs.shape[0] == gt_boxes.shape[0]


### PR DESCRIPTION
As per #233, this PR introduces the following modifications:
- added text detection route to the API template
- added corresponding API unittests


For the following image:
![detection_sample](https://user-images.githubusercontent.com/76527547/117319856-fc35bf00-ae8b-11eb-9b51-ca5aba673466.jpg)
with this piece of code:
```
import requests
import io
with open('/home/fg/Downloads/detection_sample.jpg', 'rb') as f:
    data = f.read()
response = requests.post("http://localhost:8050/detection", files={'file': io.BytesIO(data)})
```
which yields
```
In [4]: response.json()
Out[4]: 
[{'box': [0.826171875, 0.185546875, 0.90234375, 0.201171875]},
 {'box': [0.75390625, 0.185546875, 0.8173828125, 0.201171875]}]
```
(IoU > 85% with the GT)

Any feedback is welcome!