### PR TITLE
feat: add focal loss in linknet model

### DIFF
--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -276,75 +276,61 @@ class LinkNet(DetectionModel, NestedObject):
 
         return seg_target, seg_mask, edge_mask
 
-    def compute_bce_loss(
+    def compute_loss(
         self,
         out_map: tf.Tensor,
         target: List[Dict[str, Any]],
-        factor: float = 2.
+        focal_loss: bool = False,
+        factor: float = 2.,
+        alpha: float = 1.0,
+        gamma: float = 1.0,
     ) -> tf.Tensor:
-        """Compute BCE, with boosted box edges.
+        """Compute linknet loss, BCE with boosted box edges or focal loss. Focal loss implementation based on
+        <https://github.com/tensorflow/addons/>`_.
 
         Args:
             out_map: output feature map of the model of shape N x H x W x 1
             target: list of dictionary where each dict has a `boxes` and a `flags` entry
-            factor: boost factor for box edges
+            focal_loss: if True, use focal loss instead of BCE
+            factor: boost factor for box edges (in case of BCE)
+            alpha: balancing factor in the focal loss formula
+            gammma: modulating factor in the focal loss formula
 
         Returns:
             A loss tensor
         """
         seg_target, seg_mask, edge_mask = self.compute_target(target, out_map.shape[:3])
 
-        # Compute BCE loss with highlighted edges
-        loss = tf.math.multiply(
-            1 + (factor - 1) * tf.cast(edge_mask, tf.float32),
-            tf.keras.losses.binary_crossentropy(
-                seg_target[seg_mask],
-                tf.squeeze(out_map, axis=[-1])[seg_mask],
-                from_logits=True
-            )
-        )
-        return tf.math.reduce_mean(loss)
-
-    def compute_focal_loss(
-        self,
-        out_map: tf.Tensor,
-        target: List[Dict[str, Any]],
-        alpha: float = 1.0,
-        gamma: float = 1.0,
-    ) -> tf.Tensor:
-        """Compute focal loss, inspired from tensorflow addons implementation:
-        <https://github.com/tensorflow/addons/>`_.
-
-        Args:
-            out_map: output feature map of the model of shape N x H x W x 1
-            target: list of dictionary where each dict has a `boxes` and a `flags` entry
-            alpha: balancing factor in the focal loss formula
-            gammma: modulating factor in the focal loss formula
-
-        Return:
-            A loss tensor
-        """
-        seg_target, seg_mask, _ = self.compute_target(target, out_map.shape[:3])
-
-        if gamma and gamma < 0:
-            raise ValueError("Value of gamma should be greater than or equal to zero.")
-
         # Get the cross_entropy for each entry
-        ce = tf.keras.losses.binary_crossentropy(
+        bce = tf.keras.losses.binary_crossentropy(
             seg_target[seg_mask],
             tf.squeeze(out_map, axis=[-1])[seg_mask],
             from_logits=True)
 
-        # Convert logits to prob, compute gamma factor
-        pred_prob = tf.sigmoid(tf.squeeze(out_map, axis=[-1])[seg_mask])
-        p_t = (seg_target[seg_mask] * pred_prob) + ((1 - seg_target[seg_mask]) * (1 - pred_prob))
-        modulating_factor = tf.pow((1.0 - p_t), gamma)
+        if focal_loss:
+            if gamma and gamma < 0:
+                raise ValueError("Value of gamma should be greater than or equal to zero.")
 
-        # Compute alpha factor
-        alpha_factor = seg_target[seg_mask] * alpha + (1 - seg_target[seg_mask]) * (1 - alpha)
+            # Convert logits to prob, compute gamma factor
+            pred_prob = tf.sigmoid(tf.squeeze(out_map, axis=[-1])[seg_mask])
+            p_t = (seg_target[seg_mask] * pred_prob) + ((1 - seg_target[seg_mask]) * (1 - pred_prob))
+            modulating_factor = tf.pow((1.0 - p_t), gamma)
 
-        # compute the final loss and return
-        return tf.reduce_mean(alpha_factor * modulating_factor * ce)
+            # Compute alpha factor
+            alpha_factor = seg_target[seg_mask] * alpha + (1 - seg_target[seg_mask]) * (1 - alpha)
+
+            # compute the final loss
+            loss = tf.reduce_mean(alpha_factor * modulating_factor * bce)
+
+        else:
+            # Compute BCE loss with highlighted edges
+            loss = tf.math.multiply(
+                1 + (factor - 1) * tf.cast(edge_mask, tf.float32),
+                bce
+            )
+            loss = tf.reduce_mean(loss)
+
+        return loss
 
     def call(
         self,
@@ -371,7 +357,7 @@ class LinkNet(DetectionModel, NestedObject):
             out["preds"] = self.postprocessor(prob_map)
 
         if target is not None:
-            loss = self.compute_focal_loss(logits, target) if focal_loss else self.compute_bce_loss(logits, target)
+            loss = self.compute_loss(logits, target, focal_loss)
             out['loss'] = loss
 
         return out

--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -304,7 +304,7 @@ class LinkNet(DetectionModel, NestedObject):
             )
         )
         return tf.math.reduce_mean(loss)
-    
+
     def compute_focal_loss(
         self,
         out_map: tf.Tensor,

--- a/test/test_models_detection.py
+++ b/test/test_models_detection.py
@@ -176,9 +176,10 @@ def test_linknet_postprocessor():
     # Relative coords
     assert all(np.all(np.logical_and(sample[:4] >= 0, sample[:4] <= 1)) for sample in out)
 
+
 def test_linknet_losses():
     batch_size = 2
-    input_shape=(1024, 1024, 3)
+    input_shape = (1024, 1024, 3)
     model = detection.linknet(pretrained=True)
     input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
     target = [


### PR DESCRIPTION
This PR adds a compute_focal_loss method in Linknet, the old compute_loss method  is now compute_bce_loss. The focal loss is enabled by default, but the two are available with a focal_loss flag in the call.

Any feedback is welcome!