### PR TITLE
fix: Fixed Resize transformation when preserving aspect ratio

### DIFF
--- a/doctr/transforms/modules.py
+++ b/doctr/transforms/modules.py
@@ -71,7 +71,12 @@ class Resize(NestedObject):
     def __call__(self, img: tf.Tensor) -> tf.Tensor:
         img = tf.image.resize(img, self.output_size, self.method, self.preserve_aspect_ratio)
         if self.preserve_aspect_ratio:
-            img = tf.image.pad_to_bounding_box(img, 0, 0, *self.output_size)
+            # pad width
+            if self.output_size[0] == img.shape[0]:
+                offset = (0, int((self.output_size[1] - img.shape[1]) / 2))
+            else:
+                offset = (int((self.output_size[0] - img.shape[0]) / 2), 0)
+            img = tf.image.pad_to_bounding_box(img, *offset, *self.output_size)
         return img
 
 

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -103,9 +103,9 @@ def main(args):
         labels_path=os.path.join(args.data_path, 'train_labels.json'),
         sample_transforms=T.Compose([
             T.LambdaTransformation(lambda x: x / 255),
-            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=False),
-            # Augmentations
             T.RandomApply(T.ColorInversion(), .1),
+            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
+            # Augmentations
             T.RandomJpegQuality(60),
             T.RandomSaturation(.3),
             T.RandomContrast(.3),
@@ -127,7 +127,7 @@ def main(args):
         labels_path=os.path.join(args.data_path, 'val_labels.json'),
         sample_transforms=T.Compose([
             T.LambdaTransformation(lambda x: x / 255),
-            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=False),
+            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
         ]),
     )
     val_loader = DataLoader(val_set, batch_size=args.batch_size, shuffle=False, drop_last=False, workers=args.workers)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -22,6 +22,13 @@ def test_resize():
     assert not tf.reduce_all(out == 1)
     assert out.shape[:2] == output_size
 
+    # Inverse aspect ratio
+    input_t = tf.cast(tf.fill([64, 32, 3], 1), dtype=tf.float32)
+    out = transfo(input_t)
+
+    assert not tf.reduce_all(out == 1)
+    assert out.shape[:2] == output_size
+
 
 def test_compose():
 


### PR DESCRIPTION
This PR introduces the following modifications:
- switched Resize transforms to preserving aspect ratio in recognition training script
- moved `ColorInversion` before Resize to avoid getting a padding with value != 0
- fixed padding offset when preserving aspect ratio
- extended unittests

The following snippet:
```shell
python references/recognition/train.py /home/fg/Downloads/reco_samples sar_vgg16_bn -b 16 --show-samples
```
used to yield:
![resize_legacy](https://user-images.githubusercontent.com/76527547/118627369-f022f900-b7cb-11eb-8126-fec527159ae4.png)

by switching to aspect ratio preserving Resize:
![resize_before](https://user-images.githubusercontent.com/76527547/118627007-a33f2280-b7cb-11eb-8f59-7e474adfa1f8.png)

and now yields (by fixing the resize):
![resize_after](https://user-images.githubusercontent.com/76527547/118627014-a508e600-b7cb-11eb-9665-02687e681a23.png)


Any feedback is welcome!