### PR TITLE
feat: add MASTER in models.recognition module

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Credits where it's due: this repository is implementing, among others, architect
 ### Text Recognition
 - [An End-to-End Trainable Neural Network for Image-based Sequence Recognition and Its Application to Scene Text Recognition](https://arxiv.org/pdf/1507.05717.pdf).
 - [Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition](https://arxiv.org/pdf/1811.00751.pdf).
+- [MASTER: Multi-Aspect Non-local Network for Scene Text Recognition](https://arxiv.org/pdf/1910.02562.pdf).
 
 
 ## More goodies

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,7 @@ Text recognition models
 """""""""""""""""""""""
    * `SAR <https://arxiv.org/pdf/1811.00751.pdf>`_ (Show, Attend and Read)
    * `CRNN <https://arxiv.org/pdf/1507.05717.pdf>`_ (Convolutional Recurrent Neural Network)
+   * `MASTER <https://arxiv.org/pdf/1910.02562.pdf>`_ (Multi-Aspect Non-local Network for Scene Text Recognition)
 
 
 Supported datasets

--- a/doctr/models/recognition/__init__.py
+++ b/doctr/models/recognition/__init__.py
@@ -2,3 +2,5 @@ from .core import *
 from .crnn import *
 from .sar import *
 from .zoo import *
+from .transformer import *
+from .master import *

--- a/doctr/models/recognition/master.py
+++ b/doctr/models/recognition/master.py
@@ -16,6 +16,7 @@ __all__ = ['MASTER']
 
 
 class MAGC(layers.Layer):
+
     """Implements the Multi-Aspect Global Context Attention, as described in
     <https://arxiv.org/pdf/1910.02562.pdf>`_.
 
@@ -112,6 +113,7 @@ class MAGC(layers.Layer):
 
 
 class MAGCResnet(Sequential):
+
     """Implements the modified resnet with MAGC layers, as described in paper.
 
     Args:
@@ -152,6 +154,7 @@ class MAGCResnet(Sequential):
 
 
 class MASTER(RecognitionModel):
+
     """Implements MASTER as described in paper: <https://arxiv.org/pdf/1910.02562.pdf>`_.
     Implementation based on the official TF implementation: <https://github.com/jiangxiluning/MASTER-TF>`_.
 

--- a/doctr/models/recognition/master.py
+++ b/doctr/models/recognition/master.py
@@ -1,0 +1,253 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import tensorflow as tf
+from tensorflow.keras import layers
+from typing import Tuple, List
+
+from .core import RecognitionModel
+from ..backbones.resnet import ResnetStage
+from ..utils import conv_sequence
+from .transformer import Decoder, positional_encoding, create_look_ahead_mask, create_padding_mask
+
+__all__ = ['MASTER']
+
+
+class MAGC(layers.Layer):
+    """Implements the Multi-Aspect Global Context Attention, as described in
+    <https://arxiv.org/pdf/1910.02562.pdf>`_.
+
+    Args:
+        inplanes: input channels
+        headers: number of headers to split channels
+        att_scale: if True, re-scale attention to counteract the variance distibutions
+        **kwargs
+    """
+
+    def __init__(
+        self,
+        inplanes: int,
+        headers: int = 1,
+        att_scale: bool = False,
+        **kwargs
+    ) -> None:
+        super().__init__(name='MAGC', **kwargs)
+
+        self.headers = headers  # h
+        self.inplanes = inplanes  # C
+        self.att_scale = att_scale
+
+        self.single_header_inplanes = int(inplanes / headers)  # C / h
+
+        self.conv_mask = tf.keras.layers.Conv2D(
+            filters=1,
+            kernel_size=1,
+            kernel_initializer=tf.initializers.he_normal()
+        )
+
+        self.transform = tf.keras.Sequential(
+            [
+                tf.keras.layers.Conv2D(
+                    filters=self.inplanes,
+                    kernel_size=1,
+                    kernel_initializer=tf.initializers.he_normal()
+                ),
+                tf.keras.layers.LayerNormalization([1, 2, 3]),
+                tf.keras.layers.ReLU(),
+                tf.keras.layers.Conv2D(
+                    filters=self.inplanes,
+                    kernel_size=1,
+                    kernel_initializer=tf.initializers.he_normal()
+                ),
+            ],
+            name='transform'
+        )
+
+    @tf.function
+    def context_modeling(self, inputs: tf.Tensor) -> tf.Tensor:
+        B, H, W, C = tf.shape(inputs)
+
+        # B, H, W, h, C/h
+        x = tf.reshape(inputs, shape=(B, H, W, self.headers, self.single_header_inplanes))
+        # B, h, H, W, C/h
+        x = tf.transpose(x, perm=(0, 3, 1, 2, 4))
+        # B*h, H, W, C/h
+        x = tf.reshape(x, shape=(B * self.headers, H, W, self.single_header_inplanes))
+        input_x = x
+        # B*h, 1, H*W, C/h
+        input_x = tf.reshape(input_x, shape=(B * self.headers, 1, H * W, self.single_header_inplanes))
+        # B*h, 1, C/h, H*W
+        input_x = tf.transpose(input_x, perm=[0, 1, 3, 2])
+        # B*h, H, W, 1,
+        context_mask = self.conv_mask(x)
+        # B*h, 1, H*W, 1
+        context_mask = tf.reshape(context_mask, shape=(B * self.headers, 1, H * W, 1))
+        # scale variance
+        if self.att_scale and self.headers > 1:
+            context_mask = context_mask / tf.sqrt(self.single_header_inplanes)
+        # B*h, 1, H*W, 1
+        context_mask = tf.keras.activations.softmax(context_mask, axis=2)
+        # B*h, 1, C/h, 1
+        context = tf.matmul(input_x, context_mask)
+        context = tf.reshape(context, shape=(B, 1, C, 1))
+        # B, 1, 1, C
+        context = tf.transpose(context, perm=(0, 1, 3, 2))
+        return context
+
+    def call(self, inputs: tf.Tensor, **kwargs) -> tf.Tensor:
+        # Context modeling: B, H, W, C  ->  B, 1, 1, C
+        context = self.context_modeling(inputs)
+
+        # Transform: B, 1, 1, C  ->  B, 1, 1, C
+        transformed = self.transform(context)
+        return inputs + transformed
+
+
+class MAGCResnet(layers.Sequential):
+
+    def __init__(
+        self,
+        headers: int = 1,
+        input_shape: Tuple[int, int, int] = (48, 160, 3),
+    ) -> None:
+        _layers = [
+            # conv_1x
+            conv_sequence(out_channels=64, activation='relu', bn=True, kernel_size=3, input_shape=input_shape),
+            conv_sequence(out_channels=128, activation='relu', bn=True, kernel_size=3),
+            layers.MaxPooling2D((2, 2), (2, 2)),
+            # conv_2x
+            ResnetStage(num_blocks=1, output_channels=256),
+            MAGC(inplanes=256, headers=headers, att_scale=True),
+            conv_sequence(out_channels=256, activation='relu', bn=True, kernel_size=3),
+            layers.MaxPooling2D((2, 2), (2, 2)),
+            # conv_3x
+            ResnetStage(num_blocks=2, output_channels=512),
+            MAGC(inplanes=512, headers=headers, att_scale=True),
+            conv_sequence(out_channels=512, activation='relu', bn=True, kernel_size=3),
+            layers.MaxPooling2D((2, 1), (2, 1)),
+            # conv_4x
+            ResnetStage(num_blocks=5, output_channels=512),
+            MAGC(inplanes=512, headers=headers, att_scale=True),
+            conv_sequence(out_channels=512, activation='relu', bn=True, kernel_size=3),
+            # conv_5x
+            ResnetStage(num_blocks=3, output_channels=512),
+            MAGC(inplanes=512, headers=headers, att_scale=True),
+            conv_sequence(out_channels=512, activation='relu', bn=True, kernel_size=3),
+        ]
+        super().__init__(_layers)
+
+
+class MASTER(RecognitionModel):
+    """Implements MASTER as described in paper: <https://arxiv.org/pdf/1910.02562.pdf>`_.
+    Implementation based on the official TF implementation: <https://github.com/jiangxiluning/MASTER-TF>`_.
+
+    Args:
+        vocab_size: size of the vocabulary, (without EOS, SOS, PAD)
+        d_model: d parameter for the transformer decoder
+        headers: headers for the MAGC module
+        dff: depth of the pointwise feed-forward layer
+        num_layers: number of decoder layers to stack
+        max_length: maximum length of character sequence handled by the model
+        input_shape: size of the image inputs
+
+    """
+    def __init__(
+        self,
+        vocab_size: int,
+        d_model: int,
+        headers: int,
+        dff: int,
+        num_layers: int = 3,
+        max_length: int = 50,
+        input_shape: tuple = (48, 160, 3),
+    ) -> None:
+        super(MASTER, self).__init__(name='Master')
+
+        self.input_shape = input_shape
+        self.max_length = max_length
+        self.vocab_size = vocab_size
+
+        self.feature_extractor = MAGCResnet(headers=headers, input_shape=input_shape)
+        self.seq_embedding = layers.Embedding(vocab_size, d_model)
+
+        self.decoder = Decoder(
+            num_layers=num_layers,
+            d_model=d_model,
+            num_heads=headers,
+            dff=dff,
+            target_vocab_size=vocab_size,
+            maximum_position_encoding=max_length,
+        )
+        self.feature_pe = positional_encoding(input_shape[0] * input_shape[1], d_model)
+        self.linear = layers.Dense(vocab_size, kernel_initializer=tf.initializers.he_uniform())
+
+    @tf.function
+    def make_mask(self, target: List[int]) -> tf.Tensor:
+        look_ahead_mask = create_look_ahead_mask(tf.shape(target)[1])
+        target_padding_mask = create_padding_mask(target, self.vocab_size + 2)  # TODO: define padding symbol in fn
+        combined_mask = tf.maximum(target_padding_mask, look_ahead_mask)
+        return combined_mask
+
+    def call(self, inputs: tf.Tensor, **kwargs) -> tf.Tensor:
+        image: tf.Tensor = inputs[0]
+        transcript: tf.Tensor = inputs[1]
+
+        feature = self.feature_extractor(image, **kwargs)
+
+        B, H, W, C = tf.shape(feature)
+
+        feature = tf.reshape(feature, shape=(B, H * W, C))
+        memory = feature + self.feature_pe[:, :H * W, :]
+
+        tgt_mask = self.make_mask(transcript[:, :-1])
+
+        output, _ = self.decoder(transcript, memory, tgt_mask, None, training=True)
+        logits = self.linear(output)
+
+        return logits
+
+    @tf.function
+    def decode(
+        self,
+        image: tf.Tensor,
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
+
+        feature = self.feature_extractor(image, training=False)
+        B, H, W, C = tf.shape(feature)
+
+        feature = tf.reshape(feature, shape=(B, H * W, C))
+        memory = feature + self.feature_pe[:, :H * W, :]
+
+        max_len = tf.constant(self.max_length, dtype=tf.int32)
+        start_symbol = tf.constant(self.vocab_size + 1, dtype=tf.int32)  # SOS (EOS = vocab_size)
+        padding_symbol = tf.constant(self.vocab_size + 2, dtype=tf.int32)  # PAD
+
+        ys = tf.fill(dims=(B, max_len - 1), value=padding_symbol)
+        start_vector = tf.fill(dims=(B, 1), value=start_symbol)
+        ys = tf.concat([start_vector, ys], axis=-1)
+
+        final_logits = tf.zeros(shape=(B, max_len - 1, self.vocab_size), dtype=tf.float32)
+        # max_len = len + 2
+        for i in range(max_len - 1):
+            tf.autograph.experimental.set_loop_options(
+                shape_invariants=[(final_logits, tf.TensorShape([None, None, self.vocab_size]))]
+            )
+            ys_mask = self.make_mask(ys)
+            #output, _ = self.decoder(ys, memory, False, ys_mask, None)
+            output = self.decoder(self.seq_embedding(ys), memory, None, ys_mask, training=False)
+            logits = self.linear(output)
+            prob = tf.nn.softmax(logits, axis=-1)
+            next_word = tf.argmax(prob, axis=-1, output_type=ys.dtype)
+
+            # ys.shape = B, T
+            i_mesh, j_mesh = tf.meshgrid(tf.range(B), tf.range(max_len), indexing='ij')
+            indices = tf.stack([i_mesh[:, i + 1], j_mesh[:, i + 1]], axis=1)
+
+            ys = tf.tensor_scatter_nd_update(ys, indices, next_word[:, i + 1])
+
+            if i == (max_len - 2):
+                final_logits = logits
+
+        return ys, final_logits[:, 1:]

--- a/doctr/models/recognition/transformer.py
+++ b/doctr/models/recognition/transformer.py
@@ -37,7 +37,7 @@ def positional_encoding(position: int, d_model: int = 512) -> tf.Tensor:
     Args:
         position: Number of positions to encode
         d_model: depth of the encoding
-    
+
     Returns:
         2D positional encoding as described in Transformer paper.
     """

--- a/doctr/models/recognition/transformer.py
+++ b/doctr/models/recognition/transformer.py
@@ -1,0 +1,209 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+# This module 'transformer.py' is 100% inspired from this Tensorflow tutorial:
+# https://www.tensorflow.org/text/tutorials/transformer
+
+
+from typing import *
+
+import tensorflow as tf
+import numpy as np
+
+
+__all__ = ['Decoder', 'positional_encoding', 'create_look_ahead_mask', 'create_padding_mask']
+
+
+def get_angles(pos, i, d_model):
+    angle_rates = 1 / np.power(10000, (2 * (i // 2)) / np.float32(d_model))
+    return pos * angle_rates
+
+
+def positional_encoding(position, d_model):
+    angle_rads = get_angles(
+        np.arange(position)[:, np.newaxis],
+        np.arange(d_model)[np.newaxis, :],
+        d_model,
+    )
+    # apply sin to even indices in the array; 2i
+    angle_rads[:, 0::2] = np.sin(angle_rads[:, 0::2])
+    # apply cos to odd indices in the array; 2i+1
+    angle_rads[:, 1::2] = np.cos(angle_rads[:, 1::2])
+    pos_encoding = angle_rads[np.newaxis, ...]
+    return tf.cast(pos_encoding, dtype=tf.float32)
+
+
+@tf.function
+def create_padding_mask(seq):
+    seq = tf.cast(tf.math.equal(seq, 0), tf.float32)
+    # add extra dimensions to add the padding
+    # to the attention logits.
+    return seq[:, tf.newaxis, tf.newaxis, :]  # (batch_size, 1, 1, seq_len)
+
+
+@tf.function
+def create_look_ahead_mask(size):
+    mask = 1 - tf.linalg.band_part(tf.ones((size, size)), -1, 0)
+    return mask  # (seq_len, seq_len)
+
+
+@tf.function
+def scaled_dot_product_attention(q, k, v, mask):
+    """Calculate the attention weights.
+    q, k, v must have matching leading dimensions.
+    k, v must have matching penultimate dimension, i.e.: seq_len_k = seq_len_v.
+    The mask has different shapes depending on its type(padding or look ahead)
+    but it must be broadcastable for addition.
+    Args:
+        q: query shape == (..., seq_len_q, depth)
+        k: key shape == (..., seq_len_k, depth)
+        v: value shape == (..., seq_len_v, depth_v)
+        mask: Float tensor with shape broadcastable to (..., seq_len_q, seq_len_k). Defaults to None.
+    Returns:
+        output, attention_weights
+    """
+
+    matmul_qk = tf.matmul(q, k, transpose_b=True)  # (..., seq_len_q, seq_len_k)
+    # scale matmul_qk
+    dk = tf.cast(tf.shape(k)[-1], tf.float32)
+    scaled_attention_logits = matmul_qk / tf.math.sqrt(dk)
+    # add the mask to the scaled tensor.
+    if mask is not None:
+        scaled_attention_logits += (mask * -1e9)
+    # softmax is normalized on the last axis (seq_len_k) so that the scores
+    # add up to 1.
+    attention_weights = tf.nn.softmax(scaled_attention_logits, axis=-1)  # (..., seq_len_q, seq_len_k)
+    output = tf.matmul(attention_weights, v)  # (..., seq_len_q, depth_v)
+    return output, attention_weights
+
+
+class MultiHeadAttention(tf.keras.layers.Layer):
+
+    def __init__(self, d_model, num_heads):
+        super(MultiHeadAttention, self).__init__()
+        self.num_heads = num_heads
+        self.d_model = d_model
+
+        assert d_model % self.num_heads == 0
+
+        self.depth = d_model // self.num_heads
+
+        self.wq = tf.keras.layers.Dense(d_model, kernel_initializer=tf.initializers.he_uniform())
+        self.wk = tf.keras.layers.Dense(d_model, kernel_initializer=tf.initializers.he_uniform())
+        self.wv = tf.keras.layers.Dense(d_model, kernel_initializer=tf.initializers.he_uniform())
+
+        self.dense = tf.keras.layers.Dense(d_model, kernel_initializer=tf.initializers.he_uniform())
+
+    def split_heads(self, x, batch_size):
+        """Split the last dimension into (num_heads, depth).
+        Transpose the result such that the shape is (batch_size, num_heads, seq_len, depth)
+        """
+        x = tf.reshape(x, (batch_size, -1, self.num_heads, self.depth))
+        return tf.transpose(x, perm=[0, 2, 1, 3])
+
+    def call(self, v, k, q, mask):
+        batch_size = tf.shape(q)[0]
+
+        q = self.wq(q)  # (batch_size, seq_len, d_model)
+        k = self.wk(k)  # (batch_size, seq_len, d_model)
+        v = self.wv(v)  # (batch_size, seq_len, d_model)
+
+        q = self.split_heads(q, batch_size)  # (batch_size, num_heads, seq_len_q, depth)
+        k = self.split_heads(k, batch_size)  # (batch_size, num_heads, seq_len_k, depth)
+        v = self.split_heads(v, batch_size)  # (batch_size, num_heads, seq_len_v, depth)
+
+        # scaled_attention.shape == (batch_size, num_heads, seq_len_q, depth)
+        # attention_weights.shape == (batch_size, num_heads, seq_len_q, seq_len_k)
+        scaled_attention, attention_weights = scaled_dot_product_attention(
+            q, k, v, mask)
+
+        scaled_attention = tf.transpose(scaled_attention, perm=[0, 2, 1, 3])  # (batch, seq_len_q, num_heads, depth)
+
+        concat_attention = tf.reshape(scaled_attention,
+                                      (batch_size, -1, self.d_model))  # (batch_size, seq_len_q, d_model)
+
+        output = self.dense(concat_attention)  # (batch_size, seq_len_q, d_model)
+
+        return output, attention_weights
+
+
+def point_wise_feed_forward_network(d_model, dff):
+    return tf.keras.Sequential([
+        tf.keras.layers.Dense(
+            dff, activation='relu', kernel_initializer=tf.initializers.he_uniform()
+        ),  # (batch, seq_len, dff)
+        tf.keras.layers.Dense(d_model, kernel_initializer=tf.initializers.he_uniform())  # (batch, seq_len, d_model)
+    ])
+
+
+class DecoderLayer(tf.keras.layers.Layer):
+
+    def __init__(self, d_model, num_heads, dff):
+        super(DecoderLayer, self).__init__()
+
+        self.mha1 = MultiHeadAttention(d_model, num_heads)
+        self.mha2 = MultiHeadAttention(d_model, num_heads)
+
+        self.ffn = point_wise_feed_forward_network(d_model, dff)
+
+        self.layernorm1 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm3 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
+
+    def call(self, x, enc_output, training,
+             look_ahead_mask, padding_mask):
+        # enc_output.shape == (batch_size, input_seq_len, d_model)
+
+        attn1, attn_weights_block1 = self.mha1(x, x, x, look_ahead_mask)  # (batch_size, target_seq_len, d_model)
+        attn1 = self.dropout1(attn1, training=training)
+        out1 = self.layernorm1(attn1 + x)
+
+        attn2, attn_weights_block2 = self.mha2(
+            enc_output, enc_output, out1, padding_mask)  # (batch_size, target_seq_len, d_model)
+        attn2 = self.dropout2(attn2, training=training)
+        out2 = self.layernorm2(attn2 + out1)  # (batch_size, target_seq_len, d_model)
+
+        ffn_output = self.ffn(out2)  # (batch_size, target_seq_len, d_model)
+        ffn_output = self.dropout3(ffn_output, training=training)
+        out3 = self.layernorm3(ffn_output + out2)  # (batch_size, target_seq_len, d_model)
+
+        return out3, attn_weights_block1, attn_weights_block2
+
+
+class Decoder(tf.keras.layers.Layer):
+
+    def __init__(self, num_layers, d_model, num_heads, dff, target_vocab_size,
+                 maximum_position_encoding):
+        super(Decoder, self).__init__()
+
+        self.d_model = d_model
+        self.num_layers = num_layers
+
+        self.embedding = tf.keras.layers.Embedding(target_vocab_size, d_model)
+        self.pos_encoding = positional_encoding(maximum_position_encoding, d_model)
+
+        self.dec_layers = [DecoderLayer(d_model, num_heads, dff)
+                           for _ in range(num_layers)]
+
+    def call(self, x, enc_output, look_ahead_mask, padding_mask, training=False):
+
+        seq_len = tf.shape(x)[1]
+        attention_weights = {}
+
+        x = self.embedding(x)  # (batch_size, target_seq_len, d_model)
+        x *= tf.math.sqrt(tf.cast(self.d_model, tf.float32))
+        x += self.pos_encoding[:, :seq_len, :]
+
+        x = self.dropout(x, training=training)
+
+        for i in range(self.num_layers):
+            x, block1, block2 = self.dec_layers[i](
+                x, enc_output, training, look_ahead_mask, padding_mask
+            )
+            attention_weights['decoder_layer{}_block1'.format(i + 1)] = block1
+            attention_weights['decoder_layer{}_block2'.format(i + 1)] = block2
+
+        # x.shape == (batch_size, target_seq_len, d_model)
+        return x, attention_weights

--- a/doctr/models/recognition/transformer.py
+++ b/doctr/models/recognition/transformer.py
@@ -52,6 +52,7 @@ def create_look_ahead_mask(size: int) -> tf.Tensor:
 def scaled_dot_product_attention(
     q: tf.Tensor, k: tf.Tensor, v: tf.Tensor, mask: tf.Tensor
 ) -> Tuple[tf.Tensor, tf.Tensor]:
+
     """Calculate the attention weights.
     q, k, v must have matching leading dimensions.
     k, v must have matching penultimate dimension, i.e.: seq_len_k = seq_len_v.

--- a/doctr/models/recognition/transformer.py
+++ b/doctr/models/recognition/transformer.py
@@ -7,7 +7,7 @@
 # https://www.tensorflow.org/text/tutorials/transformer
 
 
-from typing import *
+from typing import Tuple
 
 import tensorflow as tf
 import numpy as np
@@ -16,12 +16,12 @@ import numpy as np
 __all__ = ['Decoder', 'positional_encoding', 'create_look_ahead_mask', 'create_padding_mask']
 
 
-def get_angles(pos, i, d_model):
+def get_angles(pos: np.array, i: np.array, d_model: int = 512) -> np.array:
     angle_rates = 1 / np.power(10000, (2 * (i // 2)) / np.float32(d_model))
     return pos * angle_rates
 
 
-def positional_encoding(position, d_model):
+def positional_encoding(position: int, d_model: int = 512) -> tf.Tensor:
     angle_rads = get_angles(
         np.arange(position)[:, np.newaxis],
         np.arange(d_model)[np.newaxis, :],
@@ -36,21 +36,22 @@ def positional_encoding(position, d_model):
 
 
 @tf.function
-def create_padding_mask(seq):
-    seq = tf.cast(tf.math.equal(seq, 0), tf.float32)
-    # add extra dimensions to add the padding
-    # to the attention logits.
+def create_padding_mask(seq: tf.Tensor, padding: int = 0) -> tf.Tensor:
+    seq = tf.cast(tf.math.equal(seq, padding), tf.float32)
+    # add extra dimensions to add the padding to the attention logits.
     return seq[:, tf.newaxis, tf.newaxis, :]  # (batch_size, 1, 1, seq_len)
 
 
 @tf.function
-def create_look_ahead_mask(size):
+def create_look_ahead_mask(size: int) -> tf.Tensor:
     mask = 1 - tf.linalg.band_part(tf.ones((size, size)), -1, 0)
     return mask  # (seq_len, seq_len)
 
 
 @tf.function
-def scaled_dot_product_attention(q, k, v, mask):
+def scaled_dot_product_attention(
+    q: tf.Tensor, k: tf.Tensor, v: tf.Tensor, mask: tf.Tensor
+) -> Tuple[tf.Tensor, tf.Tensor]:
     """Calculate the attention weights.
     q, k, v must have matching leading dimensions.
     k, v must have matching penultimate dimension, i.e.: seq_len_k = seq_len_v.
@@ -81,7 +82,7 @@ def scaled_dot_product_attention(q, k, v, mask):
 
 class MultiHeadAttention(tf.keras.layers.Layer):
 
-    def __init__(self, d_model, num_heads):
+    def __init__(self, d_model: int = 512, num_heads: int = 8) -> None:
         super(MultiHeadAttention, self).__init__()
         self.num_heads = num_heads
         self.d_model = d_model
@@ -96,14 +97,14 @@ class MultiHeadAttention(tf.keras.layers.Layer):
 
         self.dense = tf.keras.layers.Dense(d_model, kernel_initializer=tf.initializers.he_uniform())
 
-    def split_heads(self, x, batch_size):
+    def split_heads(self, x: tf.Tensor, batch_size: int) -> tf.Tensor:
         """Split the last dimension into (num_heads, depth).
         Transpose the result such that the shape is (batch_size, num_heads, seq_len, depth)
         """
         x = tf.reshape(x, (batch_size, -1, self.num_heads, self.depth))
         return tf.transpose(x, perm=[0, 2, 1, 3])
 
-    def call(self, v, k, q, mask):
+    def call(self, v: tf.Tensor, k: tf.Tensor, q: tf.Tensor, mask: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
         batch_size = tf.shape(q)[0]
 
         q = self.wq(q)  # (batch_size, seq_len, d_model)
@@ -129,7 +130,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         return output, attention_weights
 
 
-def point_wise_feed_forward_network(d_model, dff):
+def point_wise_feed_forward_network(d_model: int = 512, dff: int = 2048) -> tf.keras.Sequential:
     return tf.keras.Sequential([
         tf.keras.layers.Dense(
             dff, activation='relu', kernel_initializer=tf.initializers.he_uniform()
@@ -140,7 +141,7 @@ def point_wise_feed_forward_network(d_model, dff):
 
 class DecoderLayer(tf.keras.layers.Layer):
 
-    def __init__(self, d_model, num_heads, dff):
+    def __init__(self, d_model: int = 512, num_heads: int = 8, dff: int = 2048) -> None:
         super(DecoderLayer, self).__init__()
 
         self.mha1 = MultiHeadAttention(d_model, num_heads)
@@ -152,21 +153,24 @@ class DecoderLayer(tf.keras.layers.Layer):
         self.layernorm2 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
         self.layernorm3 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
 
-    def call(self, x, enc_output, training,
-             look_ahead_mask, padding_mask):
+    def call(
+        self,
+        x: tf.Tensor,
+        enc_output: tf.Tensor,
+        training: bool,
+        look_ahead_mask: tf.Tensor,
+        padding_mask: tf.Tensor
+    ) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
         # enc_output.shape == (batch_size, input_seq_len, d_model)
 
         attn1, attn_weights_block1 = self.mha1(x, x, x, look_ahead_mask)  # (batch_size, target_seq_len, d_model)
-        attn1 = self.dropout1(attn1, training=training)
         out1 = self.layernorm1(attn1 + x)
 
         attn2, attn_weights_block2 = self.mha2(
             enc_output, enc_output, out1, padding_mask)  # (batch_size, target_seq_len, d_model)
-        attn2 = self.dropout2(attn2, training=training)
         out2 = self.layernorm2(attn2 + out1)  # (batch_size, target_seq_len, d_model)
 
         ffn_output = self.ffn(out2)  # (batch_size, target_seq_len, d_model)
-        ffn_output = self.dropout3(ffn_output, training=training)
         out3 = self.layernorm3(ffn_output + out2)  # (batch_size, target_seq_len, d_model)
 
         return out3, attn_weights_block1, attn_weights_block2
@@ -174,20 +178,34 @@ class DecoderLayer(tf.keras.layers.Layer):
 
 class Decoder(tf.keras.layers.Layer):
 
-    def __init__(self, num_layers, d_model, num_heads, dff, target_vocab_size,
-                 maximum_position_encoding):
+    def __init__(
+        self,
+        num_layers: int = 3,
+        d_model: int = 512,
+        num_heads: int = 8,
+        dff: int = 2048,
+        vocab_size: int = 120,
+        maximum_position_encoding: int = 50,
+    ) -> None:
         super(Decoder, self).__init__()
 
         self.d_model = d_model
         self.num_layers = num_layers
 
-        self.embedding = tf.keras.layers.Embedding(target_vocab_size, d_model)
+        self.embedding = tf.keras.layers.Embedding(vocab_size + 2, d_model)  # 2 more classes EOS/SOS
         self.pos_encoding = positional_encoding(maximum_position_encoding, d_model)
 
         self.dec_layers = [DecoderLayer(d_model, num_heads, dff)
                            for _ in range(num_layers)]
 
-    def call(self, x, enc_output, look_ahead_mask, padding_mask, training=False):
+    def call(
+        self,
+        x: tf.Tensor,
+        enc_output: tf.Tensor,
+        look_ahead_mask: tf.Tensor,
+        padding_mask: tf.Tensor,
+        training: bool = False,
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
 
         seq_len = tf.shape(x)[1]
         attention_weights = {}
@@ -195,8 +213,6 @@ class Decoder(tf.keras.layers.Layer):
         x = self.embedding(x)  # (batch_size, target_seq_len, d_model)
         x *= tf.math.sqrt(tf.cast(self.d_model, tf.float32))
         x += self.pos_encoding[:, :seq_len, :]
-
-        x = self.dropout(x, training=training)
 
         for i in range(self.num_layers):
             x, block1, block2 = self.dec_layers[i](


### PR DESCRIPTION
This PR implements the [MASTER model](https://arxiv.org/pdf/1910.02562.pdf), following the official [TF implementation](https://github.com/jiangxiluning/MASTER-TF).

This model (based on a transformer decoder, and a resnet/Global Context block encoder) achieved very impressive performances compared to SAR and others, at ICDAR 2021.

The decoder used is exactly the one presented in "Attention is all you need", therefore it is implemented in a recognition.transformer.py. The MASTER is implemented in recognition.master.py.

Any feedback is welcome!
Closes #215 