### PR TITLE
feat: add FaceDetector in models.artefact

### DIFF
--- a/doctr/models/artefacts/__init__.py
+++ b/doctr/models/artefacts/__init__.py
@@ -1,0 +1,1 @@
+from .face import *

--- a/doctr/models/artefacts/face.py
+++ b/doctr/models/artefacts/face.py
@@ -25,6 +25,8 @@ class FaceDetector(NestedObject):
         n_faces: int = 1,
     ) -> None:
         self.n_faces = n_faces
+        # Instantiate classifier
+        self.detector = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
 
     def extra_repr(self) -> str:
         return f"n_faces={self.n_faces}"
@@ -43,9 +45,8 @@ class FaceDetector(NestedObject):
         """
         height, width = img.shape[:2]
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-        # Instantiate classifier
-        face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
-        faces = face_cascade.detectMultiScale(gray, 1.5, 3)
+
+        faces = self.detector.detectMultiScale(gray, 1.5, 3)
         # If faces are detected, keep only the biggest ones
         rel_faces = []
         if len(faces) > 0:

--- a/doctr/models/artefacts/face.py
+++ b/doctr/models/artefacts/face.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import cv2
+import numpy as np
+from doctr.utils.repr import NestedObject
+from typing import List, Tuple
+
+__all__ = ['FaceDetector']
+
+
+class FaceDetector(NestedObject):
+
+    """ Implements a face detector to detect profile pictures on resumes, IDS, driving licenses, passports...
+    Based on open CV CascadeClassifier (haarcascades)
+
+    Args:
+        n_faces: maximal number of faces to detect on a single image, default = 1
+    """
+
+    def __init__(
+        self,
+        n_faces: int = 1,
+    ) -> None:
+        self.n_faces = n_faces
+
+    def extra_repr(self) -> str:
+        return f"n_faces={self.n_faces}"
+
+    def __call__(
+        self,
+        img: np.array,
+    ) -> List[Tuple[float, float, float, float]]:
+        """Detect n_faces on the img
+
+        Args:
+            img: image to detect faces on
+
+        Returns:
+            A list of size n_faces, each face is a tuple of relative xmin, ymin, xmax, ymax
+        """
+        height, width = img.shape[:2]
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        # Instantiate classifier
+        face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
+        faces = face_cascade.detectMultiScale(gray, 1.5, 3)
+        # If faces are detected, keep only the biggest ones
+        rel_faces = []
+        if len(faces) > 0:
+            x, y, w, h = sorted(faces, key=lambda x: x[2] + x[3])[-min(self.n_faces, len(faces))]
+            xmin, ymin, xmax, ymax = x / width, y / height, (x + w) / width, (y + h) / height
+            rel_faces.append((xmin, ymin, xmax, ymax))
+
+        return rel_faces

--- a/test/test_artefacts.py
+++ b/test/test_artefacts.py
@@ -1,0 +1,12 @@
+import pytest
+import os
+from doctr.models.artefacts import FaceDetector
+from doctr.documents import DocumentFile
+
+
+def test_face_detector(mock_image_folder):
+    detector = FaceDetector(n_faces=1)
+    for img in os.listdir(mock_image_folder):
+        image = DocumentFile.from_images(os.path.join(mock_image_folder, img))[0]
+        faces = detector(image)
+        assert len(faces) <= 1

--- a/test/test_artefacts.py
+++ b/test/test_artefacts.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 from doctr.models.artefacts import FaceDetector
 from doctr.documents import DocumentFile


### PR DESCRIPTION
This PR adds a new sub_module dedicated to artefacts, and implements a FaceDetector to detect profile pictures on resumes, IDS, driving licenses, passports, ...
Implemented with cv2 Cascade Classifier, which very light & fast.
Samples are displayed below.
Any feedback is welcome!

![speci1](https://user-images.githubusercontent.com/70526046/118243584-e1240a00-b49e-11eb-8fdc-3daf010ca489.png)
![speci2](https://user-images.githubusercontent.com/70526046/118243592-e2edcd80-b49e-11eb-96e6-47d231e752ff.png)
![speci3](https://user-images.githubusercontent.com/70526046/118243594-e41efa80-b49e-11eb-8b63-e05014ade552.png)
![speci4](https://user-images.githubusercontent.com/70526046/118243598-e4b79100-b49e-11eb-9eeb-2f88da49bc83.png)
