### PR TITLE
refactor: Refactored dataset methods and removed unused imports

### DIFF
--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -49,7 +49,7 @@ class CORD(VisionDataset):
         self.root = os.path.join(self._root, 'image')
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         self.train = train
-        self.sample_transforms = (lambda x: x) if sample_transforms is None else sample_transforms
+        self.sample_transforms = sample_transforms
         for img_path in os.listdir(self.root):
             if not os.path.exists(os.path.join(self.root, img_path)):
                 raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_path)}")
@@ -73,20 +73,3 @@ class CORD(VisionDataset):
 
     def extra_repr(self) -> str:
         return f"train={self.train}"
-
-    def __getitem__(self, index: int) -> Tuple[tf.Tensor, Dict[str, Any]]:
-        img_name, target = self.data[index]
-        # Read image
-        img = tf.io.read_file(os.path.join(self.root, img_name))
-        img = tf.image.decode_jpeg(img, channels=3)
-        img = self.sample_transforms(img)
-
-        return img, target
-
-    @staticmethod
-    def collate_fn(samples: List[Tuple[tf.Tensor, Dict[str, Any]]]) -> Tuple[tf.Tensor, List[Dict[str, Any]]]:
-
-        images, targets = zip(*samples)
-        images = tf.stack(images, axis=0)
-
-        return images, list(targets)

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -5,7 +5,6 @@
 
 import os
 import json
-import math
 import tensorflow as tf
 import numpy as np
 from typing import List, Tuple, Dict, Any, Optional, Callable

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -43,7 +43,7 @@ class FUNSD(VisionDataset):
 
         super().__init__(self.URL, self.FILE_NAME, self.SHA256, True, **kwargs)
         self.train = train
-        self.sample_transforms = (lambda x: x) if sample_transforms is None else sample_transforms
+        self.sample_transforms = sample_transforms
 
         # Use the subset
         subfolder = os.path.join('dataset', 'training_data' if train else 'testing_data')
@@ -67,20 +67,3 @@ class FUNSD(VisionDataset):
 
     def extra_repr(self) -> str:
         return f"train={self.train}"
-
-    def __getitem__(self, index: int) -> Tuple[tf.Tensor, Dict[str, Any]]:
-        img_name, target = self.data[index]
-        # Read image
-        img = tf.io.read_file(os.path.join(self.root, img_name))
-        img = tf.image.decode_jpeg(img, channels=3)
-        img = self.sample_transforms(img)
-
-        return img, target
-
-    @staticmethod
-    def collate_fn(samples: List[Tuple[tf.Tensor, Dict[str, Any]]]) -> Tuple[tf.Tensor, List[Dict[str, Any]]]:
-
-        images, targets = zip(*samples)
-        images = tf.stack(images, axis=0)
-
-        return images, list(targets)

--- a/doctr/datasets/loader.py
+++ b/doctr/datasets/loader.py
@@ -6,7 +6,7 @@
 import math
 import tensorflow as tf
 import numpy as np
-from typing import List, Tuple, Dict, Any, Optional
+from typing import Tuple, Dict, Any, Optional
 
 from .multithreading import multithread_exec
 

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -34,7 +34,7 @@ class OCRDataset(AbstractDataset):
         **kwargs: Any,
     ) -> None:
 
-        self.sample_transforms = (lambda x: x) if sample_transforms is None else sample_transforms
+        self.sample_transforms = sample_transforms
         self.root = img_folder
 
         # List images
@@ -66,20 +66,3 @@ class OCRDataset(AbstractDataset):
 
             text_targets = [word for word, _valid in zip(file_dic["string"], is_valid) if _valid]
             self.data.append((img_name, dict(boxes=np.asarray(box_targets, dtype=np.float32), labels=text_targets)))
-
-    def __getitem__(self, index: int) -> Tuple[tf.Tensor, Dict[str, Any]]:
-        img_name, target = self.data[index]
-        # Read image
-        img = tf.io.read_file(os.path.join(self.root, img_name))
-        img = tf.image.decode_jpeg(img, channels=3)
-        img = self.sample_transforms(img)
-
-        return img, target
-
-    @staticmethod
-    def collate_fn(samples: List[Tuple[tf.Tensor, Dict[str, Any]]]) -> Tuple[tf.Tensor, List[Dict[str, Any]]]:
-
-        images, targets = zip(*samples)
-        images = tf.stack(images, axis=0)
-
-        return images, list(targets)

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import List, Dict, Any, Tuple, Optional, Callable
 import tensorflow as tf
 
-from doctr.documents.reader import read_img, read_pdf
 from .core import AbstractDataset
 
 

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -6,7 +6,7 @@
 import os
 import json
 import tensorflow as tf
-from typing import Tuple, List, Dict, Any, Optional, Callable
+from typing import Tuple, List, Any, Optional, Callable
 
 from .core import AbstractDataset
 

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -45,23 +45,3 @@ class RecognitionDataset(AbstractDataset):
             if not isinstance(label, str):
                 raise KeyError("Image is not in referenced in label file")
             self.data.append((img_path, label))
-
-    def __getitem__(
-        self,
-        index: int
-    ) -> Tuple[tf.Tensor, str]:
-
-        img_name, label = self.data[index]
-        img = tf.io.read_file(os.path.join(self.root, img_name))
-        img = tf.image.decode_jpeg(img, channels=3)
-        img = self.sample_transforms(img)
-
-        return img, label
-
-    @staticmethod
-    def collate_fn(samples: List[Tuple[tf.Tensor, str]]) -> Tuple[tf.Tensor, List[str]]:
-
-        images, labels = zip(*samples)
-        images = tf.stack(images, axis=0)
-
-        return images, list(labels)

--- a/doctr/datasets/sroie.py
+++ b/doctr/datasets/sroie.py
@@ -45,7 +45,7 @@ class SROIE(VisionDataset):
 
         url, sha256 = self.TRAIN if train else self.TEST
         super().__init__(url, None, sha256, True, **kwargs)
-        self.sample_transforms = (lambda x: x) if sample_transforms is None else sample_transforms
+        self.sample_transforms = sample_transforms
         self.train = train
 
         # # List images
@@ -75,20 +75,3 @@ class SROIE(VisionDataset):
 
     def extra_repr(self) -> str:
         return f"train={self.train}"
-
-    def __getitem__(self, index: int) -> Tuple[tf.Tensor, Dict[str, Any]]:
-        img_name, target = self.data[index]
-        # Read image
-        img = tf.io.read_file(os.path.join(self.root, img_name))
-        img = tf.image.decode_jpeg(img, channels=3)
-        img = self.sample_transforms(img)
-
-        return img, target
-
-    @staticmethod
-    def collate_fn(samples: List[Tuple[tf.Tensor, Dict[str, Any]]]) -> Tuple[tf.Tensor, List[Dict[str, Any]]]:
-
-        images, targets = zip(*samples)
-        images = tf.stack(images, axis=0)
-
-        return images, list(targets)

--- a/doctr/models/artefacts/barcode.py
+++ b/doctr/models/artefacts/barcode.py
@@ -66,7 +66,7 @@ class BarCodeDetector:
         edges = cv2.dilate(edges, np.ones((k, 1), np.uint8))
 
         # Find contours, and keep the widest as barcodes
-        contours, hierarchy = cv2.findContours(edges, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+        contours, _ = cv2.findContours(edges, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
         barcodes = []
         for contour in contours:
             x, y, w, h = cv2.boundingRect(contour)

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 from tensorflow import keras
 import numpy as np
 import cv2
-from typing import Union, List, Tuple, Any, Optional, Dict
+from typing import List, Tuple, Any, Optional, Dict
 from ..preprocessor import PreProcessor
 from doctr.utils.repr import NestedObject
 

--- a/doctr/models/detection/zoo.py
+++ b/doctr/models/detection/zoo.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-from typing import Dict, Any
+from typing import Any
 
 from .core import DetectionPredictor
 from ..preprocessor import PreProcessor

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-from typing import Dict, Any
+from typing import Any
 
 from .core import RecognitionPredictor
 from ..preprocessor import PreProcessor

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -20,7 +20,7 @@ gpu_devices = tf.config.experimental.list_physical_devices('GPU')
 if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
-from doctr.models import detection, DetectionPreProcessor
+from doctr.models import detection
 from doctr.utils.metrics import LocalizationConfusion
 from doctr.datasets import DetectionDataset, DataLoader
 from doctr import transforms as T

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -8,7 +8,6 @@ import os
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
 import time
-import json
 import datetime
 import math
 import numpy as np
@@ -22,7 +21,7 @@ gpu_devices = tf.config.experimental.list_physical_devices('GPU')
 if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
-from doctr.models import recognition, RecognitionPreProcessor
+from doctr.models import recognition
 from doctr.utils.metrics import TextMatch
 from doctr.datasets import RecognitionDataset, DataLoader, VOCABS
 from doctr import transforms as T

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import tensorflow as tf
 
 from doctr import datasets

--- a/test/test_datasets_recognition.py
+++ b/test/test_datasets_recognition.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
 import pytest
 import json
-import numpy as np
 
 from doctr.datasets import RecognitionDataset
 from doctr.datasets import DataLoader

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -1,5 +1,4 @@
 import pytest
-import math
 import numpy as np
 import tensorflow as tf
 

--- a/test/test_models_export.py
+++ b/test/test_models_export.py
@@ -1,6 +1,5 @@
 import pytest
 import sys
-import tensorflow as tf
 from tensorflow.keras import layers, Sequential
 
 from doctr.models import export

--- a/test/test_models_recognition.py
+++ b/test/test_models_recognition.py
@@ -1,6 +1,5 @@
 import pytest
 import numpy as np
-import math
 import tensorflow as tf
 
 from doctr.models import recognition, PreProcessor


### PR DESCRIPTION
This PR introduces the following modifications:
- refactored duplicated dataset methods
- forced fp32 for box targets of `OCRDataset` (previously np.float64)
- removed unused imports
- removed unused variables
- added unittests for `OCRDataset`

Any feedback is welcome!