### PR TITLE
feat: Updated focal loss parameters

### DIFF
--- a/doctr/models/detection/linknet.py
+++ b/doctr/models/detection/linknet.py
@@ -284,8 +284,8 @@ class LinkNet(DetectionModel, NestedObject):
         target: List[Dict[str, Any]],
         focal_loss: bool = False,
         factor: float = 2.,
-        alpha: float = 1.0,
-        gamma: float = 1.0,
+        alpha: float = .5,
+        gamma: float = 2.,
     ) -> tf.Tensor:
         """Compute linknet loss, BCE with boosted box edges or focal loss. Focal loss implementation based on
         <https://github.com/tensorflow/addons/>`_.


### PR DESCRIPTION
This PR sets the focal loss parameters to alpha = .5 and gamma = 2. in the Linknet.