### PR TITLE
feat: add edge mask in linknet compute_target

### DIFF
--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -280,7 +280,7 @@ class LinkNet(DetectionModel, NestedObject):
         self,
         out_map: tf.Tensor,
         target: List[Dict[str, Any]],
-        factor: int = 2
+        factor: float = 2.
     ) -> tf.Tensor:
         """Compute a batch of gts and masks from a list of boxes and a list of masks for each image
         Then, it computes the loss function with proba_map, gts and masks


### PR DESCRIPTION
This PR adds an edge_mask in linknet compute_target and compute_loss to enhance spatial resolution of boxes. 
It will add more weight to the edges of boxes, and thus help the model to easily separate words.

Any feedback is welcome!