### PR TITLE
feat: Added OCR route to API template

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -11,16 +11,13 @@ ENV PYTHONPATH "${PYTHONPATH}:/app"
 # copy requirements file
 COPY api/requirements.txt /usr/src/app/api-requirements.txt
 COPY ./requirements.txt /tmp/requirements.txt
-COPY ./README.md /tmp/README.md
-COPY ./setup.py /tmp/setup.py
-COPY ./doctr /tmp/doctr
 
 # install dependencies
 RUN apt-get update \
     && apt-get install --no-install-recommends ffmpeg libsm6 libxext6 -y \
     && pip install --upgrade pip setuptools wheel \
-    && pip install -e /tmp/. \
     && pip install -r /usr/src/app/api-requirements.txt \
+    && pip install -r /tmp/requirements.txt \
     && pip cache purge \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
@@ -28,3 +25,13 @@ RUN apt-get update \
 
 # copy project
 COPY api/ /usr/src/app/
+
+
+# install doctr
+COPY ./README.md /tmp/README.md
+COPY ./setup.py /tmp/setup.py
+COPY ./doctr /tmp/doctr
+
+RUN pip install -e /tmp/. \
+    && pip cache purge \
+    && rm -rf /root/.cache/pip

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 
 from app import config as cfg
-from app.routes import recognition, detection
+from app.routes import recognition, detection, ocr
 
 
 app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, debug=cfg.DEBUG, version=cfg.VERSION)
@@ -17,6 +17,7 @@ app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, debug
 # Routing
 app.include_router(recognition.router, prefix="/recognition", tags=["recognition"])
 app.include_router(detection.router, prefix="/detection", tags=["detection"])
+app.include_router(ocr.router, prefix="/ocr", tags=["ocr"])
 
 
 # Middleware

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -6,25 +6,16 @@
 from fastapi import APIRouter, UploadFile, File
 from typing import List
 
-import tensorflow as tf
-
-gpu_devices = tf.config.experimental.list_physical_devices('GPU')
-if any(gpu_devices):
-    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
-
-from doctr.models import detection_predictor
-
+from app.vision import decode_image, det_predictor
 from app.schemas import DetectionOut
 
-
-det_predictor = detection_predictor(pretrained=True)
 
 router = APIRouter()
 
 
 @router.post("/", response_model=List[DetectionOut], status_code=200, summary="Perform text detection")
 async def text_detection(file: UploadFile = File(...)):
-    """Runs DocTR text recognition model to analyze the input"""
-    img = tf.io.decode_image(file.file.read())
+    """Runs DocTR text detection model to analyze the input"""
+    img = decode_image(file.file.read())
     out = det_predictor(img[None, ...], training=False)
     return [DetectionOut(box=box.tolist()) for box in out[0][:, :4]]

--- a/api/app/routes/ocr.py
+++ b/api/app/routes/ocr.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+from fastapi import APIRouter, UploadFile, File
+from typing import List
+
+from app.vision import decode_image, predictor
+from app.schemas import OCROut
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=List[OCROut], status_code=200, summary="Perform OCR")
+async def perform_ocr(file: UploadFile = File(...)):
+    """Runs DocTR OCR model to analyze the input"""
+    img = decode_image(file.file.read())
+    out = predictor(img[None, ...], training=False)
+
+    return [OCROut(box=(*word.geometry[0], *word.geometry[1]), value=word.value)
+            for word in out.pages[0].blocks[0].lines[0].words]

--- a/api/app/routes/recognition.py
+++ b/api/app/routes/recognition.py
@@ -5,18 +5,9 @@
 
 from fastapi import APIRouter, UploadFile, File
 
-import tensorflow as tf
-
-gpu_devices = tf.config.experimental.list_physical_devices('GPU')
-if any(gpu_devices):
-    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
-
-from doctr.models import recognition_predictor
-
+from app.vision import decode_image, reco_predictor
 from app.schemas import RecognitionOut
 
-
-reco_predictor = recognition_predictor(pretrained=True)
 
 router = APIRouter()
 
@@ -24,6 +15,6 @@ router = APIRouter()
 @router.post("/", response_model=RecognitionOut, status_code=200, summary="Perform text recognition")
 async def text_recognition(file: UploadFile = File(...)):
     """Runs DocTR text recognition model to analyze the input"""
-    img = tf.io.decode_image(file.file.read())
+    img = decode_image(file.file.read())
     out = reco_predictor(img[None, ...], training=False)
     return RecognitionOut(value=out[0])

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -14,3 +14,7 @@ class RecognitionOut(BaseModel):
 
 class DetectionOut(BaseModel):
     box: Tuple[float, float, float, float]
+
+
+class OCROut(RecognitionOut, DetectionOut):
+    pass

--- a/api/app/vision.py
+++ b/api/app/vision.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import tensorflow as tf
+
+gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+if any(gpu_devices):
+    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
+
+from doctr.models import ocr_predictor
+
+
+predictor = ocr_predictor(pretrained=True)
+det_predictor = predictor.det_predictor
+reco_predictor = predictor.reco_predictor
+
+
+def decode_image(img_bytes: bytes) -> tf.Tensor:
+    """Decodes an image from bytes"""
+    return tf.io.decode_image(img_bytes)

--- a/api/tests/routes/test_ocr.py
+++ b/api/tests/routes/test_ocr.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import pytest
+import numpy as np
+from doctr.utils.metrics import box_iou, assign_pairs
+
+
+@pytest.mark.asyncio
+async def test_perform_ocr(test_app_asyncio, mock_detection_image):
+
+    response = await test_app_asyncio.post("/ocr", files={'file': mock_detection_image})
+    assert response.status_code == 200
+    json_response = response.json()
+
+    gt_boxes = np.array([[1240, 430, 1355, 470], [1360, 430, 1495, 470]], dtype=np.float32)
+    gt_boxes[:, [0, 2]] = gt_boxes[:, [0, 2]] / 1654
+    gt_boxes[:, [1, 3]] = gt_boxes[:, [1, 3]] / 2339
+    gt_labels = ["Hello", "world!"]
+
+    # Check that IoU with GT if reasonable
+    assert isinstance(json_response, list) and len(json_response) == gt_boxes.shape[0]
+    pred_boxes = np.array([elt['box'] for elt in json_response])
+    pred_labels = np.array([elt['value'] for elt in json_response])
+    iou_mat = box_iou(gt_boxes, pred_boxes)
+    gt_idxs, pred_idxs = assign_pairs(iou_mat, 0.8)
+    assert gt_idxs.shape[0] == gt_boxes.shape[0]
+    assert all(gt_labels[gt_idx] == pred_labels[pred_idx] for gt_idx, pred_idx in zip(gt_idxs, pred_idxs))

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -55,7 +55,7 @@ class OCRPredictor(NestedObject):
         char_sequences = self.reco_predictor(crops, **kwargs)
 
         # Reorganize
-        out = self.doc_builder(boxes, char_sequences, [page.shape[:2] for page in pages])
+        out = self.doc_builder(boxes, char_sequences, [tuple(page.shape[:2]) for page in pages])
 
         return out
 


### PR DESCRIPTION
As per #233, this PR introduces the following modifications:
- added an end-to-end OCR route to the API template
- added corresponding API unittests
- optimized API dockerfile
- refactored recognition & detection route model instantiation
- fixed typing inconsistency in page shape export

For the following image:
![detection_sample](https://user-images.githubusercontent.com/76527547/117319856-fc35bf00-ae8b-11eb-9b51-ca5aba673466.jpg)

with this piece of code:
```python
import requests
import io
with open('/home/fg/Downloads/detection_sample.jpg', 'rb') as f:
    data = f.read()
response = requests.post("http://localhost:8050/ocr", files={'file': io.BytesIO(data)})
```
which yields
```python
In [4]: response.json()
Out[4]: 
[{'box': [0.75390625, 0.185546875, 0.8173828125, 0.201171875],
  'value': 'Hello'},
 {'box': [0.826171875, 0.185546875, 0.90234375, 0.201171875],
  'value': 'world!'}]
```
(IoU > 85% with the GT)


Resolves #233

Any feedback is welcome!
