### PR TITLE
refactor: Refactored page to img conversion

### DIFF
--- a/doctr/documents/reader.py
+++ b/doctr/documents/reader.py
@@ -120,7 +120,7 @@ def convert_page_to_numpy(
     # Generate the pixel map using the transformation matrix
     pixmap = page.getPixmap(matrix=transform_matrix)
     # Decode it into a numpy
-    img = np.frombuffer(stream.pixels, dtype=np.uint8).reshape(pixmap.height, pixmap.width, 3)
+    img = np.frombuffer(pixmap.samples, dtype=np.uint8).reshape(pixmap.height, pixmap.width, 3)
 
     # Switch the channel order
     if rgb_output:


### PR DESCRIPTION
This PR refactors the PDF page to image conversion by improving the inference speed.

With this snippet:
```python
import timeit
timeit.timeit('doc = DocumentFile.from_pdf("/home/fg/Downloads/sample.pdf").as_images()', setup='from doctr.documents import DocumentFile', number=1000)
```
before: 119.51s
after: 13.90s

