### PR TITLE
refactor: Added granularity to evaluation metrics

### DIFF
--- a/api/tests/routes/test_ocr.py
+++ b/api/tests/routes/test_ocr.py
@@ -5,7 +5,8 @@
 
 import pytest
 import numpy as np
-from doctr.utils.metrics import box_iou, assign_pairs
+from scipy.optimize import linear_sum_assignment
+from doctr.utils.metrics import box_iou
 
 
 @pytest.mark.asyncio
@@ -25,6 +26,8 @@ async def test_perform_ocr(test_app_asyncio, mock_detection_image):
     pred_boxes = np.array([elt['box'] for elt in json_response])
     pred_labels = np.array([elt['value'] for elt in json_response])
     iou_mat = box_iou(gt_boxes, pred_boxes)
-    gt_idxs, pred_idxs = assign_pairs(iou_mat, 0.8)
+    gt_idxs, pred_idxs = linear_sum_assignment(-iou_mat)
+    is_kept = iou_mat[gt_idxs, pred_idxs] >= 0.8
+    gt_idxs, pred_idxs = gt_idxs[is_kept], pred_idxs[is_kept]
     assert gt_idxs.shape[0] == gt_boxes.shape[0]
     assert all(gt_labels[gt_idx] == pred_labels[pred_idx] for gt_idx, pred_idx in zip(gt_idxs, pred_idxs))

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -21,7 +21,7 @@ Here are all datasets that are available through DocTR:
 .. autoclass:: FUNSD
 .. autoclass:: SROIE
 .. autoclass:: CORD
-..autoclass:: OCRDataset
+.. autoclass:: OCRDataset
 
 
 Data Loading

--- a/docs/source/documents.rst
+++ b/docs/source/documents.rst
@@ -45,6 +45,8 @@ A Page is a collection of Blocks that were on the same physical page.
 
 .. autoclass:: Page
 
+   .. automethod:: show
+
 
 Document
 ^^^^^^^^
@@ -52,6 +54,8 @@ Document
 A Document is a collection of Pages.
 
 .. autoclass:: Document
+
+   .. automethod:: show
 
 
 File reading

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -23,8 +23,14 @@ Implementations of task-specific metrics to easily assess your model performance
 
 .. currentmodule:: doctr.utils.metrics
 
-.. autoclass:: ExactMatch
+.. autoclass:: TextMatch
+
+   .. automethod:: summary
 
 .. autoclass:: LocalizationConfusion
 
+   .. automethod:: summary
+
 .. autoclass:: OCRMetric
+
+   .. automethod:: summary

--- a/doctr/documents/elements.py
+++ b/doctr/documents/elements.py
@@ -191,6 +191,12 @@ class Page(Element):
         return f"dimensions={self.dimensions}"
 
     def show(self, page: np.ndarray, interactive: bool = True, **kwargs) -> None:
+        """Overlay the result on a given image
+
+        Args:
+            page: image encoded as a numpy array in uint8
+            interactive: whether the display should be interactive
+        """
         visualize_page(self.export(), page, interactive=interactive)
         plt.show(**kwargs)
 
@@ -215,6 +221,10 @@ class Document(Element):
         return page_break.join(p.render() for p in self.pages)
 
     def show(self, pages: List[np.ndarray], **kwargs) -> None:
-        """Plot the results"""
+        """Overlay the result on a given image
+
+        Args:
+            pages: list of images encoded as numpy arrays in uint8
+        """
         for img, result in zip(pages, self.pages):
             result.show(img, **kwargs)

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -92,7 +92,7 @@ class TextMatch:
         """Computes the aggregated metrics
 
         Returns:
-            a dictionary with the exact match score for the raw data, its lower-case counterpart, its unidecode 
+            a dictionary with the exact match score for the raw data, its lower-case counterpart, its unidecode
             counterpart and its lower-case unidecode counterpart
         """
         if self.total == 0:

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -89,7 +89,12 @@ class TextMatch:
         self.total += len(gt)
 
     def summary(self) -> Dict[str, float]:
-        """Computes the aggregated metrics"""
+        """Computes the aggregated metrics
+
+        Returns:
+            a dictionary with the exact match score for the raw data, its lower-case counterpart, its unidecode 
+            counterpart and its lower-case unidecode counterpart
+        """
         if self.total == 0:
             raise AssertionError("you need to update the metric before getting the summary")
 
@@ -194,6 +199,11 @@ class LocalizationConfusion:
         self.num_preds += preds.shape[0]
 
     def summary(self) -> Tuple[float, float, float]:
+        """Computes the aggregated metrics
+
+        Returns:
+            a tuple with the recall, precision and meanIoU scores
+        """
 
         # Recall
         recall = self.matches / self.num_gts if self.num_gts > 0 else None
@@ -290,6 +300,11 @@ class OCRMetric:
         self.num_preds += pred_boxes.shape[0]
 
     def summary(self) -> Tuple[Dict[str, float], Dict[str, float], float]:
+        """Computes the aggregated metrics
+
+        Returns:
+            a tuple with the recall & precision for each string comparison flexibility and the mean IoU
+        """
 
         # Recall
         recall = dict(

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -33,9 +33,9 @@ def string_match(word1: str, word2: str) -> Tuple[bool, bool, bool, bool]:
 
 
 class TextMatch:
-    """Implements exact match metric (word-level accuracy) for recognition task.
+    """Implements text match metric (word-level accuracy) for recognition task.
 
-    The aggregated metric is computed as follows:
+    The raw aggregated metric is computed as follows:
 
     .. math::
         \\forall X, Y \\in \\mathcal{W}^N,

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -21,7 +21,7 @@ if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
 from doctr.models import detection, DetectionPreProcessor
-from doctr.utils import metrics
+from doctr.utils.metrics import LocalizationConfusion
 from doctr.datasets import DetectionDataset, DataLoader
 from doctr import transforms as T
 
@@ -157,7 +157,7 @@ def main(args):
     step = tf.Variable(0, dtype="int64")
 
     # Metrics
-    val_metric = metrics.LocalizationConfusion()
+    val_metric = LocalizationConfusion()
 
     if args.test_only:
         print("Running evaluation")

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -90,8 +90,8 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         batch_cnt += 1
 
     val_loss /= batch_cnt
-    exact_match, _, _, partial_match = val_metric.summary()
-    return val_loss, exact_match, partial_match
+    result = val_metric.summary()
+    return val_loss, result['raw'], result['unicase']
 
 
 def main(args):

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -23,7 +23,7 @@ if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
 from doctr.models import recognition, RecognitionPreProcessor
-from doctr.utils import metrics
+from doctr.utils.metrics import TextMatch
 from doctr.datasets import RecognitionDataset, DataLoader, VOCABS
 from doctr import transforms as T
 
@@ -90,8 +90,8 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         batch_cnt += 1
 
     val_loss /= batch_cnt
-    exact_match = val_metric.summary()
-    return val_loss, exact_match
+    exact_match, _, _, partial_match = val_metric.summary()
+    return val_loss, exact_match, partial_match
 
 
 def main(args):
@@ -151,7 +151,7 @@ def main(args):
     step = tf.Variable(0, dtype="int64")
 
     # Metrics
-    val_metric = metrics.ExactMatch()
+    val_metric = TextMatch()
 
     batch_transforms = T.Compose([
         T.Normalize(mean=(0.694, 0.695, 0.693), std=(0.299, 0.296, 0.301)),
@@ -181,16 +181,18 @@ def main(args):
         fit_one_epoch(model, train_loader, batch_transforms, optimizer, loss_q, mb, tb_writer, step)
 
         # Validation loop at the end of each epoch
-        val_loss, exact_match = evaluate(model, val_loader, batch_transforms, val_metric)
+        val_loss, exact_match, partial_match = evaluate(model, val_loader, batch_transforms, val_metric)
         if val_loss < min_loss:
             print(f"Validation loss decreased {min_loss:.6} --> {val_loss:.6}: saving state...")
             model.save_weights(f'./{exp_name}/weights')
             min_loss = val_loss
-        mb.write(f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} (Acc: {exact_match:.2%})")
+        mb.write(f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} "
+                 f"(Exact: {exact_match:.2%} | Partial: {partial_match:.2%})")
         # Tensorboard
         with tb_writer.as_default():
             tf.summary.scalar('val_loss', val_loss, step=step)
             tf.summary.scalar('exact_match', exact_match, step=step)
+            tf.summary.scalar('partial_match', exact_match, step=step)
         #reset val metric
         val_metric.reset()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0
 mplcursors>=0.3
-rapidfuzz>=1.0.0
 weasyprint>=52.2
+unidecode>=1.0.0

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -74,7 +74,7 @@ def main(args):
     print(f"Text Detection - Recall: {recall:.2%}, Precision: {precision:.2%}, Mean IoU: {mean_iou:.2%}")
     acc = reco_metric.summary()
     print(f"Text Recognition - Accuracy: {acc['raw']:.2%} (unicase: {acc['unicase']:.2%})")
-    recall, precision, mean_iou, _ = e2e_metric.summary()
+    recall, precision, mean_iou = e2e_metric.summary()
     print(f"OCR - Recall: {recall['raw']:.2%} (unicase: {recall['unicase']:.2%}), "
           f"Precision: {precision['raw']:.2%} (unicase: {precision['unicase']:.2%}), Mean IoU: {mean_iou:.2%}")
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -32,9 +32,9 @@ def main(args):
         val_set = datasets.__dict__[args.dataset](train=False, download=True)
         sets = [train_set, val_set]
 
-    det_metric = LocalizationConfusion()
+    det_metric = LocalizationConfusion(iou_thresh=args.iou)
     reco_metric = TextMatch()
-    e2e_metric = OCRMetric()
+    e2e_metric = OCRMetric(iou_thresh=args.iou)
 
     for dataset in sets:
         for page, target in tqdm(dataset):
@@ -70,13 +70,13 @@ def main(args):
     # Unpack aggregated metrics
     print(f"Model Evaluation (model= {args.detection} + {args.recognition}, "
           f"dataset={'OCRDataset' if args.img_folder else args.dataset})")
-    recall, precision, mean_iou = det_metric.summary(iou_thresh=args.iou)
+    recall, precision, mean_iou = det_metric.summary()
     print(f"Text Detection - Recall: {recall:.2%}, Precision: {precision:.2%}, Mean IoU: {mean_iou:.2%}")
     acc = reco_metric.summary()
-    print(f"Text Recognition - Accuracy: {acc["raw"]:.2%} (unicase: {acc["unicase"]:.2%})")
-    recall, precision, mean_iou, _ = e2e_metric.summary(iou_thresh=args.iou)
-    print(f"OCR - Recall: {recall["raw"]:.2%} (unicase: {recall["unicase"]:.2%}), "
-          f"Precision: {precision["raw"]:.2%} (unicase: {precision["unicase"]:.2%}), Mean IoU: {mean_iou:.2%}")
+    print(f"Text Recognition - Accuracy: {acc['raw']:.2%} (unicase: {acc['unicase']:.2%})")
+    recall, precision, mean_iou, _ = e2e_metric.summary()
+    print(f"OCR - Recall: {recall['raw']:.2%} (unicase: {recall['unicase']:.2%}), "
+          f"Precision: {precision['raw']:.2%} (unicase: {precision['unicase']:.2%}), Mean IoU: {mean_iou:.2%}")
 
 
 def parse_args():

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ requirements = [
     "shapely>=1.6.0",
     "matplotlib>=3.1.0",
     "mplcursors>=0.3",
-    "rapidfuzz>=1.0.0",
     "weasyprint>=52.2",
+    "unidecode>=1.0.0",
 ]
 
 setup(

--- a/test/test_utils_metrics.py
+++ b/test/test_utils_metrics.py
@@ -55,12 +55,12 @@ def test_box_iou(box1, box2, iou, abs_tol):
 )
 def test_localization_confusion(gts, preds, iou_thresh, recall, precision, mean_iou):
 
-    metric = metrics.LocalizationConfusion()
+    metric = metrics.LocalizationConfusion(iou_thresh)
     for _gts, _preds in zip(gts, preds):
         metric.update(np.asarray(_gts), np.zeros((0, 4)) if _preds is None else np.asarray(_preds))
-    assert metric.summary(iou_thresh) == (recall, precision, mean_iou)
+    assert metric.summary() == (recall, precision, mean_iou)
     metric.reset()
-    assert metric.num_gts == metric.num_preds == len(metric.ious) == metric.tot_iou == 0
+    assert metric.num_gts == metric.num_preds == metric.matches == metric.tot_iou == 0
 
 
 @pytest.mark.parametrize(
@@ -103,7 +103,7 @@ def test_localization_confusion(gts, preds, iou_thresh, recall, precision, mean_
 def test_ocr_metric(
     gt_boxes, gt_words, pred_boxes, pred_words, iou_thresh, recall, precision, mean_iou
 ):
-    metric = metrics.OCRMetric()
+    metric = metrics.OCRMetric(iou_thresh)
     for _gboxes, _gwords, _pboxes, _pwords in zip(gt_boxes, gt_words, pred_boxes, pred_words):
         metric.update(
             np.asarray(_gboxes),
@@ -111,9 +111,10 @@ def test_ocr_metric(
             _gwords,
             _pwords
         )
-    _recall, _precision, _mean_iou = metric.summary(iou_thresh)
+    _recall, _precision, _mean_iou = metric.summary()
     assert _recall == recall
     assert _precision == precision
     assert _mean_iou == mean_iou
     metric.reset()
-    assert metric.num_gts == metric.num_preds == metric.tot_iou == len(metric.ious) == len(metric.text_matches) == 0
+    assert metric.num_gts == metric.num_preds == metric.tot_iou == 0
+    assert metric.raw_matches == metric.caseless_matches == metric.unidecode_matches == metric.unicase_matches == 0

--- a/test/test_utils_metrics.py
+++ b/test/test_utils_metrics.py
@@ -4,39 +4,25 @@ from doctr.utils import metrics
 
 
 @pytest.mark.parametrize(
-    "gt, pred, ignore_case, ignore_accents, result",
+    "gt, pred, raw, caseless, unidecode, unicase",
     [
-        [['grass', '56', 'True', 'STOP'], ['grass', '56', 'true', 'stop'], True, False, 1.0],
-        [['grass', '56', 'True', 'STOP'], ['grass', '56', 'true', 'stop'], False, False, .5],
-        [['éléphant'], ['elephant'], False, True, 1.0],
+        [['grass', '56', 'True', 'EUR'], ['grass', '56', 'true', '€'], .5, .75, .75, 1],
+        [['éléphant', 'ça'], ['elephant', 'ca'], 0, 0, 1, 1],
     ],
 )
-def test_exact_match(gt, pred, ignore_case, ignore_accents, result):
-    metric = metrics.ExactMatch(ignore_case, ignore_accents)
+def test_text_match(gt, pred, raw, caseless, unidecode, unicase):
+    metric = metrics.TextMatch()
     with pytest.raises(AssertionError):
         metric.summary()
-    if ignore_accents:
-        with pytest.raises(NotImplementedError):
-            metric.update(gt, pred)
-    else:
-        metric.update(gt, pred)
-        assert metric.summary() == result
-        metric.reset()
-        assert metric.matches == metric.total == 0
 
+    with pytest.raises(AssertionError):
+        metric.update(['a', 'b'], ['c'])
 
-@pytest.mark.parametrize(
-    "mat, row_indices, col_indices",
-    [
-        [[[1, 0, 0], [0, 1, 0], [0, 0, 1]], [0, 1, 2], [0, 1, 2]],  # Perfect diagonal
-        [[[1, 0, 0], [0, .4, 0], [0, 0, 1]], [0, 2], [0, 2]],  # below threshold
-        [[[1, 0, 0], [0, 1, 0], [0, 0, 0.5], [0, 0, 1]], [0, 1, 3], [0, 1, 2]],  # rectangular matrix
-    ],
-)
-def test_assign_pairs(mat, row_indices, col_indices):
-    gt_idxs, pred_idxs = metrics.assign_pairs(np.asarray(mat))
-    assert all(a == b for a, b in zip(row_indices, gt_idxs)), print(gt_idxs)
-    assert all(a == b for a, b in zip(col_indices, pred_idxs)), print(pred_idxs)
+    metric.update(gt, pred)
+    assert metric.summary() == dict(raw=raw, caseless=caseless, unidecode=unidecode, unicase=unicase)
+
+    metric.reset()
+    assert metric.raw == metric.caseless == metric.unidecode == metric.unicase == metric.total == 0
 
 
 @pytest.mark.parametrize(
@@ -69,43 +55,55 @@ def test_box_iou(box1, box2, iou, abs_tol):
 )
 def test_localization_confusion(gts, preds, iou_thresh, recall, precision, mean_iou):
 
-    metric = metrics.LocalizationConfusion(iou_thresh)
+    metric = metrics.LocalizationConfusion()
     for _gts, _preds in zip(gts, preds):
         metric.update(np.asarray(_gts), np.zeros((0, 4)) if _preds is None else np.asarray(_preds))
-    assert metric.summary() == (recall, precision, mean_iou)
+    assert metric.summary(iou_thresh) == (recall, precision, mean_iou)
     metric.reset()
-    assert metric.num_matches == metric.num_gts == metric.num_preds == 0
+    assert metric.num_gts == metric.num_preds == len(metric.ious) == metric.tot_iou == 0
 
 
 @pytest.mark.parametrize(
-    "gt_boxes, gt_words, pred_boxes, pred_words, iou_thresh, max_dist, recall, precision, mean_iou, mean_distance",
+    "gt_boxes, gt_words, pred_boxes, pred_words, iou_thresh, recall, precision, mean_iou",
     [
         [  # Perfect match
             [[[0, 0, .5, .5]]], [["elephant"]],
             [[[0, 0, .5, .5]]], [["elephant"]],
-            0.5, 0, 1, 1, 1, 0
+            0.5,
+            {"raw": 1, "caseless": 1, "unidecode": 1, "unicase": 1},
+            {"raw": 1, "caseless": 1, "unidecode": 1, "unicase": 1},
+            1,
         ],
         [  # Bad match
             [[[0, 0, .5, .5]]], [["elefant"]],
             [[[0, 0, .5, .5]]], [["elephant"]],
-            0.5, 1, 0, 0, 1, 2
+            0.5,
+            {"raw": 0, "caseless": 0, "unidecode": 0, "unicase": 0},
+            {"raw": 0, "caseless": 0, "unidecode": 0, "unicase": 0},
+            1,
         ],
         [  # Good match
-            [[[0, 0, 1, 1]]], [["home"]],
-            [[[0, 0, .5, .5], [.6, .6, .7, .7]]], [["hom", "e"]],
-            0.2, 1, 1, 0.5, 0.125, 1
+            [[[0, 0, 1, 1]]], [["EUR"]],
+            [[[0, 0, .5, .5], [.6, .6, .7, .7]]], [["€", "e"]],
+            0.2,
+            {"raw": 0, "caseless": 0, "unidecode": 1, "unicase": 1},
+            {"raw": 0, "caseless": 0, "unidecode": .5, "unicase": .5},
+            0.125,
         ],
         [  # No preds on 2nd sample
-            [[[0, 0, .5, .5]], [[0, 0, .5, .5]]], [["elephant"], ["elephant"]],
+            [[[0, 0, .5, .5]], [[0, 0, .5, .5]]], [["Elephant"], ["elephant"]],
             [[[0, 0, .5, .5]], None], [["elephant"], []],
-            0.5, 0, 0.5, 1, 1, 0
+            0.5,
+            {"raw": 0, "caseless": .5, "unidecode": 0, "unicase": .5},
+            {"raw": 0, "caseless": 1, "unidecode": 0, "unicase": 1},
+            1,
         ],
     ],
 )
 def test_ocr_metric(
-    gt_boxes, gt_words, pred_boxes, pred_words, iou_thresh, max_dist, recall, precision, mean_iou, mean_distance
+    gt_boxes, gt_words, pred_boxes, pred_words, iou_thresh, recall, precision, mean_iou
 ):
-    metric = metrics.OCRMetric(iou_thresh, max_dist)
+    metric = metrics.OCRMetric()
     for _gboxes, _gwords, _pboxes, _pwords in zip(gt_boxes, gt_words, pred_boxes, pred_words):
         metric.update(
             np.asarray(_gboxes),
@@ -113,7 +111,9 @@ def test_ocr_metric(
             _gwords,
             _pwords
         )
-    assert metric.summary() == (recall, precision, mean_iou, mean_distance)
+    _recall, _precision, _mean_iou = metric.summary(iou_thresh)
+    assert _recall == recall
+    assert _precision == precision
+    assert _mean_iou == mean_iou
     metric.reset()
-    assert metric.num_reco_matches == metric.num_det_matches == metric.num_gts == metric.num_preds == 0
-    assert metric.tot_iou == metric.tot_dist == 0.
+    assert metric.num_gts == metric.num_preds == metric.tot_iou == len(metric.ious) == len(metric.text_matches) == 0


### PR DESCRIPTION
This PR introduces the following modifications:
- added granularity to string comparison : raw comparison, case-insensitive, unidecode comparison, and comparison of unidecoded lower-case pairs
- added this granularity to RecognitionMetric, which has been renamed to `TextMatch`
- added this granularity in the recall & precision computation of `OCRMetric`
- updated requirements accordingly
- updated unittests accordingly
- reflected changes on evaluation script and training scripts
- fixed documentation of `OCRDataset`
- added documentation of `show` methods of `Page` and `Document`
- added documentation of `summary` methods of metrics