### PR TITLE
fix: multi-page demo & RGB for pdf reader

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -76,7 +76,7 @@ def main():
                 processed_batches = predictor.det_predictor.pre_processor(doc)
                 out = predictor.det_predictor.model(processed_batches[0], return_model_output=True, training=False)
                 seg_map = out["out_map"]
-                seg_map = tf.squeeze(seg_map, axis=[0, 3])
+                seg_map = tf.squeeze(seg_map[0, ...], axis=[2])
                 seg_map = cv2.resize(seg_map.numpy(), (doc[0].shape[1], doc[0].shape[0]),
                                      interpolation=cv2.INTER_LINEAR)
                 # Plot the raw heatmap

--- a/doctr/documents/reader.py
+++ b/doctr/documents/reader.py
@@ -91,7 +91,7 @@ def read_pdf(file: AbstractFile, **kwargs: Any) -> fitz.Document:
 def convert_page_to_numpy(
     page: fitz.fitz.Page,
     output_size: Optional[Tuple[int, int]] = None,
-    rgb_output: bool = True,
+    bgr_output: bool = False,
     default_scales: Tuple[float, float] = (2, 2),
 ) -> np.ndarray:
     """Convert a fitz page to a numpy-formatted image
@@ -123,8 +123,8 @@ def convert_page_to_numpy(
     img = np.frombuffer(pixmap.samples, dtype=np.uint8).reshape(pixmap.height, pixmap.width, 3)
 
     # Switch the channel order
-    if rgb_output:
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    if bgr_output:
+        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
 
     return img
 

--- a/test/test_documents_reader.py
+++ b/test/test_documents_reader.py
@@ -15,7 +15,7 @@ def test_convert_page_to_numpy(mock_pdf):
     assert rgb_page.shape == (792, 612, 3)
 
     # Check channel order
-    bgr_page = reader.convert_page_to_numpy(pdf[0], default_scales=(1, 1), rgb_output=False)
+    bgr_page = reader.convert_page_to_numpy(pdf[0], default_scales=(1, 1), bgr_output=True)
     assert np.all(bgr_page == rgb_page[..., ::-1])
 
     # Check resizing


### PR DESCRIPTION
This PR fixes 2 bugs spotted on the demo:
- multi-pages pdf were crashing the app
- pdf reader as images was outputing BGR instead of RGB

Any feedback is welcome!