### PR TITLE
feat: Added recognition sequence probability

### DIFF
--- a/api/app/routes/recognition.py
+++ b/api/app/routes/recognition.py
@@ -17,4 +17,4 @@ async def text_recognition(file: UploadFile = File(...)):
     """Runs DocTR text recognition model to analyze the input"""
     img = decode_image(file.file.read())
     out = reco_predictor([img], training=False)
-    return RecognitionOut(value=out[0])
+    return RecognitionOut(value=out[0][0])

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -64,21 +64,15 @@ class RecognitionPostProcessor(NestedObject):
 
     Args:
         vocab: string containing the ordered sequence of supported characters
-        ignore_case: if True, ignore case of letters
-        ignore_accents: if True, ignore accents of letters
     """
 
     def __init__(
         self,
         vocab: str,
-        ignore_case: bool = False,
-        ignore_accents: bool = False
     ) -> None:
 
         self.vocab = vocab
         self._embedding = tf.constant(list(self.vocab) + ['<eos>'], dtype=tf.string)
-        self.ignore_case = ignore_case
-        self.ignore_accents = ignore_accents
 
     def extra_repr(self) -> str:
         return f"vocab_size={len(self.vocab)}"

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -113,7 +113,7 @@ class RecognitionPredictor(NestedObject):
         self,
         crops: List[np.ndarray],
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> List[Tuple[str, float]]:
 
         out = []
         if len(crops) > 0:
@@ -125,9 +125,9 @@ class RecognitionPredictor(NestedObject):
             processed_batches = self.pre_processor(crops)
 
             # Forward it
-            out = [self.model(batch, return_preds=True, **kwargs)['preds'] for batch in processed_batches]
+            raw = [self.model(batch, return_preds=True, **kwargs)['preds'] for batch in processed_batches]
 
             # Process outputs
-            out = [charseq for batch in out for charseq in batch]
+            out = [charseq for batch in raw for charseq in batch]
 
         return out

--- a/doctr/models/recognition/crnn.py
+++ b/doctr/models/recognition/crnn.py
@@ -82,12 +82,6 @@ class CTCPostProcessor(RecognitionPostProcessor):
         decoded_strings_pred = tf.sparse.to_dense(_decoded_strings_pred.to_sparse(), default_value='not valid')[:, 0]
         word_values = [word.decode() for word in decoded_strings_pred.numpy().tolist()]
 
-        if self.ignore_case:
-            word_values = [word.lower() for word in word_values]
-
-        if self.ignore_accents:
-            raise NotImplementedError
-
         return list(zip(word_values, probs.numpy().tolist()))
 
 

--- a/doctr/models/recognition/crnn.py
+++ b/doctr/models/recognition/crnn.py
@@ -83,7 +83,7 @@ class CTCPostProcessor(RecognitionPostProcessor):
         word_values = [word.decode() for word in decoded_strings_pred.numpy().tolist()]
 
         if self.ignore_case:
-            words_list = [word.lower() for word in words_list]
+            word_values = [word.lower() for word in word_values]
 
         if self.ignore_accents:
             raise NotImplementedError

--- a/doctr/models/recognition/sar.py
+++ b/doctr/models/recognition/sar.py
@@ -308,13 +308,7 @@ class SARPostProcessor(RecognitionPostProcessor):
         decoded_strings_pred = tf.strings.reduce_join(inputs=tf.nn.embedding_lookup(self._embedding, out_idxs), axis=-1)
         decoded_strings_pred = tf.strings.split(decoded_strings_pred, "<eos>")
         decoded_strings_pred = tf.sparse.to_dense(decoded_strings_pred.to_sparse(), default_value='not valid')[:, 0]
-        word_values = [word.decode() for word in list(decoded_strings_pred.numpy())]
-
-        if self.ignore_case:
-            word_values = [word.lower() for word in word_values]
-
-        if self.ignore_accents:
-            raise NotImplementedError
+        word_values = [word.decode() for word in decoded_strings_pred.numpy().tolist()]
 
         return list(zip(word_values, probs.numpy().tolist()))
 

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -83,7 +83,8 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         images = batch_transforms(images)
         out = model(images, targets, return_preds=True, training=False)
         # Compute metric
-        val_metric.update(targets, out['preds'])
+        words, _ = zip(*out['preds'])
+        val_metric.update(targets, words)
 
         val_loss += out['loss'].numpy().mean()
         batch_cnt += 1

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -49,6 +49,7 @@ def main(args):
             out = predictor(page[None, ...], training=False)
             crops = extract_crops(page, gt_boxes)
             reco_out = predictor.reco_predictor(crops, training=False)
+            reco_words, _ = zip(*reco_out)
 
             # Unpack preds
             pred_boxes = []
@@ -67,7 +68,7 @@ def main(args):
 
             # Update the metric
             det_metric.update(gt_boxes, np.asarray(pred_boxes))
-            reco_metric.update(gt_labels, reco_out)
+            reco_metric.update(gt_labels, reco_words)
             e2e_metric.update(gt_boxes, np.asarray(pred_boxes), gt_labels, pred_labels)
 
     # Unpack aggregated metrics

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -48,7 +48,7 @@ def test_documentbuilder():
     boxes = np.random.rand(words_per_page, 5)
     boxes[:2] *= boxes[2:4]
 
-    out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [(100, 200), (100, 200)])
+    out = doc_builder([boxes, boxes], [('hello', 1.0)] * (num_pages * words_per_page), [(100, 200), (100, 200)])
     assert isinstance(out, Document)
     assert len(out.pages) == num_pages
     # 1 Block & 1 line per page
@@ -57,7 +57,7 @@ def test_documentbuilder():
 
     # Resolve lines
     doc_builder = models.DocumentBuilder(resolve_lines=True, resolve_blocks=True)
-    out = doc_builder([boxes, boxes], ['hello'] * (num_pages * words_per_page), [(100, 200), (100, 200)])
+    out = doc_builder([boxes, boxes], [('hello', 1.0)] * (num_pages * words_per_page), [(100, 200), (100, 200)])
 
     # No detection
     boxes = np.zeros((0, 5))

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -84,7 +84,6 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     assert isinstance(out['loss'], tf.Tensor)
 
 
-@pytest.fixture(scope="session")
 def test_detectionpredictor(mock_pdf):  # noqa: F811
 
     batch_size = 4

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -84,6 +84,7 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     assert isinstance(out['loss'], tf.Tensor)
 
 
+@pytest.fixture(scope="session")
 def test_detectionpredictor(mock_pdf):  # noqa: F811
 
     batch_size = 4

--- a/test/test_models_recognition.py
+++ b/test/test_models_recognition.py
@@ -51,6 +51,7 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
     assert repr(processor) == f'{post_processor}(vocab_size={len(mock_vocab)})'
 
 
+@pytest.fixture(scope="session")
 def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
 
     batch_size = 4

--- a/test/test_models_recognition.py
+++ b/test/test_models_recognition.py
@@ -27,7 +27,8 @@ def test_recognition_models(arch_name, input_shape):
     assert isinstance(out, dict)
     assert len(out) == 3
     assert isinstance(out['preds'], list)
-    assert len(out['preds']) == batch_size and all(isinstance(word, str) for word in out['preds'])
+    assert len(out['preds']) == batch_size
+    assert all(isinstance(word, str) and isinstance(conf, float) and 0 <= conf <= 1 for word, conf in out['preds'])
     assert isinstance(out['out_map'], tf.Tensor)
     assert isinstance(out['loss'], tf.Tensor)
 
@@ -42,14 +43,14 @@ def test_recognition_models(arch_name, input_shape):
 def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
     processor = recognition.__dict__[post_processor](mock_vocab)
     decoded = processor(tf.random.uniform(shape=input_shape, minval=0, maxval=1, dtype=tf.float32))
-    assert isinstance(decoded, list) and all(isinstance(word, str) for word in decoded)
+    assert isinstance(decoded, list)
+    assert all(isinstance(word, str) and isinstance(conf, float) and 0 <= conf <= 1 for word, conf in decoded)
     assert len(decoded) == input_shape[0]
-    assert all(char in mock_vocab for word in decoded for char in word)
+    assert all(char in mock_vocab for word, _ in decoded for char in word)
     # Repr
     assert repr(processor) == f'{post_processor}(vocab_size={len(mock_vocab)})'
 
 
-@pytest.fixture(scope="session")
 def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
 
     batch_size = 4
@@ -67,7 +68,7 @@ def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
 
     # One prediction per crop
     assert len(out) == boxes.shape[0]
-    assert all(isinstance(charseq, str) for charseq in out)
+    assert all(isinstance(val, str) and isinstance(conf, float) for val, conf in out)
 
     # Dimension check
     with pytest.raises(ValueError):
@@ -95,7 +96,7 @@ def test_recognition_zoo(arch_name):
     input_tensor = tf.random.uniform(shape=[batch_size, 1024, 1024, 3], minval=0, maxval=1)
     out = predictor(input_tensor)
     assert isinstance(out, list) and len(out) == batch_size
-    assert all(isinstance(word, str) for word in out)
+    assert all(isinstance(word, str) and isinstance(conf, float) for word, conf in out)
 
 
 def test_recognition_zoo_error():


### PR DESCRIPTION
This PR introduces the following modifications:
- adds computation of the sequence probabilities in text recognition model (CRNN: switch from [greedy decoder](https://www.tensorflow.org/api_docs/python/tf/nn/ctc_greedy_decoder) to [beam search decoder](https://www.tensorflow.org/api_docs/python/tf/nn/ctc_beam_search_decoder) / SAR: took the minimum character probability in the sequence)
- reflected changes on API, training and evaluation scripts
- updated unittests
- removed `ignore_case` and `ignore_accents` from recognition postprocessors as those operations can be conducted by the user on its own after the export.

Any feedback is welcome!