### PR TITLE
feat: Added sample display option in training script

### DIFF
--- a/doctr/transforms/modules.py
+++ b/doctr/transforms/modules.py
@@ -200,7 +200,7 @@ class RandomContrast(NestedObject):
         return f"delta={self.delta}"
 
     def __call__(self, img: tf.Tensor) -> tf.Tensor:
-        return tf.image.random_contrast(img, lower=1 - self.delta, upper=1 + self.delta)
+        return tf.image.random_contrast(img, lower=1 - self.delta, upper=1 / (1 - self.delta))
 
 
 class RandomSaturation(NestedObject):
@@ -223,7 +223,7 @@ class RandomSaturation(NestedObject):
         return f"delta={self.delta}"
 
     def __call__(self, img: tf.Tensor) -> tf.Tensor:
-        return tf.image.random_saturation(img, lower=1 - self.delta, upper=1 + self.delta)
+        return tf.image.random_saturation(img, lower=1 - self.delta, upper=1 / (1 - self.delta))
 
 
 class RandomHue(NestedObject):
@@ -295,17 +295,19 @@ class RandomJpegQuality(NestedObject):
         >>> out = transfo(tf.random.uniform(shape=[64, 64, 3], minval=0, maxval=1))
 
     Args:
-        min_quality: int between [0, 100], quality will be picked in [min_quality, 100]
+        min_quality: int between [0, 100]
+        max_quality: int between [0, 100]
     """
-    def __init__(self, min_quality: int = 60) -> None:
+    def __init__(self, min_quality: int = 60, max_quality: int = 100) -> None:
         self.min_quality = min_quality
+        self.max_quality = max_quality
 
     def extra_repr(self) -> str:
         return f"min_quality={self.min_quality}"
 
     def __call__(self, img: tf.Tensor) -> tf.Tensor:
         return tf.image.random_jpeg_quality(
-            img, min_jpeg_quality=self.min_quality, max_jpeg_quality=100
+            img, min_jpeg_quality=self.min_quality, max_jpeg_quality=self.max_quality
         )
 
 

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -118,11 +118,11 @@ def main(args):
             T.LambdaTransformation(lambda x: x / 255),
             T.Resize((args.input_size, args.input_size)),
             # Augmentations
-            T.RandomApply(T.ColorInversion(), .2),
+            T.RandomApply(T.ColorInversion(), .1),
             T.RandomJpegQuality(60),
             T.RandomSaturation(.3),
             T.RandomContrast(.3),
-            T.RandomBrightness(0.3),
+            T.RandomBrightness(.3),
         ]),
     )
     train_loader = DataLoader(train_set, batch_size=args.batch_size, shuffle=True, drop_last=True, workers=args.workers)

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -91,11 +91,11 @@ def main(args):
             T.LambdaTransformation(lambda x: x / 255),
             T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=False),
             # Augmentations
-            T.RandomApply(T.ColorInversion(), .2),
+            T.RandomApply(T.ColorInversion(), .1),
             T.RandomJpegQuality(60),
             T.RandomSaturation(.3),
             T.RandomContrast(.3),
-            T.RandomBrightness(0.3),
+            T.RandomBrightness(.3),
         ]),
     )
     train_loader = DataLoader(train_set, batch_size=args.batch_size, shuffle=True, drop_last=True, workers=args.workers)


### PR DESCRIPTION
This PR introduces the following modifications:
- added option to plot samples for training sanity check
- refactored transformations
- updated probability of color inversion in training scripts

Here is how it renders for text detection:
![det_samples](https://user-images.githubusercontent.com/76527547/117647554-6486e800-b18d-11eb-867b-171d6d730046.png)

and for text recognition:
![reco_samples](https://user-images.githubusercontent.com/76527547/117648813-fa6f4280-b18e-11eb-88b3-aa380b0c1510.png)


Any feedback is welcome!