### PR TITLE
feat: Added support of remaining transforms in PyTorch

### DIFF
--- a/doctr/transforms/functional/__init__.py
+++ b/doctr/transforms/functional/__init__.py
@@ -1,4 +1,6 @@
-from doctr.file_utils import is_tf_available
+from doctr.file_utils import is_tf_available, is_torch_available
 
 if is_tf_available():
     from .tensorflow import *
+elif is_torch_available():
+    from .pytorch import *

--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -5,13 +5,12 @@
 
 import torch
 from torchvision.transforms import functional as F
-from typing import Optional
 
 
 __all__ = ["invert_colors"]
 
 
-def invert_colors(img: torch.Tensor, min_val: Optional[float] = 0.6) -> torch.Tensor:
+def invert_colors(img: torch.Tensor, min_val: float = 0.6) -> torch.Tensor:
     out = F.rgb_to_grayscale(img, num_output_channels=3)
     # Random RGB shift
     shift_shape = [img.shape[0], 3, 1, 1] if img.ndim == 4 else [3, 1, 1]

--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import torch
+from torchvision.transforms import functional as F
+from typing import Optional
+
+
+__all__ = ["invert_colors"]
+
+
+def invert_colors(img: torch.Tensor, min_val: Optional[float] = 0.6) -> torch.Tensor:
+    out = F.rgb_to_grayscale(img, num_output_channels=3)
+    # Random RGB shift
+    shift_shape = [img.shape[0], 3, 1, 1] if img.ndim == 4 else [3, 1, 1]
+    rgb_shift = min_val + (1 - min_val) * torch.rand(shift_shape)
+    # Inverse the color
+    if out.dtype == torch.uint8:
+        out = (out.to(dtype=torch.float32) * rgb_shift).to(dtype=torch.uint8)
+    else:
+        out = out * rgb_shift
+    # Inverse the color
+    out = 255 - out if out.dtype == torch.uint8 else 1 - out
+    return out

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -4,13 +4,12 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import tensorflow as tf
-from typing import Optional
 
 
 __all__ = ["invert_colors"]
 
 
-def invert_colors(img: tf.Tensor, min_val: Optional[float] = 0.6) -> tf.Tensor:
+def invert_colors(img: tf.Tensor, min_val: float = 0.6) -> tf.Tensor:
     out = tf.image.rgb_to_grayscale(img)  # Convert to gray
     # Random RGB shift
     shift_shape = [img.shape[0], 1, 1, 3] if img.ndim == 4 else [1, 1, 3]

--- a/doctr/transforms/modules/__init__.py
+++ b/doctr/transforms/modules/__init__.py
@@ -1,3 +1,5 @@
+from .base import *
+
 from doctr.file_utils import is_tf_available, is_torch_available
 
 if is_tf_available():

--- a/doctr/transforms/modules/base.py
+++ b/doctr/transforms/modules/base.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import random
+from typing import List, Any, Callable
+
+from doctr.utils.repr import NestedObject
+from .. import functional as F
+
+
+__all__ = ['ColorInversion', 'OneOf', 'RandomApply']
+
+
+class ColorInversion(NestedObject):
+    """Applies the following tranformation to a tensor (image or batch of images):
+    convert to grayscale, colorize (shift 0-values randomly), and then invert colors
+
+    Example::
+        >>> from doctr.transforms import Normalize
+        >>> import tensorflow as tf
+        >>> transfo = ColorInversion(min_val=0.6)
+        >>> out = transfo(tf.random.uniform(shape=[8, 64, 64, 3], minval=0, maxval=1))
+
+    Args:
+        min_val: range [min_val, 1] to colorize RGB pixels
+    """
+    def __init__(self, min_val: float = 0.5) -> None:
+        self.min_val = min_val
+
+    def extra_repr(self) -> str:
+        return f"min_val={self.min_val}"
+
+    def __call__(self, img: Any) -> Any:
+        return F.invert_colors(img, self.min_val)
+
+
+class OneOf(NestedObject):
+    """Randomly apply one of the input transformations
+
+    Example::
+        >>> from doctr.transforms import Normalize
+        >>> import tensorflow as tf
+        >>> transfo = OneOf([JpegQuality(), Gamma()])
+        >>> out = transfo(tf.random.uniform(shape=[64, 64, 3], minval=0, maxval=1))
+
+    Args:
+        transforms: list of transformations, one only will be picked
+    """
+
+    _children_names: List[str] = ['transforms']
+
+    def __init__(self, transforms: List[Callable[[Any], Any]]) -> None:
+        self.transforms = transforms
+
+    def __call__(self, img: Any) -> Any:
+        # Pick transformation
+        transfo = self.transforms[int(random.random() * len(self.transforms))]
+        # Apply
+        return transfo(img)
+
+
+class RandomApply(NestedObject):
+    """Apply with a probability p the input transformation
+
+    Example::
+        >>> from doctr.transforms import Normalize
+        >>> import tensorflow as tf
+        >>> transfo = RandomApply(Gamma(), p=.5)
+        >>> out = transfo(tf.random.uniform(shape=[64, 64, 3], minval=0, maxval=1))
+
+    Args:
+        transform: transformation to apply
+        p: probability to apply
+    """
+    def __init__(self, transform: Callable[[Any], Any], p: float = .5) -> None:
+        self.transform = transform
+        self.p = p
+
+    def extra_repr(self) -> str:
+        return f"transform={self.transform}, p={self.p}"
+
+    def __call__(self, img: Any) -> Any:
+        if random.random() < self.p:
+            return self.transform(img)
+        return img

--- a/doctr/transforms/modules/tensorflow.py
+++ b/doctr/transforms/modules/tensorflow.py
@@ -11,9 +11,8 @@ from doctr.utils.repr import NestedObject
 from .. import functional as F
 
 
-__all__ = ['Compose', 'Resize', 'Normalize', 'LambdaTransformation', 'ToGray', 'ColorInversion',
-           'RandomBrightness', 'RandomContrast', 'RandomSaturation', 'RandomHue', 'RandomGamma', 'RandomJpegQuality',
-           'OneOf', 'RandomApply']
+__all__ = ['Compose', 'Resize', 'Normalize', 'LambdaTransformation', 'ToGray', 'RandomBrightness',
+           'RandomContrast', 'RandomSaturation', 'RandomHue', 'RandomGamma', 'RandomJpegQuality']
 
 
 class Compose(NestedObject):
@@ -144,29 +143,6 @@ class ToGray(NestedObject):
     """
     def __call__(self, img: tf.Tensor) -> tf.Tensor:
         return tf.image.rgb_to_grayscale(img)
-
-
-class ColorInversion(NestedObject):
-    """Applies the following tranformation to a tensor (image or batch of images):
-    convert to grayscale, colorize (shift 0-values randomly), and then invert colors
-
-    Example::
-        >>> from doctr.transforms import Normalize
-        >>> import tensorflow as tf
-        >>> transfo = ColorInversion(min_val=0.6)
-        >>> out = transfo(tf.random.uniform(shape=[8, 64, 64, 3], minval=0, maxval=1))
-
-    Args:
-        min_val: range [min_val, 1] to colorize RGB pixels
-    """
-    def __init__(self, min_val: float = 0.5) -> None:
-        self.min_val = min_val
-
-    def extra_repr(self) -> str:
-        return f"min_val={self.min_val}"
-
-    def __call__(self, img: tf.Tensor) -> tf.Tensor:
-        return F.invert_colors(img, self.min_val)
 
 
 class RandomBrightness(NestedObject):
@@ -322,54 +298,3 @@ class RandomJpegQuality(NestedObject):
         return tf.image.random_jpeg_quality(
             img, min_jpeg_quality=self.min_quality, max_jpeg_quality=self.max_quality
         )
-
-
-class OneOf(NestedObject):
-    """Randomly apply one of the input transformations
-
-    Example::
-        >>> from doctr.transforms import Normalize
-        >>> import tensorflow as tf
-        >>> transfo = OneOf([JpegQuality(), Gamma()])
-        >>> out = transfo(tf.random.uniform(shape=[64, 64, 3], minval=0, maxval=1))
-
-    Args:
-        transforms: list of transformations, one only will be picked
-    """
-
-    _children_names: List[str] = ['transforms']
-
-    def __init__(self, transforms: List[Callable[[Any], Any]]) -> None:
-        self.transforms = transforms
-
-    def __call__(self, img: tf.Tensor) -> tf.Tensor:
-        # Pick transformation
-        transfo = self.transforms[int(random.random() * len(self.transforms))]
-        # Apply
-        return transfo(img)
-
-
-class RandomApply(NestedObject):
-    """Apply with a probability p the input transformation
-
-    Example::
-        >>> from doctr.transforms import Normalize
-        >>> import tensorflow as tf
-        >>> transfo = RandomApply(Gamma(), p=.5)
-        >>> out = transfo(tf.random.uniform(shape=[64, 64, 3], minval=0, maxval=1))
-
-    Args:
-        transform: transformation to apply
-        p: probability to apply
-    """
-    def __init__(self, transform: Callable[[Any], Any], p: float = .5) -> None:
-        self.transform = transform
-        self.p = p
-
-    def extra_repr(self) -> str:
-        return f"transform={self.transform}, p={self.p}"
-
-    def __call__(self, img: tf.Tensor) -> tf.Tensor:
-        if random.random() < self.p:
-            return self.transform(img)
-        return img

--- a/test/pytorch/test_transforms.py
+++ b/test/pytorch/test_transforms.py
@@ -1,5 +1,8 @@
+import pytest
+
+import math
 import torch
-from doctr.transforms import Resize
+from doctr.transforms import Resize, ColorInversion
 
 
 def test_resize():
@@ -36,3 +39,25 @@ def test_resize():
 
     assert not torch.all(out == 1)
     assert out.shape[-2:] == output_size
+
+
+@pytest.mark.parametrize(
+    "rgb_min",
+    [
+        0.2,
+        0.4,
+        0.6,
+    ],
+)
+def test_invert_colorize(rgb_min):
+
+    transfo = ColorInversion(min_val=rgb_min)
+    input_t = torch.ones((8, 3, 32, 32), dtype=torch.float32)
+    out = transfo(input_t)
+    assert torch.all(out <= 1 - rgb_min + 1e-4)
+    assert torch.all(out >= 0)
+
+    input_t = torch.full((8, 3, 32, 32), 255, dtype=torch.uint8)
+    out = transfo(input_t)
+    assert torch.all(out <= int(math.ceil(255 * (1 - rgb_min))))
+    assert torch.all(out >= 0)


### PR DESCRIPTION
Following up on #261, this PR introduces the following modifications:
- added ColorInversion support in PyTorch
- refactored transforms dispatch
- fixed typing of `doctr.transforms.functional.invert_colors`
- updated unittests

_Note: RandomJPEGQuality doesn't have a pytorch equivalent, but there is plenty of other similar stuff & AutoAugment_

Any feedback is welcome!