### PR TITLE
refactor: Refactored model calls and fixed validation loop

### DIFF
--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -69,8 +69,11 @@ class DetectionModel(keras.Model, NestedObject):
     def call(
         self,
         x: tf.Tensor,
+        target: Optional[List[Dict[str, Any]]] = None,
+        return_model_output: bool = False,
+        return_boxes: bool = False,
         **kwargs: Any,
-    ) -> Union[List[tf.Tensor], tf.Tensor]:
+    ) -> Dict[str, Any]:
         raise NotImplementedError
 
 

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -167,10 +167,9 @@ class DetectionPredictor(NestedObject):
     Args:
         pre_processor: transform inputs for easier batched model inference
         model: core detection architecture
-        post_processor: post process model outputs
     """
 
-    _children_names: List[str] = ['pre_processor', 'model', 'post_processor']
+    _children_names: List[str] = ['pre_processor', 'model']
 
     def __init__(
         self,
@@ -180,7 +179,6 @@ class DetectionPredictor(NestedObject):
 
         self.pre_processor = pre_processor
         self.model = model
-        self.post_processor = self.model.postprocessor
 
     def __call__(
         self,

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -515,7 +515,7 @@ class DBNet(DetectionModel, NestedObject):
         return_model_output: bool = False,
         return_boxes: bool = False,
         **kwargs: Any,
-    ) -> Dict[str, tf.Tensor]:
+    ) -> Dict[str, Any]:
 
         feat_maps = self.feat_extractor(x, **kwargs)
         feat_concat = self.fpn(feat_maps, **kwargs)

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -227,7 +227,7 @@ class LinkNet(DetectionModel, NestedObject):
 
 
         seg_target = tf.convert_to_tensor(seg_target, dtype=tf.float32)
-        seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.float32)
+        seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
 
         return seg_target, seg_mask
 
@@ -250,8 +250,8 @@ class LinkNet(DetectionModel, NestedObject):
 
         # Compute BCE loss
         return tf.math.reduce_mean(tf.keras.losses.binary_crossentropy(
-            seg_mask * seg_target,
-            seg_mask * tf.squeeze(out_map, axis=[-1]),
+            seg_target[seg_mask],
+            tf.squeeze(out_map, axis=[-1])[seg_mask],
             from_logits=True
         ))
 

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -224,7 +224,6 @@ class LinkNet(DetectionModel, NestedObject):
                 # Fill polygon with 1
                 seg_target[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = True
 
-
         seg_target = tf.convert_to_tensor(seg_target, dtype=tf.float32)
         seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
 
@@ -266,7 +265,6 @@ class LinkNet(DetectionModel, NestedObject):
         logits = self.stem(x)
         logits = self.fpn(logits)
         logits = self.classifier(logits)
-
 
         out: Dict[str, tf.Tensor] = {}
         if return_model_output or target is None or return_boxes:

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -279,7 +279,7 @@ class LinkNet(DetectionModel, NestedObject):
         return_model_output: bool = False,
         return_boxes: bool = False,
         **kwargs: Any,
-    ) -> Dict[str, tf.Tensor]:
+    ) -> Dict[str, Any]:
 
         proba_map = Sequential(self._layers)(x)
 

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -202,7 +202,7 @@ class LinkNet(DetectionModel, NestedObject):
 
     def compute_loss(
         self,
-        model_output: Dict[str, tf.Tensor],
+        proba_map: tf.Tensor,
         target: List[Dict[str, Any]]
     ) -> tf.Tensor:
         """Compute a batch of gts and masks from a list of boxes and a list of masks for each image
@@ -217,7 +217,6 @@ class LinkNet(DetectionModel, NestedObject):
             A loss tensor
         """
         # Get model output
-        proba_map = model_output["proba_map"]
         batch_size, h, w, _ = proba_map.shape
 
         batch_boxes = [t['boxes'] for t in target]
@@ -284,16 +283,15 @@ class LinkNet(DetectionModel, NestedObject):
         proba_map = Sequential(self._layers)(x)
 
         out: Dict[str, tf.Tensor] = {}
-        if target is None or return_model_output:
-            out["proba_map"] = proba_map
+        if return_model_output:
+            out["out_map"] = proba_map
 
         if target is None or return_boxes:
             # Post-process boxes
             out["boxes"] = self.postprocessor(proba_map)
 
         if target is not None:
-            maps = dict(proba_map=proba_map)
-            loss = self.compute_loss(maps, target)
+            loss = self.compute_loss(proba_map, target)
             out['loss'] = loss
 
         return out

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -183,7 +183,6 @@ class LinkNet(DetectionModel, NestedObject):
                 use_bias=False,
                 kernel_initializer='he_normal'
             ),
-            layers.Activation('sigmoid'),
         ])
 
         self.min_size_box = 3

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -87,38 +87,26 @@ class LinkNetPostProcessor(DetectionPostProcessor):
         return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 5), dtype=np.float32)
 
 
-class DecoderBlock(Sequential):
-    """This class implements a Linknet decoder block as described in paper/
+def decoder_block(in_chan: int, out_chan: int) -> Sequential:
+    """Creates a LinkNet decoder block"""
 
-    Args:
-        in_chan: input channels (must be a multiple of 4)
-        out_chan: output channels
-
-    """
-    def __init__(
-        self,
-        in_chan: int,
-        out_chan: int,
-    ) -> None:
-        _layers = []
-        _layers.extend(conv_sequence(in_chan // 4, 'relu', True, kernel_size=1))
-        _layers.append(
-            layers.Conv2DTranspose(
-                filters=in_chan // 4,
-                kernel_size=3,
-                strides=2,
-                padding="same",
-                use_bias=False,
-                kernel_initializer='he_normal'
-            )
-        )
-        _layers.append(layers.BatchNormalization())
-        _layers.append(layers.Activation('relu'))
-        _layers.extend(conv_sequence(out_chan, 'relu', True, kernel_size=1))
-        super().__init__(_layers)
+    return Sequential([
+        *conv_sequence(in_chan // 4, 'relu', True, kernel_size=1),
+        layers.Conv2DTranspose(
+            filters=in_chan // 4,
+            kernel_size=3,
+            strides=2,
+            padding="same",
+            use_bias=False,
+            kernel_initializer='he_normal'
+        ),
+        layers.BatchNormalization(),
+        layers.Activation('relu'),
+        *conv_sequence(out_chan, 'relu', True, kernel_size=1),
+    ])
 
 
-class LinkNetPyramid(layers.Layer, NestedObject):
+class LinkNetFPN(layers.Layer, NestedObject):
     """LinkNet Encoder-Decoder module
 
     """
@@ -132,10 +120,10 @@ class LinkNetPyramid(layers.Layer, NestedObject):
         self.encoder_2 = ResnetStage(num_blocks=2, output_channels=128, downsample=True)
         self.encoder_3 = ResnetStage(num_blocks=2, output_channels=256, downsample=True)
         self.encoder_4 = ResnetStage(num_blocks=2, output_channels=512, downsample=True)
-        self.decoder_1 = DecoderBlock(in_chan=64, out_chan=64)
-        self.decoder_2 = DecoderBlock(in_chan=128, out_chan=64)
-        self.decoder_3 = DecoderBlock(in_chan=256, out_chan=128)
-        self.decoder_4 = DecoderBlock(in_chan=512, out_chan=256)
+        self.decoder_1 = decoder_block(in_chan=64, out_chan=64)
+        self.decoder_2 = decoder_block(in_chan=128, out_chan=64)
+        self.decoder_3 = decoder_block(in_chan=256, out_chan=128)
+        self.decoder_4 = decoder_block(in_chan=512, out_chan=256)
 
     def call(
         self,
@@ -167,11 +155,15 @@ class LinkNet(DetectionModel, NestedObject):
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(cfg=cfg)
-        _layers = []
-        _layers.extend(conv_sequence(64, 'relu', True, strides=2, kernel_size=7, input_shape=input_shape))
-        _layers.append(layers.MaxPool2D(pool_size=(3, 3), strides=2, padding='same'))
-        _layers.append(LinkNetPyramid())
-        _layers.append(
+
+        self.stem = Sequential([
+            *conv_sequence(64, 'relu', True, strides=2, kernel_size=7, input_shape=input_shape),
+            layers.MaxPool2D(pool_size=(3, 3), strides=2, padding='same'),
+        ])
+
+        self.fpn = LinkNetFPN()
+
+        self.classifier = Sequential([
             layers.Conv2DTranspose(
                 filters=32,
                 kernel_size=3,
@@ -179,12 +171,10 @@ class LinkNet(DetectionModel, NestedObject):
                 padding="same",
                 use_bias=False,
                 kernel_initializer='he_normal'
-            )
-        )
-        _layers.append(layers.BatchNormalization())
-        _layers.append(layers.Activation('relu'))
-        _layers.extend(conv_sequence(32, 'relu', True, strides=1, kernel_size=3))
-        _layers.append(
+            ),
+            layers.BatchNormalization(),
+            layers.Activation('relu'),
+            *conv_sequence(32, 'relu', True, strides=1, kernel_size=3),
             layers.Conv2DTranspose(
                 filters=out_chan,
                 kernel_size=2,
@@ -192,84 +182,78 @@ class LinkNet(DetectionModel, NestedObject):
                 padding="same",
                 use_bias=False,
                 kernel_initializer='he_normal'
-            )
-        )
-        _layers.append(layers.Activation('sigmoid'))
-        self._layers = _layers
+            ),
+            layers.Activation('sigmoid'),
+        ])
+
         self.min_size_box = 3
 
         self.postprocessor = LinkNetPostProcessor()
 
+    def compute_target(
+        self,
+        target: List[Dict[str, Any]],
+        output_shape: Tuple[int, int, int],
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
+
+        seg_target = np.zeros(output_shape, dtype=np.bool)
+        seg_mask = np.ones(output_shape, dtype=np.bool)
+
+        for idx, _target in enumerate(target):
+            # Draw each polygon on gt
+            if _target['boxes'].shape[0] == 0:
+                # Empty image, full masked
+                seg_mask[idx] = False
+
+            # Absolute bounding boxes
+            abs_boxes = _target['boxes'].copy()
+            abs_boxes[:, [0, 2]] *= output_shape[-1]
+            abs_boxes[:, [1, 3]] *= output_shape[-2]
+            abs_boxes = abs_boxes.round().astype(np.int32)
+
+            boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
+
+            for box, box_size, is_ambiguous in zip(abs_boxes, boxes_size, _target['flags']):
+                # Mask ambiguous boxes
+                if is_ambiguous:
+                    seg_mask[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = False
+                    continue
+                # Mask boxes that are too small
+                if box_size < self.min_size_box:
+                    seg_mask[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = False
+                    continue
+                # Fill polygon with 1
+                seg_target[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = True
+
+
+        seg_target = tf.convert_to_tensor(seg_target, dtype=tf.float32)
+        seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.float32)
+
+        return seg_target, seg_mask
+
     def compute_loss(
         self,
-        proba_map: tf.Tensor,
+        out_map: tf.Tensor,
         target: List[Dict[str, Any]]
     ) -> tf.Tensor:
         """Compute a batch of gts and masks from a list of boxes and a list of masks for each image
         Then, it computes the loss function with proba_map, gts and masks
 
         Args:
-            model_output: dictionary containing the output of the model, proba_map, shape: N x H x W x C
-            batch_boxes: list of boxes for each image of the batch
-            batch_flags: list of boxes to mask for each image of the batch
+            out_map: output feature map of the model of shape N x H x W x 1
+            target: list of dictionary where each dict has a `boxes` and a `flags` entry
 
         Returns:
             A loss tensor
         """
-        # Get model output
-        batch_size, h, w, _ = proba_map.shape
-
-        batch_boxes = [t['boxes'] for t in target]
-        batch_flags = [t['flags'] for t in target]
-
-        # Compute masks and gts
-        batch_gts, batch_masks = [], []
-        for batch_idx in range(batch_size):
-            # Initialize mask and gt
-            gt = np.zeros((h, w), dtype=np.float32)
-            mask = np.ones((h, w), dtype=np.float32)
-
-            # Draw each polygon on gt
-            if batch_boxes[batch_idx].shape[0] == 0:
-                # Empty image, full masked
-                mask = np.zeros((h, w), dtype=np.float32)
-
-            # Absolute bounding boxes
-            abs_boxes = batch_boxes[batch_idx].copy()
-            abs_boxes[:, [0, 2]] *= w
-            abs_boxes[:, [1, 3]] *= h
-            abs_boxes = abs_boxes.astype(np.int32)
-
-            boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
-
-            for box, box_size, flag in zip(abs_boxes, boxes_size, batch_flags[batch_idx]):
-                if flag is True:
-                    mask[box[1]: box[3] + 1, box[0]: box[2] + 1] = 0
-                    continue
-                if box_size < self.min_size_box:
-                    mask[box[1]: box[3] + 1, box[0]: box[2] + 1] = 0
-                    continue
-                # Fill polygon with 1
-                gt[box[1]: box[3] + 1, box[0]: box[2] + 1] = 1
-
-            # Cast
-            gts = tf.convert_to_tensor(gt, tf.float32)
-            masks = tf.convert_to_tensor(mask, tf.float32)
-
-            # Batch
-            batch_gts.append(gts)
-            batch_masks.append(masks)
-
-        # Stack
-        gts = tf.stack(batch_gts, axis=0)
-        masks = tf.stack(batch_masks, axis=0)
-
-        proba_map = tf.squeeze(proba_map, axis=[-1])
+        seg_target, seg_mask = self.compute_target(target, out_map.shape[:3])
 
         # Compute BCE loss
-        bce_loss = tf.math.reduce_mean(tf.keras.losses.binary_crossentropy(gts * mask, proba_map * masks))
-
-        return bce_loss
+        return tf.math.reduce_mean(tf.keras.losses.binary_crossentropy(
+            seg_mask * seg_target,
+            seg_mask * tf.squeeze(out_map, axis=[-1]),
+            from_logits=True
+        ))
 
     def call(
         self,
@@ -280,18 +264,23 @@ class LinkNet(DetectionModel, NestedObject):
         **kwargs: Any,
     ) -> Dict[str, Any]:
 
-        proba_map = Sequential(self._layers)(x)
+        logits = self.stem(x)
+        logits = self.fpn(logits)
+        logits = self.classifier(logits)
+
 
         out: Dict[str, tf.Tensor] = {}
+        if return_model_output or target is None or return_boxes:
+            prob_map = tf.math.sigmoid(logits)
         if return_model_output:
-            out["out_map"] = proba_map
+            out["out_map"] = prob_map
 
         if target is None or return_boxes:
             # Post-process boxes
-            out["boxes"] = self.postprocessor(proba_map)
+            out["boxes"] = self.postprocessor(prob_map)
 
         if target is not None:
-            loss = self.compute_loss(proba_map, target)
+            loss = self.compute_loss(logits, target)
             out['loss'] = loss
 
         return out

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -150,10 +150,9 @@ class RecognitionPredictor(NestedObject):
     Args:
         pre_processor: transform inputs for easier batched model inference
         model: core detection architecture
-        post_processor: post process model outputs
     """
 
-    _children_names: List[str] = ['pre_processor', 'model', 'post_processor']
+    _children_names: List[str] = ['pre_processor', 'model']
 
     def __init__(
         self,
@@ -163,7 +162,6 @@ class RecognitionPredictor(NestedObject):
 
         self.pre_processor = pre_processor
         self.model = model
-        self.post_processor = self.model.postprocessor
 
     def __call__(
         self,

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -107,6 +107,7 @@ class RecognitionModel(keras.Model, NestedObject):
         self,
         x: tf.Tensor,
         target: Optional[List[str]] = None,
+        return_model_output: bool = False,
         return_preds: bool = False,
         **kwargs: Any,
     ) -> Dict[str, Any]:

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -106,8 +106,10 @@ class RecognitionModel(keras.Model, NestedObject):
     def call(
         self,
         x: tf.Tensor,
+        target: Optional[List[str]] = None,
+        return_preds: bool = False,
         **kwargs: Any,
-    ) -> tf.Tensor:
+    ) -> Dict[str, Any]:
         raise NotImplementedError
 
 
@@ -179,9 +181,9 @@ class RecognitionPredictor(NestedObject):
             processed_batches = self.pre_processor(crops)
 
             # Forward it
-            out = [self.model(batch, **kwargs) for batch in processed_batches]
+            out = [self.model(batch, return_preds=True, **kwargs)['preds'] for batch in processed_batches]
 
             # Process outputs
-            out = [charseq for batch in out for charseq in self.post_processor(batch)]
+            out = [charseq for batch in out for charseq in batch]
 
         return out

--- a/doctr/models/recognition/crnn.py
+++ b/doctr/models/recognition/crnn.py
@@ -169,6 +169,7 @@ class CRNN(RecognitionModel):
         self,
         x: tf.Tensor,
         target: Optional[List[str]] = None,
+        return_model_output: bool = False,
         return_preds: bool = False,
         **kwargs: Any,
     ) -> Dict[str, tf.Tensor]:
@@ -182,6 +183,9 @@ class CRNN(RecognitionModel):
         decoded_features = self.decoder(features_seq, **kwargs)
 
         out: Dict[str, tf.Tensor] = {}
+        if return_model_output:
+            out["out_map"] = decoded_features
+
         if target is None or return_preds:
             # Post-process boxes
             out["preds"] = self.postprocessor(decoded_features)

--- a/doctr/models/recognition/crnn.py
+++ b/doctr/models/recognition/crnn.py
@@ -144,9 +144,8 @@ class CRNN(RecognitionModel):
 
     def compute_loss(
         self,
-        gt: tf.Tensor,
         model_output: tf.Tensor,
-        seq_len: tf.Tensor
+        target: List[str],
     ) -> tf.Tensor:
         """Compute CTC loss for the model.
 
@@ -158,6 +157,7 @@ class CRNN(RecognitionModel):
         Returns:
             The loss of the model on the batch
         """
+        gt, seq_len = self.compute_target(target)
         batch_len = model_output.shape[0]
         input_length = model_output.shape[1] * tf.ones(shape=(batch_len))
         ctc_loss = tf.nn.ctc_loss(
@@ -168,8 +168,10 @@ class CRNN(RecognitionModel):
     def call(
         self,
         x: tf.Tensor,
+        target: Optional[List[str]] = None,
+        return_preds: bool = False,
         **kwargs: Any,
-    ) -> tf.Tensor:
+    ) -> Dict[str, tf.Tensor]:
 
         features = self.feat_extractor(x, **kwargs)
         # B x H x W x C --> B x W x H x C
@@ -178,7 +180,16 @@ class CRNN(RecognitionModel):
         # B x W x H x C --> B x W x H * C
         features_seq = tf.reshape(transposed_feat, shape=(-1, w, h * c))
         decoded_features = self.decoder(features_seq, **kwargs)
-        return decoded_features
+
+        out: Dict[str, tf.Tensor] = {}
+        if target is None or return_preds:
+            # Post-process boxes
+            out["preds"] = self.postprocessor(decoded_features)
+
+        if target is not None:
+            out['loss'] = self.compute_loss(decoded_features, target)
+
+        return out
 
 
 def _crnn(arch: str, pretrained: bool, input_shape: Optional[Tuple[int, int, int]] = None, **kwargs: Any) -> CRNN:

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -267,7 +267,7 @@ class SAR(RecognitionModel):
         encoded = self.encoder(pooled_features, **kwargs)
         if target is not None:
             gt, seq_len = self.compute_target(target)
-        decoded_features = self.decoder(features, encoded, gt, **kwargs)
+        decoded_features = self.decoder(features, encoded, gt=None if target is None else gt, **kwargs)
 
         out: Dict[str, tf.Tensor] = {}
         if return_model_output:

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -257,6 +257,7 @@ class SAR(RecognitionModel):
         self,
         x: tf.Tensor,
         target: Optional[List[str]] = None,
+        return_model_output: bool = False,
         return_preds: bool = False,
         **kwargs: Any,
     ) -> Dict[str, tf.Tensor]:
@@ -269,6 +270,9 @@ class SAR(RecognitionModel):
         decoded_features = self.decoder(features, encoded, gt, **kwargs)
 
         out: Dict[str, tf.Tensor] = {}
+        if return_model_output:
+            out["out_map"] = decoded_features
+
         if target is None or return_preds:
             # Post-process boxes
             out["preds"] = self.postprocessor(decoded_features)

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -131,7 +131,7 @@ class SARDecoder(layers.Layer, NestedObject):
         self,
         features: tf.Tensor,
         holistic: tf.Tensor,
-        labels: Optional[tf.Tensor] = None,
+        gt: Optional[tf.Tensor] = None,
         **kwargs: Any,
     ) -> tf.Tensor:
 
@@ -145,6 +145,8 @@ class SARDecoder(layers.Layer, NestedObject):
         # Initialize with the index of virtual START symbol (placed after <eos>)
         symbol = tf.fill(features.shape[0], self.vocab_size + 1)
         logits_list = []
+        if kwargs.get('training') and gt is None:
+            raise ValueError('Need to provide labels during training for teacher forcing')
         for t in range(self.max_length + 1):  # keep 1 step for <eos>
             # one-hot symbol with depth vocab_size + 1
             # embeded_symbol: shape (N, embedding_units)
@@ -159,7 +161,7 @@ class SARDecoder(layers.Layer, NestedObject):
             logits = self.output_dense(logits, **kwargs)
             # update symbol with predicted logits for t+1 step
             if kwargs.get('training'):
-                symbol = labels[:, t]
+                symbol = gt[:, t]
             else:
                 symbol = tf.argmax(logits, axis=-1)
             logits_list.append(logits)
@@ -219,11 +221,11 @@ class SAR(RecognitionModel):
 
         self.postprocessor = SARPostProcessor(vocab=vocab)
 
-    @staticmethod
     def compute_loss(
-        gt: tf.Tensor,
+        self,
         model_output: tf.Tensor,
-        seq_len: tf.Tensor
+        gt: tf.Tensor,
+        seq_len: tf.Tensor,
     ) -> tf.Tensor:
         """Compute categorical cross-entropy loss for the model.
         Sequences are masked after the EOS character.
@@ -254,21 +256,27 @@ class SAR(RecognitionModel):
     def call(
         self,
         x: tf.Tensor,
-        labels: Optional[tf.sparse.SparseTensor] = None,
+        target: Optional[List[str]] = None,
+        return_preds: bool = False,
         **kwargs: Any,
-    ) -> tf.Tensor:
+    ) -> Dict[str, tf.Tensor]:
 
         features = self.feat_extractor(x, **kwargs)
         pooled_features = tf.reduce_max(features, axis=1)  # vertical max pooling
         encoded = self.encoder(pooled_features, **kwargs)
-        if kwargs.get('training'):
-            if labels is None:
-                raise ValueError('Need to provide labels during training for teacher forcing')
-            decoded = self.decoder(features, encoded, labels, **kwargs)
-        else:
-            decoded = self.decoder(features, encoded, **kwargs)
+        if target is not None:
+            gt, seq_len = self.compute_target(target)
+        decoded_features = self.decoder(features, encoded, gt, **kwargs)
 
-        return decoded
+        out: Dict[str, tf.Tensor] = {}
+        if target is None or return_preds:
+            # Post-process boxes
+            out["preds"] = self.postprocessor(decoded_features)
+
+        if target is not None:
+            out['loss'] = self.compute_loss(decoded_features, gt, seq_len)
+
+        return out
 
 
 class SARPostProcessor(RecognitionPostProcessor):

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -26,21 +26,16 @@ from doctr.datasets import RecognitionDataset, DataLoader, VOCABS
 from doctr import transforms as T
 
 
-def fit_one_epoch(model, train_loader, batch_transforms, optimizer, loss_q, mb, tb_writer, step, teacher_forcing=False):
+def fit_one_epoch(model, train_loader, batch_transforms, optimizer, loss_q, mb, tb_writer, step):
     train_iter = iter(train_loader)
     # Iterate over the batches of the dataset
     for batch_step in progress_bar(range(train_loader.num_batches), parent=mb):
         images, targets = next(train_iter)
 
         images = batch_transforms(images)
-        encoded_gts, seq_len = model.compute_target(targets)
 
         with tf.GradientTape() as tape:
-            if teacher_forcing:
-                train_logits = model(images, encoded_gts, training=True)
-            else:
-                train_logits = model(images, training=True)
-            train_loss = model.compute_loss(encoded_gts, train_logits, seq_len)
+            train_loss = model(images, targets, training=True)['loss']
         grads = tape.gradient(train_loss, model.trainable_weights)
         optimizer.apply_gradients(zip(grads, model.trainable_weights))
 
@@ -65,14 +60,11 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
     val_iter = iter(val_loader)
     for images, targets in val_iter:
         images = batch_transforms(images)
-        val_logits = model(images, training=False)
-        encoded_gts, seq_len = model.compute_target(targets)
-        loss = model.compute_loss(encoded_gts, val_logits, seq_len)
-        decoded = model.postprocessor(val_logits)
+        out = model(images, targets, return_preds=True, training=False)
         # Compute metric
-        val_metric.update(targets, decoded)
+        val_metric.update(targets, out['preds'])
 
-        val_loss += loss.numpy().mean()
+        val_loss += out['loss'].numpy().mean()
         batch_cnt += 1
 
     val_loss /= batch_cnt
@@ -159,8 +151,7 @@ def main(args):
     # Training loop
     mb = master_bar(range(args.epochs))
     for epoch in mb:
-        fit_one_epoch(model, train_loader, batch_transforms, optimizer,
-                      loss_q, mb, tb_writer, step, args.teacher_forcing)
+        fit_one_epoch(model, train_loader, batch_transforms, optimizer, loss_q, mb, tb_writer, step)
 
         # Validation loop at the end of each epoch
         val_loss, exact_match = evaluate(model, val_loader, batch_transforms, val_metric)
@@ -189,8 +180,6 @@ def parse_args():
     parser.add_argument('-b', '--batch_size', type=int, default=64, help='batch size for training')
     parser.add_argument('--input_size', type=int, default=32, help='input size H for the model, W = 4*H')
     parser.add_argument('--lr', type=float, default=0.001, help='learning rate for the optimizer (Adam)')
-    parser.add_argument("--teacher_forcing", dest="teacher_forcing",
-                        help="enables teacher forcing during training", action="store_true")
     parser.add_argument('-j', '--workers', type=int, default=4, help='number of workers used for dataloading')
     parser.add_argument('--resume', type=str, default=None, help='Path to your checkpoint')
     parser.add_argument("--test-only", dest='test_only', action='store_true', help="Run the validation loop")

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -37,7 +37,7 @@ def test_detpreprocessor(mock_pdf):  # noqa: F811
 
 def test_dbpostprocessor():
     postprocessor = detection.DBPostProcessor()
-    mock_batch = dict(proba_map=tf.random.uniform(shape=[2, 512, 512, 1], minval=0, maxval=1))
+    mock_batch = tf.random.uniform(shape=[2, 512, 512, 1], minval=0, maxval=1)
     out = postprocessor(mock_batch)
     # Batch composition
     assert isinstance(out, list)
@@ -161,7 +161,7 @@ def test_detection_zoo_error():
 
 def test_linknet_postprocessor():
     postprocessor = detection.LinkNetPostProcessor()
-    mock_batch = dict(proba_map=tf.random.uniform(shape=[2, 512, 512, 1], minval=0, maxval=1))
+    mock_batch = tf.random.uniform(shape=[2, 512, 512, 1], minval=0, maxval=1)
     out = postprocessor(mock_batch)
     # Batch composition
     assert isinstance(out, list)

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -79,21 +79,6 @@ def test_dbpostprocessor():
     assert isinstance(out, tuple) and len(out) == 4
 
 
-def test_db_resnet50_training_mode():
-    model = detection.db_resnet50(pretrained=False)
-    assert isinstance(model, tf.keras.Model)
-    dbinput = tf.random.uniform(shape=[2, 1024, 1024, 3], minval=0, maxval=1)
-    # test training model
-    dboutput_train = model(dbinput, training=True)
-    assert isinstance(dboutput_train, dict)
-    assert len(dboutput_train) == 3
-    assert all(
-        np.all(np.logical_and(out_map.numpy() >= 0, out_map.numpy() <= 1)) for out_map in dboutput_train.values()
-    )
-    # batch size
-    assert all(out.numpy().shape == (2, 1024, 1024, 1) for out in dboutput_train.values())
-
-
 @pytest.mark.parametrize(
     "arch_name, input_shape, output_size, out_prob",
     [
@@ -102,18 +87,30 @@ def test_db_resnet50_training_mode():
     ],
 )
 def test_detection_models(arch_name, input_shape, output_size, out_prob):
-
     batch_size = 2
     model = detection.__dict__[arch_name](pretrained=True)
     assert isinstance(model, tf.keras.Model)
     input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
-    # test prediction model
-    out = model(input_tensor)
+    target = [
+        dict(boxes=np.array([[0, 0, 1, 1], [0.5, 0.5, 1, 1]], dtype=np.float32), flags=[True, False]),
+        dict(boxes=np.array([[0, 0, 1, 1], [0.5, 0.5, 1, 1]], dtype=np.float32), flags=[True, False])
+    ]
+    # test training model
+    out = model(input_tensor, target, return_model_output=True, return_boxes=True, training=True)
     assert isinstance(out, dict)
-    out = out["proba_map"].numpy()
-    assert out.shape == (batch_size, *output_size)
+    assert len(out) == 3
+    # Check proba map
+    seg_map = out['out_map'].numpy()
+    assert seg_map.shape == (batch_size, *output_size)
     if out_prob:
-        assert np.all(np.logical_and(out >= 0, out <= 1))
+        assert np.all(np.logical_and(seg_map >= 0, seg_map <= 1))
+    # Check boxes
+    for boxes in out['boxes']:
+        assert boxes.shape[1] == 5
+        assert np.all(boxes[:, :2] < boxes[:, 2:4])
+        assert np.all(boxes[:, :4] >= 0) and np.all(boxes[:, :4] <= 1)
+    # Check loss
+    assert isinstance(out['loss'], tf.Tensor)
 
 
 @pytest.fixture(scope="session")
@@ -160,31 +157,6 @@ def test_detection_zoo(arch_name):
 def test_detection_zoo_error():
     with pytest.raises(ValueError):
         _ = detection.zoo.detection_predictor("my_fancy_model", pretrained=False)
-
-
-@pytest.mark.parametrize(
-    "arch_name",
-    [
-        "db_resnet50",
-        "linknet"
-    ],
-)
-def test_compute_detection_loss(arch_name):
-    boxes = [
-        np.array([[0.003, 0.002, 0.04, 0.03], [0.3, 0.1, 0.4, 0.3]]),
-        np.array([[0.003, 0.002, 0.04, 0.03], [0.3, 0.1, 0.4, 0.3]]),
-        np.zeros((0, 4)),
-    ]
-    flags = [[True, False], [True, False], []]
-    model = detection.__dict__[arch_name](pretrained=True)
-    model_input = tf.random.uniform(shape=[3, 1024, 1024, 3], minval=0, maxval=1)
-    output = model(model_input, training=True)
-    loss = model.compute_loss(
-        model_output=output,
-        batch_boxes=boxes,
-        batch_flags=flags,
-    )
-    assert isinstance(loss, tf.Tensor)
 
 
 def test_linknet_postprocessor():

--- a/test/test_models_recognition.py
+++ b/test/test_models_recognition.py
@@ -36,42 +36,28 @@ def test_recopreprocessor(mock_pdf):  # noqa: F811
 
 
 @pytest.mark.parametrize(
-    "arch_name, input_shape, output_size",
+    "arch_name, input_shape",
     [
-        ["crnn_vgg16_bn", (32, 128, 3), (32, 119)],
-        ["sar_vgg16_bn", (32, 128, 3), (31, 119)],
-        ["sar_resnet31", (32, 128, 3), (31, 119)],
-        ["crnn_resnet31", (32, 128, 3), (32, 119)],
+        ["crnn_vgg16_bn", (32, 128, 3)],
+        ["sar_vgg16_bn", (32, 128, 3)],
+        ["sar_resnet31", (32, 128, 3)],
+        ["crnn_resnet31", (32, 128, 3)],
     ],
 )
-def test_recognition_models(arch_name, input_shape, output_size):
-    batch_size = 8
-    reco_model = recognition.__dict__[arch_name](pretrained=True, input_shape=input_shape)
-    input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
-    out = reco_model(input_tensor)
-    assert isinstance(out, tf.Tensor)
-    assert isinstance(reco_model, tf.keras.Model)
-    assert out.numpy().shape == (batch_size, *output_size)
-
-
-def test_sar_training():
+def test_recognition_models(arch_name, input_shape):
     batch_size = 4
-    input_shape = (32, 128, 3)
-    output_size = (31, 119)
-    reco_model = recognition.sar_vgg16_bn(input_shape=input_shape)
-    input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
-    # input_labels: sparse_tensor of shape batch_size x max_len, encoding the labels
-    # filled with integers (classes of the characters at each timestep)
-    indices = [[0, 0], [0, 1], [1, 0], [1, 1], [1, 2], [2, 0], [3, 0], [3, 1], [3, 2], [3, 3], [3, 4]]
-    values = tf.random.uniform(shape=[11], minval=0, maxval=118, dtype=tf.dtypes.int64)
-    input_labels = tf.sparse.reorder(
-        tf.sparse.SparseTensor(indices=indices, values=values, dense_shape=[batch_size, 31])
-    )
-    input_dense = tf.sparse.to_dense(input_labels, default_value=118)
-    out = reco_model(input_tensor, labels=input_dense, training=True)
-    assert isinstance(out, tf.Tensor)
+    reco_model = recognition.__dict__[arch_name](pretrained=True, input_shape=input_shape)
     assert isinstance(reco_model, tf.keras.Model)
-    assert out.numpy().shape == (batch_size, *output_size)
+    input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
+    target = ["i", "am", "a", "jedi"]
+
+    out = reco_model(input_tensor, target, return_model_output=True, return_preds=True)
+    assert isinstance(out, dict)
+    assert len(out) == 3
+    assert isinstance(out['preds'], list)
+    assert len(out['preds']) == batch_size and all(isinstance(word, str) for word in out['preds'])
+    assert isinstance(out['out_map'], tf.Tensor)
+    assert isinstance(out['loss'], tf.Tensor)
 
 
 @pytest.mark.parametrize(
@@ -143,29 +129,3 @@ def test_recognition_zoo(arch_name):
 def test_recognition_zoo_error():
     with pytest.raises(ValueError):
         _ = recognition.zoo.recognition_predictor("my_fancy_model", pretrained=False)
-
-
-def test_compute_loss_sar():
-    list_gts = ['elephants', '1234', 'Rémouleur']
-    model_input = tf.random.uniform(shape=[3, 32, 128, 3], minval=0, maxval=1)
-    model = recognition.sar_vgg16_bn()
-    model_output = model(model_input)
-    encoded_gts, seq_len = model.compute_target(list_gts)
-    assert isinstance(encoded_gts, tf.Tensor)
-    assert isinstance(seq_len, tf.Tensor)
-    assert list(seq_len.numpy()) == [9, 4, 9]
-    loss = model.compute_loss(encoded_gts, model_output, seq_len)
-    assert isinstance(loss, tf.Tensor)
-
-
-def test_compute_loss_crnn():
-    list_gts = ['elephants', '1234', 'Rémouleur']
-    model_input = tf.random.uniform(shape=[3, 32, 128, 3], minval=0, maxval=1)
-    model = recognition.crnn_vgg16_bn()
-    model_output = model(model_input)
-    encoded_gts, seq_len = model.compute_target(list_gts)
-    assert isinstance(encoded_gts, tf.Tensor)
-    assert isinstance(seq_len, tf.Tensor)
-    assert list(seq_len.numpy()) == [9, 4, 9]
-    loss = model.compute_loss(encoded_gts, model_output, seq_len)
-    assert isinstance(loss, tf.Tensor)


### PR DESCRIPTION
This PR introduces the following modifications:
- fully moved post_processor inside model definition (the predictor has no knowledge of it)
- removed final activation layers from detection models for loss computation
- model output is now a dictionary for all models : if a target is passed, the loss will be computed and returned in the dict. If it isn't, boxes are returned for detection models and preds for recognition models. Additional call options (return_model_outputs, return_preds, return_boxes) can enforce adding extra information in the returned dict. This way, the training mode is completely decorrelated to the model output.
```python
det_model = db_resnet50()
print(det_model(input_t).keys())
print(det_model(input_t, return_model_output=True).keys())
print(det_model(input_t, target).keys())
print(det_model(input_t, target, return_boxes=True).keys())
print(det_model(input_t, target, return_boxes=True, return_model_output=True).keys())
```
yields
```
dict_keys(['boxes'])
dict_keys(['boxes', 'out_map'])
dict_keys(['loss'])
dict_keys(['loss', 'boxes'])
dict_keys(['loss', 'boxes', 'out_map'])
```
_`out_map` is mainly for debug and plotting heatmaps_ 
- updated unittests accordingly
- updated training scripts accordingly

Any feedback is welcome!