### PR TITLE
feat: add rotate_boxes in model._utils

### DIFF
--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -5,10 +5,8 @@
 
 import numpy as np
 import cv2
-from numpy.ma.core import concatenate
 import tensorflow as tf
-from typing import List, Union, Tuple
-from ..utils.geometry import bbox_to_polygon, fit_rbbox
+from typing import List, Union
 
 __all__ = ['extract_crops', 'extract_rcrops', 'rotate_page', 'get_bitmap_angle', 'rotate_boxes']
 

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -181,11 +181,12 @@ def rotate_boxes(
     angle_rad = angle * np.pi / 180.  # compute radian angle for np functions
     rotation_mat = np.array([[np.cos(angle_rad), -np.sin(angle_rad)], [np.sin(angle_rad), np.cos(angle_rad)]])
     # Compute unrotated boxes
-    x_unrotated, y_unrotated = (boxes[:, 0, None] + boxes[:, 2, None]) / 2, (boxes[:, 1, None] + boxes[:, 3, None]) / 2
-    width, height = boxes[:, 2, None] - boxes[:, 0, None], boxes[:, 3, None] - boxes[:, 1, None]
+    x_unrotated, y_unrotated = (boxes[:, 0] + boxes[:, 2]) / 2, (boxes[:, 1] + boxes[:, 3]) / 2
+    width, height = boxes[:, 2] - boxes[:, 0], boxes[:, 3] - boxes[:, 1]
     # Rotate centers
-    centers = np.concatenate((x_unrotated, y_unrotated), axis=-1)
+    centers = np.stack((x_unrotated, y_unrotated), axis=-1)
     rotated_centers = .5 + np.matmul(centers - .5, np.transpose(rotation_mat))
+    x_center, y_center = rotated_centers[:, 0], rotated_centers[:, 1]
     # Compute rotated boxes
-    rotated_boxes = np.concatenate((rotated_centers, width, height, angle * np.ones_like(boxes[:, 0, None])), axis=-1)
+    rotated_boxes = np.stack((x_center, y_center, width, height, angle * np.ones_like(boxes[:, 0])), axis=1)
     return rotated_boxes

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -9,7 +9,7 @@ from scipy.cluster.hierarchy import fclusterdata
 from typing import List, Any, Tuple
 from .detection import DetectionPredictor
 from .recognition import RecognitionPredictor
-from ._utils import extract_crops, extract_rcrops, rotate_page
+from ._utils import extract_crops, extract_rcrops, rotate_page, rotate_boxes
 from doctr.documents.elements import Word, Line, Block, Page, Document
 from doctr.utils.repr import NestedObject
 from doctr.utils.geometry import resolve_enclosing_bbox, resolve_enclosing_rbbox
@@ -57,8 +57,9 @@ class OCRPredictor(NestedObject):
         # Identify character sequences
         word_preds = self.reco_predictor(crops, **kwargs)
 
-        # Reorganize
-        boxes, _ = zip(*boxes)
+        # Rotate back boxes if necessary
+        boxes, angles = zip(*boxes)
+        boxes = [rotate_boxes(boxes_page, angle) for boxes_page, angle in zip(boxes, angles)]
         out = self.doc_builder(boxes, word_preds, [tuple(page.shape[:2]) for page in pages])
         return out
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -256,4 +256,4 @@ def test_rotate_boxes():
     # Angle = 30
     rotated = models.rotate_boxes(boxes, angle=30)
     assert rotated.shape == (1, 5)
-    print(rotated)
+    assert rotated[0, 4] == 30.

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -243,3 +243,17 @@ def test_get_bitmap_angle(mock_bitmap):
 def test_rotate_page(mock_bitmap):
     rotated = models.rotate_page(mock_bitmap, -30.)
     assert abs(models.get_bitmap_angle(rotated) - 0.) < 1.
+
+
+def test_rotate_boxes():
+    boxes = np.array([[0.1, 0.1, 0.8, 0.3]])
+    # Angle = 0
+    rotated = models.rotate_boxes(boxes, angle=0.)
+    assert rotated.all() == boxes.all()
+    # Angle < 1:
+    rotated = models.rotate_boxes(boxes, angle=0.5)
+    assert rotated.all() == boxes.all()
+    # Angle = 30
+    rotated = models.rotate_boxes(boxes, angle=30)
+    assert rotated.shape == (1, 5)
+    print(rotated)


### PR DESCRIPTION
This PR adds a rotate_boxes function to rotate predicted straight bounding boxes when the original document is rotated.
This function is called in the OCRPredictor to compute boxes corresponding to the original document, although we forwarded the model with a rectified (straight) version of the document.

This is an example of a rotated bitmap (black and white), with predicted straight bounding boxes in cyan and rectified bounding boxes (OCR predictions) in yellow:

![bitmapro](https://user-images.githubusercontent.com/70526046/121030560-df055080-c7a9-11eb-8b19-a3a1a55cf145.png)

Any feedback is welcome!