### PR TITLE
feat: add support for page rotation

### DIFF
--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -17,5 +17,5 @@ router = APIRouter()
 async def text_detection(file: UploadFile = File(...)):
     """Runs DocTR text detection model to analyze the input"""
     img = decode_image(file.file.read())
-    boxes, angle = det_predictor([img], training=False)[0]
+    boxes, _ = det_predictor([img], training=False)[0]
     return [DetectionOut(box=box.tolist()) for box in boxes[:, :-1]]

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -17,6 +17,5 @@ router = APIRouter()
 async def text_detection(file: UploadFile = File(...)):
     """Runs DocTR text detection model to analyze the input"""
     img = decode_image(file.file.read())
-    out = det_predictor([img], training=False)
-    print(out)
-    return [DetectionOut(box=box.tolist()) for box in out[0][:, :-1]]
+    [(boxes, angle)] = det_predictor([img], training=False)
+    return [DetectionOut(box=box.tolist()) for box in boxes[:, :-1]]

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -17,5 +17,5 @@ router = APIRouter()
 async def text_detection(file: UploadFile = File(...)):
     """Runs DocTR text detection model to analyze the input"""
     img = decode_image(file.file.read())
-    out, angle = det_predictor([img], training=False)
+    [out, angle] = det_predictor([img], training=False)
     return [DetectionOut(box=box.tolist()) for box in out[0][:, :-1]]

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -17,5 +17,5 @@ router = APIRouter()
 async def text_detection(file: UploadFile = File(...)):
     """Runs DocTR text detection model to analyze the input"""
     img = decode_image(file.file.read())
-    out = det_predictor([img], training=False)
+    out, angle = det_predictor([img], training=False)
     return [DetectionOut(box=box.tolist()) for box in out[0][:, :-1]]

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -17,5 +17,6 @@ router = APIRouter()
 async def text_detection(file: UploadFile = File(...)):
     """Runs DocTR text detection model to analyze the input"""
     img = decode_image(file.file.read())
-    [out, angle] = det_predictor([img], training=False)
+    out = det_predictor([img], training=False)
+    print(out)
     return [DetectionOut(box=box.tolist()) for box in out[0][:, :-1]]

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -17,5 +17,5 @@ router = APIRouter()
 async def text_detection(file: UploadFile = File(...)):
     """Runs DocTR text detection model to analyze the input"""
     img = decode_image(file.file.read())
-    [(boxes, angle)] = det_predictor([img], training=False)
+    boxes, angle = det_predictor([img], training=False)[0]
     return [DetectionOut(box=box.tolist()) for box in boxes[:, :-1]]

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -90,23 +90,31 @@ def extract_rcrops(img: Union[np.ndarray, tf.Tensor], boxes: np.ndarray) -> List
     return crops
 
 
-def rotate_page(image: np.array, angle: float = 0., min_angle: float = 1.) -> np.array:
+def rotate_page(
+    image: Union[tf.Tensor, np.array],
+    angle: float = 0.,
+    min_angle: float = 1.
+) -> Union[tf.Tensor, np.array]:
     """Rotate an image counterclockwise by an ange alpha (negative angle to go clockwise).
 
     Args:
-        image: np array to rotate
+        image: tf tensor or np array to rotate
         angle: rotation angle in degrees, between -90 and +90
         min_angle: min. angle in degrees to rotate a page
 
     Returns:
-        Rotated np array, padded by 0 by default.
+        Rotated array or tf.Tensor, padded by 0 by default.
     """
     if abs(angle) < min_angle or abs(angle) > 90 - min_angle:
         return image
     height, width = image.shape[:2]
     center = (height / 2, width / 2)
     rot_mat = cv2.getRotationMatrix2D(center, angle, 1.0)
-    rotated = cv2.warpAffine(image, rot_mat, (width, height))
+    if isinstance(image, tf.Tensor):
+        rotated = cv2.warpAffine(image.numpy(), rot_mat, (width, height))
+        rotated = tf.cast(rotated, tf.float32)
+    else:
+        rotated = cv2.warpAffine(image, rot_mat, (width, height))
     return rotated
 
 

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -101,7 +101,7 @@ def rotate_page(image: np.array, angle: float = 0., min_angle: float = 1.) -> np
     Returns:
         Rotated np array
     """
-    if angle < min_angle or angle > 90 - min_angle:
+    if abs(angle) < min_angle or abs(angle) > 90 - min_angle:
         return image
     height, width = image.shape[:2]
     center=tuple(np.array([height, width]) / 2)
@@ -139,10 +139,10 @@ def get_bitmap_angle(bitmap: np.array, n_ct: int = 5, std_max: float = 3.) -> fl
         # Edge case with angles of both 0 and 90°, or multi_oriented docs
         angle = 0.
     else:
-        angle = np.mean(angles)
+        angle = -np.mean(angles)
         # Determine rotation direction (clockwise/counterclockwise)
         # Angle coverage: [-90°, +90°], half of the quadrant
         if np.sum(widths) < np.sum(heights):  # CounterClockwise
-            angle = angle - 90
+            angle = 90 + angle
 
     return angle

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -8,7 +8,7 @@ import cv2
 import tensorflow as tf
 from typing import List, Union
 
-__all__ = ['extract_crops', 'extract_rcrops']
+__all__ = ['extract_crops', 'extract_rcrops', 'rotate_page', 'get_bitmap_angle']
 
 
 def extract_crops(img: Union[np.ndarray, tf.Tensor], boxes: np.ndarray) -> List[Union[np.ndarray, tf.Tensor]]:
@@ -88,3 +88,61 @@ def extract_rcrops(img: Union[np.ndarray, tf.Tensor], boxes: np.ndarray) -> List
         crops.append(crop)
 
     return crops
+
+
+def rotate_page(image: np.array, angle: float = 0., min_angle: float = 1.) -> np.array:
+    """Rotate an image counterclockwise by an ange alpha
+
+    Args:
+        alpha: angle, degrees, between -90 and +90
+        image: np array to rotate
+        min_angle: min. angle in degrees to rotate a page
+
+    Returns:
+        Rotated np array
+    """
+    if angle < min_angle or angle > 90 - min_angle:
+        return image
+    height, width = image.shape[:2]
+    center=tuple(np.array([height, width]) / 2)
+    rot_mat = cv2.getRotationMatrix2D(center, angle, 1.0)
+    rotated = cv2.warpAffine(image, rot_mat, (width, height))
+    return rotated
+
+
+def get_bitmap_angle(bitmap: np.array, n_ct: int = 5, std_max: float = 3.) -> float:
+    """From a binarized segmentation map, find contours and fit min area rectangles to determine page angle
+
+    Args:
+        bitmap: binarized segmentation map
+        n_ct: number of contours to use to fit page angle
+        std_max: maximum deviation of the angle distribution to consider the mean angle reliable
+
+    Returns:
+        The angle of the page
+    """
+    # Find all contours on binarized seg map
+    contours, hierarchy = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+    # Sort contours
+    contours = sorted(contours, key = cv2.contourArea, reverse = True)
+
+    # Find largest contours and fit angles
+    # Track heights and widths to find aspect ratio (determine is rotation is clockwise)
+    angles, heights, widths = [], [], []
+    for ct in contours[:n_ct]:
+        _, (w, h), alpha = cv2.minAreaRect(ct)
+        widths.append(w)
+        heights.append(h)
+        angles.append(alpha)
+
+    if np.std(angles) > std_max:
+        # Edge case with angles of both 0 and 90°, or multi_oriented docs
+        angle = 0.
+    else:
+        angle = np.mean(angles)
+        # Determine rotation direction (clockwise/counterclockwise)
+        # Angle coverage: [-90°, +90°], half of the quadrant
+        if np.sum(widths) < np.sum(heights):  # CounterClockwise
+            angle = angle - 90
+
+    return angle

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -118,7 +118,7 @@ def rotate_page(
     return rotated
 
 
-def get_bitmap_angle(bitmap: np.array, n_ct: int = 5, std_max: float = 3.) -> float:
+def get_bitmap_angle(bitmap: np.array, n_ct: int = 20, std_max: float = 3.) -> float:
     """From a binarized segmentation map, find contours and fit min area rectangles to determine page angle
 
     Args:

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -104,7 +104,7 @@ def rotate_page(image: np.array, angle: float = 0., min_angle: float = 1.) -> np
     if abs(angle) < min_angle or abs(angle) > 90 - min_angle:
         return image
     height, width = image.shape[:2]
-    center=tuple(np.array([height, width]) / 2)
+    center = tuple(np.array([height, width]) / 2)
     rot_mat = cv2.getRotationMatrix2D(center, angle, 1.0)
     rotated = cv2.warpAffine(image, rot_mat, (width, height))
     return rotated
@@ -124,7 +124,7 @@ def get_bitmap_angle(bitmap: np.array, n_ct: int = 5, std_max: float = 3.) -> fl
     # Find all contours on binarized seg map
     contours, hierarchy = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
     # Sort contours
-    contours = sorted(contours, key = cv2.contourArea, reverse = True)
+    contours = sorted(contours, key=cv2.contourArea, reverse=True)
 
     # Find largest contours and fit angles
     # Track heights and widths to find aspect ratio (determine is rotation is clockwise)

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -91,8 +91,7 @@ def extract_rcrops(img: Union[np.ndarray, tf.Tensor], boxes: np.ndarray) -> List
 
 
 def rotate_page(image: np.array, angle: float = 0., min_angle: float = 1.) -> np.array:
-    """Rotate an image counterclockwise by an ange alpha (negative angle to go clockwise)
-    It will pad with 0 by default aroud the image to perform rotation.
+    """Rotate an image counterclockwise by an ange alpha (negative angle to go clockwise).
 
     Args:
         image: np array to rotate
@@ -100,7 +99,7 @@ def rotate_page(image: np.array, angle: float = 0., min_angle: float = 1.) -> np
         min_angle: min. angle in degrees to rotate a page
 
     Returns:
-        Rotated np array
+        Rotated np array, padded by 0 by default.
     """
     if abs(angle) < min_angle or abs(angle) > 90 - min_angle:
         return image
@@ -123,7 +122,7 @@ def get_bitmap_angle(bitmap: np.array, n_ct: int = 5, std_max: float = 3.) -> fl
         The angle of the page
     """
     # Find all contours on binarized seg map
-    contours, hierarchy = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+    contours, _ = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
     # Sort contours
     contours = sorted(contours, key=cv2.contourArea, reverse=True)
 

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -91,11 +91,12 @@ def extract_rcrops(img: Union[np.ndarray, tf.Tensor], boxes: np.ndarray) -> List
 
 
 def rotate_page(image: np.array, angle: float = 0., min_angle: float = 1.) -> np.array:
-    """Rotate an image counterclockwise by an ange alpha
+    """Rotate an image counterclockwise by an ange alpha (negative angle to go clockwise)
+    It will pad with 0 by default aroud the image to perform rotation.
 
     Args:
-        alpha: angle, degrees, between -90 and +90
         image: np array to rotate
+        angle: rotation angle in degrees, between -90 and +90
         min_angle: min. angle in degrees to rotate a page
 
     Returns:
@@ -104,7 +105,7 @@ def rotate_page(image: np.array, angle: float = 0., min_angle: float = 1.) -> np
     if abs(angle) < min_angle or abs(angle) > 90 - min_angle:
         return image
     height, width = image.shape[:2]
-    center = tuple(np.array([height, width]) / 2)
+    center = (height / 2, width / 2)
     rot_mat = cv2.getRotationMatrix2D(center, angle, 1.0)
     rotated = cv2.warpAffine(image, rot_mat, (width, height))
     return rotated

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -58,9 +58,8 @@ class OCRPredictor(NestedObject):
         word_preds = self.reco_predictor(crops, **kwargs)
 
         # Reorganize
-        boxes = [_boxes for (_boxes, angle) in boxes]
+        boxes, _ = zip(*boxes)
         out = self.doc_builder(boxes, word_preds, [tuple(page.shape[:2]) for page in pages])
-
         return out
 
 

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -9,7 +9,7 @@ from scipy.cluster.hierarchy import fclusterdata
 from typing import List, Any, Tuple
 from .detection import DetectionPredictor
 from .recognition import RecognitionPredictor
-from ._utils import extract_crops, extract_rcrops
+from ._utils import extract_crops, extract_rcrops, rotate_page
 from doctr.documents.elements import Word, Line, Block, Page, Document
 from doctr.utils.repr import NestedObject
 from doctr.utils.geometry import resolve_enclosing_bbox, resolve_enclosing_rbbox
@@ -51,12 +51,14 @@ class OCRPredictor(NestedObject):
 
         # Localize text elements
         boxes = self.det_predictor(pages, **kwargs)
-        # Crop images
-        crops = [crop for page, _boxes in zip(pages, boxes) for crop in self.extract_crops_fn(page, _boxes[:, :-1])]
+        # Crop images, rotate page if necessary
+        crops = [crop for page, (_boxes, angle) in zip(pages, boxes) for crop in
+                 self.extract_crops_fn(rotate_page(page, -angle), _boxes[:, :-1])]
         # Identify character sequences
         word_preds = self.reco_predictor(crops, **kwargs)
 
         # Reorganize
+        boxes = [_boxes for (_boxes, angle) in boxes]
         out = self.doc_builder(boxes, word_preds, [tuple(page.shape[:2]) for page in pages])
 
         return out

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -3,14 +3,17 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
+from tensorflow.python.keras.regularizers import get
+from qrco import rotate_bitmap
 from numpy.core.defchararray import startswith
 import tensorflow as tf
 from tensorflow import keras
 import numpy as np
 import cv2
-from typing import List, Any, Optional, Dict
+from typing import List, Any, Optional, Dict, Tuple
 from ..preprocessor import PreProcessor
 from doctr.utils.repr import NestedObject
+from doctr.models._utils import rotate_page, get_bitmap_angle
 
 
 __all__ = ['DetectionModel', 'DetectionPostProcessor', 'DetectionPredictor']
@@ -120,8 +123,11 @@ class DetectionPostProcessor(NestedObject):
         for p_, bitmap_ in zip(proba_map, bitmap):
             p_ = p_.numpy()
             bitmap_ = bitmap_.numpy()
-            # perform opening (erosion + dilatation)
+            # Perform opening (erosion + dilatation)
             bitmap_ = cv2.morphologyEx(bitmap_, cv2.MORPH_OPEN, kernel)
+            # Rotate bitmap and proba_map
+            angle = get_bitmap_angle(bitmap_)
+            bitmap_, p_ = rotate_page(bitmap_, angle), rotate_page(p_, angle)
             boxes = self.bitmap_to_boxes(pred=p_, bitmap=bitmap_)
             boxes_batch.append(boxes)
 

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -3,14 +3,11 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-from tensorflow.python.keras.regularizers import get
-from qrco import rotate_bitmap
-from numpy.core.defchararray import startswith
 import tensorflow as tf
 from tensorflow import keras
 import numpy as np
 import cv2
-from typing import List, Any, Optional, Dict, Tuple
+from typing import List, Any, Optional, Dict
 from ..preprocessor import PreProcessor
 from doctr.utils.repr import NestedObject
 from doctr.models._utils import rotate_page, get_bitmap_angle

--- a/doctr/models/detection/core.py
+++ b/doctr/models/detection/core.py
@@ -163,7 +163,5 @@ class DetectionPredictor(NestedObject):
             raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")
 
         processed_batches = self.pre_processor(pages)
-        out = [self.model(batch, return_boxes=True, **kwargs)['boxes + angles'] for batch in processed_batches]
-        out = [(boxes, angle) for (batch_boxes, batch_angles) in out for boxes, angle in zip(batch_boxes, batch_angles)]
-
-        return out
+        predicted_batches = [self.model(batch, return_boxes=True, **kwargs)['preds'] for batch in processed_batches]
+        return [pred for batch in predicted_batches for pred in zip(*batch)]

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -525,7 +525,7 @@ class DBNet(DetectionModel, NestedObject):
 
         if target is None or return_boxes:
             # Post-process boxes
-            out["boxes + angles"] = self.postprocessor(prob_map)
+            out["preds"] = self.postprocessor(prob_map)
 
         if target is not None:
             thresh_map = self.threshold_head(feat_concat, **kwargs)

--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -525,7 +525,7 @@ class DBNet(DetectionModel, NestedObject):
 
         if target is None or return_boxes:
             # Post-process boxes
-            out["boxes"] = self.postprocessor(prob_map)
+            out["boxes + angles"] = self.postprocessor(prob_map)
 
         if target is not None:
             thresh_map = self.threshold_head(feat_concat, **kwargs)

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -313,7 +313,7 @@ class LinkNet(DetectionModel, NestedObject):
 
         if target is None or return_boxes:
             # Post-process boxes
-            out["boxes + angles"] = self.postprocessor(prob_map)
+            out["preds"] = self.postprocessor(prob_map)
 
         if target is not None:
             loss = self.compute_loss(logits, target)

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -314,7 +314,7 @@ class LinkNet(DetectionModel, NestedObject):
 
         if target is None or return_boxes:
             # Post-process boxes
-            out["boxes"] = self.postprocessor(prob_map)
+            out["boxes + angles"] = self.postprocessor(prob_map)
 
         if target is not None:
             loss = self.compute_loss(logits, target)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,4 +1,3 @@
-from qrco import rotate_page
 import pytest
 import math
 import numpy as np
@@ -239,5 +238,5 @@ def test_get_bitmap_angle(mock_bitmap):
     assert abs(angle - 30.) < 1e-2
 
 def test_rotate_page(mock_bitmap):
-    rotated = models.rotate_page(mock_bitmap, 30.)
+    rotated = models.rotate_page(mock_bitmap, -30.)
     assert abs(models.get_bitmap_angle(rotated) - 0.) < 1e-2

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -222,6 +222,7 @@ def test_preprocessor(mock_pdf):
     # Image size
     assert all(batch.shape[1:] == (256, 128, 3) for batch in batched_docs)
 
+
 @pytest.fixture(scope="function")
 def mock_bitmap(tmpdir_factory):
     url = 'https://github.com/mindee/doctr/releases/download/v0.2.1/bitmap30.png'
@@ -233,10 +234,12 @@ def mock_bitmap(tmpdir_factory):
     bitmap = np.squeeze(cv2.cvtColor(bitmap, cv2.COLOR_BGR2GRAY) / 255.)
     return bitmap
 
+
 def test_get_bitmap_angle(mock_bitmap):
     angle = models.get_bitmap_angle(mock_bitmap)
-    assert abs(angle - 30.) < 1e-2
+    assert abs(angle - 30.) < 1.
+
 
 def test_rotate_page(mock_bitmap):
     rotated = models.rotate_page(mock_bitmap, -30.)
-    assert abs(models.get_bitmap_angle(rotated) - 0.) < 1e-2
+    assert abs(models.get_bitmap_angle(rotated) - 0.) < 1.

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -11,8 +11,8 @@ def test_dbpostprocessor():
     postprocessor = detection.DBPostProcessor(rotated_bbox=False)
     r_postprocessor = detection.DBPostProcessor(rotated_bbox=True)
     mock_batch = tf.random.uniform(shape=[2, 512, 512, 1], minval=0, maxval=1)
-    out = postprocessor(mock_batch)[0]
-    r_out = r_postprocessor(mock_batch)[0]
+    out, _ = postprocessor(mock_batch)
+    r_out, _ = r_postprocessor(mock_batch)
     # Batch composition
     assert isinstance(out, list)
     assert len(out) == 2
@@ -83,7 +83,7 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     if out_prob:
         assert np.all(np.logical_and(seg_map >= 0, seg_map <= 1))
     # Check boxes
-    for boxes in out['boxes + angles'][0]:
+    for boxes in out['preds'][0]:
         assert boxes.shape[1] == 5
         assert np.all(boxes[:, :2] < boxes[:, 2:4])
         assert np.all(boxes[:, :4] >= 0) and np.all(boxes[:, :4] <= 1)
@@ -102,7 +102,7 @@ def test_detectionpredictor(mock_pdf):  # noqa: F811
 
     pages = DocumentFile.from_pdf(mock_pdf).as_images()
     out = predictor(pages)
-    out = [_boxes for _boxes, _ in out]
+    out, _ = zip(*out)
     # The input PDF has 8 pages
     assert len(out) == 8
 
@@ -151,8 +151,9 @@ def test_detection_zoo(arch_name):
     assert isinstance(predictor, detection.DetectionPredictor)
     input_tensor = tf.random.uniform(shape=[2, 1024, 1024, 3], minval=0, maxval=1)
     out = predictor(input_tensor)
-    out = [boxes for boxes, _ in out]
-    assert all(isinstance(boxes, np.ndarray) and boxes.shape[1] == 5 for boxes in out)
+    assert all(isinstance(out_img, tuple) for out_img in out)
+    all_boxes, _ = zip(*out)
+    assert all(isinstance(boxes, np.ndarray) and boxes.shape[1] == 5 for boxes in all_boxes)
 
 
 def test_detection_zoo_error():
@@ -164,9 +165,10 @@ def test_linknet_postprocessor():
     postprocessor = detection.LinkNetPostProcessor()
     r_postprocessor = detection.LinkNetPostProcessor(rotated_bbox=True)
     mock_batch = tf.random.uniform(shape=[2, 512, 512, 1], minval=0, maxval=1)
-    out = postprocessor(mock_batch)[0]
-    r_out = r_postprocessor(mock_batch)[0]
+    out, _ = postprocessor(mock_batch)
+    r_out, _ = r_postprocessor(mock_batch)
     # Batch composition
+    assert isinstance(out, list)
     assert len(out) == 2
     assert all(isinstance(sample, np.ndarray) for sample in out)
     assert all(sample.shape[1] == 5 for sample in out)


### PR DESCRIPTION
This PR introduces 2 fonctions in models._utils.py:
`rotate_page` and `get_bitmap_angle`
These 2 fonctions are used to find the bitmap orientation after segmentation task (in detection postprocessor), and to rotate back the segmentation map to fit straight Bboxes. Angles are passed in the OCRPredictor to similarly rotate the source page, to extract straight crops for the recognition task.

The only remaining part is to add a function to obtain to the (rotated) boxes coordinates in the original image, to return to the user the "original" boxes and to be able to draw polygons on the original (rotated) image.

Any feedback is welcome!