### PR TITLE
fix: Fixed image decoding in API template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@ Everything you need to know to contribute efficiently to the project.
 - [doctr](https://github.com/mindee/doctr/blob/main/doctr) - The actual doctr library
 - [test](https://github.com/mindee/doctr/blob/main/test) - Python unit tests
 - [docs](https://github.com/mindee/doctr/blob/main/docs) - Library documentation building
+- [scripts](https://github.com/mindee/doctr/blob/main/scripts) - Example scripts
+- [references](https://github.com/mindee/doctr/blob/main/references) - Reference training scripts
+- [demo](https://github.com/mindee/doctr/blob/main/demo) - Small demo app to showcase DocTR capabilities 
+- [api](https://github.com/mindee/doctr/blob/main/api) - A minimal template to deploy an API with DocTR
 
 
 ## Continuous Integration

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ All script arguments can be checked using `python scripts/analyze.py --help`
 
 ### Minimal API integration
 
-Looking to integrate DocTR into your API? Here is a template to get you started with a fully working API.
+Looking to integrate DocTR into your API? Here is a template to get you started with a fully working API using the wonderful [FastAPI](https://github.com/tiangolo/fastapi) framework.
 
-#### Manual setup
+#### Deploy your API locally
 Specific dependencies are required to run the API template, which you can install as follows:
 ```shell
 pip install -r api/requirements.txt
@@ -160,14 +160,27 @@ pip install -r api/requirements.txt
 You can now run your API locally:
 
 ```shell
-uvicorn --reload --workers 1 --host 0.0.0.0 --port=8050 --app-dir api/ app.main:app
+uvicorn --reload --workers 1 --host 0.0.0.0 --port=8002 --app-dir api/ app.main:app
 ```
 
-#### Docker setup
-You can run the same server on a docker container if you prefer using:
+Alternatively, you can run the same server on a docker container if you prefer using:
 ```shell
-PORT=8050 docker-compose up -d --build
+PORT=8002 docker-compose up -d --build
 ```
+
+#### What you have deployed
+
+Your API should now be running locally on your port 8002. Access your automatically-built documentation at [http://localhost:8002/redoc](http://localhost:8002/redoc) and enjoy your three functional routes ("/detection", "/recognition", "/ocr"). Here is an example with Python to send a request to the OCR route:
+
+```python
+
+import requests
+import io
+with open('/path/to/your/doc.jpg', 'rb') as f:
+    data = f.read()
+response = requests.post("http://localhost:8002/ocr", files={'file': io.BytesIO(data)}).json()
+```
+
 
 ## Citation
 

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -17,5 +17,5 @@ router = APIRouter()
 async def text_detection(file: UploadFile = File(...)):
     """Runs DocTR text detection model to analyze the input"""
     img = decode_image(file.file.read())
-    out = det_predictor(img[None, ...], training=False)
+    out = det_predictor([img], training=False)
     return [DetectionOut(box=box.tolist()) for box in out[0][:, :4]]

--- a/api/app/routes/ocr.py
+++ b/api/app/routes/ocr.py
@@ -17,7 +17,7 @@ router = APIRouter()
 async def perform_ocr(file: UploadFile = File(...)):
     """Runs DocTR OCR model to analyze the input"""
     img = decode_image(file.file.read())
-    out = predictor(img[None, ...], training=False)
+    out = predictor([img], training=False)
 
     return [OCROut(box=(*word.geometry[0], *word.geometry[1]), value=word.value)
             for word in out.pages[0].blocks[0].lines[0].words]

--- a/api/app/routes/recognition.py
+++ b/api/app/routes/recognition.py
@@ -16,5 +16,5 @@ router = APIRouter()
 async def text_recognition(file: UploadFile = File(...)):
     """Runs DocTR text recognition model to analyze the input"""
     img = decode_image(file.file.read())
-    out = reco_predictor(img[None, ...], training=False)
+    out = reco_predictor([img], training=False)
     return RecognitionOut(value=out[0])

--- a/api/app/vision.py
+++ b/api/app/vision.py
@@ -19,4 +19,4 @@ reco_predictor = predictor.reco_predictor
 
 def decode_image(img_bytes: bytes) -> tf.Tensor:
     """Decodes an image from bytes"""
-    return tf.io.decode_image(img_bytes)
+    return tf.io.decode_image(img_bytes, channels=3)


### PR DESCRIPTION
This PR introduces the following modifications:
- fixed default channels in image decoding (previously 0 = grayscale, now 3)
- enforced correct resizing by passing list of TF tensor rather than plan tensor
- updated README and CONTRIBUTING references to the API template

Any feedback is welcome!