### PR TITLE
docs: Improved landing page of the documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,10 @@ DocTR: Document Text Recognition
 
 State-of-the-art Optical Character Recognition made seamless & accessible to anyone, powered by TensorFlow 2
 
+.. image:: https://github.com/mindee/doctr/releases/download/v0.2.0/ocr.png
+        :align: center
+
+
 DocTR provides an easy and powerful way to extract valuable information from your documents:
 
 * |:receipt:| **for automation**: seemlessly process documents for Natural Language Understanding tasks: we provide OCR predictors to parse textual information (localize and identify each word) from your documents.
@@ -11,43 +15,17 @@ DocTR provides an easy and powerful way to extract valuable information from you
 Welcome to the documentation of `DocTR <https://github.com/mindee/doctr>`_!
 
 
+
 Main Features
 -------------
 
-* |:robot:| Robust 2-stage (detection + recognition) OCR predictors fully trained
+* |:robot:| Robust 2-stage (detection + recognition) OCR predictors with pretrained parameters
 * |:zap:| User-friendly, 3 lines of code to load a document and extract text with a predictor
 * |:rocket:| State-of-the-art performances on public document datasets, comparable with GoogleVision/AWS Textract
 * |:zap:| Optimized for inference speed on both CPU & GPU
 * |:bird:| Light package, small dependencies
 * |:tools:| Daily maintained
 * |:factory:| Easy integration
-
-
-|:scientist:| Build & train your predictor
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* Compose your own end-to-end OCR predictor: mix and match detection & recognition predictors (all-pretrained)
-* Fine-tune or train from scratch any detection or recognition model to specialize on your data
-
-
-|:toolbox:| Implemented models
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Detection models
-""""""""""""""""
-   * DB (Differentiable Binarization), `"Real-time Scene Text Detection with Differentiable Binarization" <https://arxiv.org/pdf/1911.08947.pdf>`_.
-   * LinkNet, `"LinkNet: Exploiting Encoder Representations for Efficient Semantic Segmentation" <https://arxiv.org/pdf/1707.03718.pdf>`_.
-
-Recognition models
-""""""""""""""""""
-   * SAR (Show, Attend and Read), `"Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition" <https://arxiv.org/pdf/1811.00751.pdf>`_.
-   * CRNN (Convolutional Recurrent Neural Network), `"An End-to-End Trainable Neural Network for Image-based Sequence Recognition and Its Application to Scene Text Recognition" <https://arxiv.org/pdf/1507.05717.pdf>`_.
-
-
-|:receipt:| Supported datasets
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   * FUNSD from `"FUNSD: A Dataset for Form Understanding in Noisy Scanned Documents" <https://arxiv.org/pdf/1905.13538.pdf>`_.
-   * CORD from `"CORD: A Consolidated Receipt Dataset forPost-OCR Parsing" <https://openreview.net/pdf?id=SJl3z659UH>`_.
-   * SROIE from `ICDAR 2019 <https://rrc.cvc.uab.es/?ch=13>`_.
 
 
 Getting Started
@@ -57,6 +35,33 @@ Getting Started
    :maxdepth: 2
 
    installing
+
+
+Build & train your predictor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Compose your own end-to-end OCR predictor: mix and match detection & recognition predictors (all-pretrained)
+* Fine-tune or train from scratch any detection or recognition model to specialize on your data
+
+
+Model zoo
+^^^^^^^^^
+
+Text detection models
+"""""""""""""""""""""
+   * `DBNet <https://arxiv.org/pdf/1911.08947.pdf>`_ (Differentiable Binarization)
+   * `LinkNet <https://arxiv.org/pdf/1707.03718.pdf>`_
+
+Text recognition models
+"""""""""""""""""""""""
+   * `SAR <https://arxiv.org/pdf/1811.00751.pdf>`_ (Show, Attend and Read)
+   * `CRNN <https://arxiv.org/pdf/1507.05717.pdf>`_ (Convolutional Recurrent Neural Network)
+
+
+Supported datasets
+^^^^^^^^^^^^^^^^^^
+   * FUNSD from `"FUNSD: A Dataset for Form Understanding in Noisy Scanned Documents" <https://arxiv.org/pdf/1905.13538.pdf>`_.
+   * CORD from `"CORD: A Consolidated Receipt Dataset forPost-OCR Parsing" <https://openreview.net/pdf?id=SJl3z659UH>`_.
+   * SROIE from `ICDAR 2019 <https://rrc.cvc.uab.es/?ch=13>`_.
 
 
 .. toctree::


### PR DESCRIPTION
This PR introduces the following modifications:
- added README illustration in the documentation
- reordered sections
- changed model zoo listing to display only the name of the model (rather than adding the full name of the paper)

Here is how it renders:
![image](https://user-images.githubusercontent.com/76527547/119949950-ad66db00-bf9a-11eb-958f-1790ac8ed844.png)


Any feedback is welcome!