### PR TITLE
refactor: Avoids unnecessary computation in datasets constructors

### DIFF
--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -59,12 +59,12 @@ class CORD(VisionDataset):
                 label = json.load(f)
                 for line in label["valid_line"]:
                     for word in line["words"]:
-                        x = word["quad"]["x1"], word["quad"]["x2"], word["quad"]["x3"], word["quad"]["x4"]
-                        y = word["quad"]["y1"], word["quad"]["y2"], word["quad"]["y3"], word["quad"]["y4"]
-                        # Reduce 8 coords to 4
-                        left, right = min(x), max(x)
-                        top, bot = min(y), max(y)
                         if len(word["text"]) > 0:
+                            x = word["quad"]["x1"], word["quad"]["x2"], word["quad"]["x3"], word["quad"]["x4"]
+                            y = word["quad"]["y1"], word["quad"]["y2"], word["quad"]["y3"], word["quad"]["y4"]
+                            # Reduce 8 coords to 4
+                            left, right = min(x), max(x)
+                            top, bot = min(y), max(y)
                             _targets.append((word["text"], [left, top, right, bot]))
 
             text_targets, box_targets = zip(*_targets)

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -58,11 +58,9 @@ class OCRDataset(AbstractDataset):
             for box in file_dic["coordinates"]:
                 xs, ys = zip(*box)
                 box = [min(xs), min(ys), max(xs), max(ys)]
-                if box[0] < box[2] and box[1] < box[3]:
+                is_valid.append(box[0] < box[2] and box[1] < box[3])
+                if is_valid[-1]:
                     box_targets.append(box)
-                    is_valid.append(True)
-                else:
-                    is_valid.append(False)
 
             text_targets = [word for word, _valid in zip(file_dic["string"], is_valid) if _valid]
             self.data.append((img_name, dict(boxes=np.asarray(box_targets, dtype=np.float32), labels=text_targets)))


### PR DESCRIPTION
To help with the modifications in #281, this PR introduces the following modifications:
- prevents unnecessary computation in the dataset constructor of `CORD`
- cleans up the `OCRDataset` constructor

Any feedback is welcome!