### PR TITLE
feat: Added PyTorch support to models.utils

### DIFF
--- a/doctr/models/__init__.py
+++ b/doctr/models/__init__.py
@@ -1,5 +1,6 @@
 from .preprocessor import *
 from .detection import *
+from . import artefacts
 from . import utils
 from ._utils import *
 

--- a/doctr/models/__init__.py
+++ b/doctr/models/__init__.py
@@ -1,5 +1,7 @@
 from .preprocessor import *
 from .detection import *
+from . import utils
+from ._utils import *
 
 
 from doctr.file_utils import is_tf_available
@@ -7,8 +9,6 @@ from doctr.file_utils import is_tf_available
 if is_tf_available():
     from .backbones import *
     from .recognition import *
-    from . import utils
-    from ._utils import *
     from .core import *
     from .export import *
     from .zoo import *

--- a/doctr/models/utils/__init__.py
+++ b/doctr/models/utils/__init__.py
@@ -1,0 +1,6 @@
+from doctr.file_utils import is_tf_available, is_torch_available
+
+if is_tf_available():
+    from .tensorflow import *
+elif is_torch_available():
+    from .pytorch import *  # type: ignore[misc]

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import logging
+import torch
+from torch import nn
+from typing import Optional, List, Any
+
+from ..data_utils import download_from_url
+
+
+__all__ = ['load_pretrained_params', 'conv_sequence']
+
+
+def load_pretrained_params(
+    model: nn.Module,
+    url: Optional[str] = None,
+    hash_prefix: Optional[str] = None,
+    overwrite: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Load a set of parameters onto a model
+
+    Example::
+        >>> from doctr.models import load_pretrained_params
+        >>> load_pretrained_params(model, "https://yoursource.com/yourcheckpoint-yourhash.zip")
+
+    Args:
+        model: the keras model to be loaded
+        url: URL of the zipped set of parameters
+        hash_prefix: first characters of SHA256 expected hash
+        overwrite: should the zip extraction be enforced if the archive has already been extracted
+    """
+
+    if url is None:
+        logging.warning("Invalid model URL, using default initialization.")
+    else:
+        archive_path = download_from_url(url, hash_prefix=hash_prefix, cache_subdir='models', **kwargs)
+
+        # Read state_dict
+        state_dict = torch.load(archive_path, map_location='cpu')
+
+        # Load weights
+        model.load_state_dict(state_dict)
+
+
+def conv_sequence(
+    in_channels: int,
+    out_channels: int,
+    relu: bool = False,
+    bn: bool = False,
+    **kwargs: Any,
+) -> List[nn.Module]:
+    """Builds a convolutional-based layer sequence
+
+    Example::
+        >>> from doctr.models import conv_sequence
+        >>> from torch.nn import Sequential
+        >>> module = Sequential(conv_sequence(3, 32, True, True, kernel_size=3))
+
+    Args:
+        out_channels: number of output channels
+        relu: whether ReLU should be used
+        bn: should a batch normalization layer be added
+
+    Returns:
+        list of layers
+    """
+    # No bias before Batch norm
+    kwargs['bias'] = kwargs.get('bias', not(bn))
+    # Add activation directly to the conv if there is no BN
+    conv_seq: List[nn.Module] = [
+        nn.Conv2d(in_channels, out_channels, **kwargs)
+    ]
+
+    if bn:
+        conv_seq.append(nn.BatchNorm2d(out_channels))
+
+    if relu:
+        conv_seq.append(nn.ReLU(inplace=True))
+
+    return conv_seq

--- a/doctr/models/utils/tensorflow.py
+++ b/doctr/models/utils/tensorflow.py
@@ -4,15 +4,12 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import logging
-import re
 import os
-import hashlib
-from pathlib import Path
 from zipfile import ZipFile
 from tensorflow.keras import layers, Model
-from typing import Optional, List, Any, Union
+from typing import Optional, List, Any
 
-from .data_utils import download_from_url
+from ..data_utils import download_from_url
 
 logging.getLogger("tensorflow").setLevel(logging.DEBUG)
 

--- a/test/pytorch/test_models_utils.py
+++ b/test/pytorch/test_models_utils.py
@@ -1,0 +1,29 @@
+import pytest
+import os
+
+from torch import nn
+from doctr.models import utils
+
+
+def test_load_pretrained_params(tmpdir_factory):
+
+    model = nn.Sequential(nn.Linear(8, 8), nn.ReLU(), nn.Linear(8, 4))
+    # Retrieve this URL
+    url = "https://github.com/mindee/doctr/releases/download/v0.2.1/tmp_checkpoint-6f0ce0e6.pt"
+    # Temp cache dir
+    cache_dir = tmpdir_factory.mktemp("cache")
+    # Pass an incorrect hash
+    with pytest.raises(ValueError):
+        utils.load_pretrained_params(model, url, "mywronghash", cache_dir=str(cache_dir))
+    # Let tit resolve the hash from the file name
+    utils.load_pretrained_params(model, url, cache_dir=str(cache_dir))
+    # Check that the file was downloaded & the archive extracted
+    assert os.path.exists(cache_dir.join('models').join(url.rpartition("/")[-1]))
+
+
+def test_conv_sequence():
+
+    assert len(utils.conv_sequence(3, 8, kernel_size=3)) == 1
+    assert len(utils.conv_sequence(3, 8, True, kernel_size=3)) == 2
+    assert len(utils.conv_sequence(3, 8, False, True, kernel_size=3)) == 2
+    assert len(utils.conv_sequence(3, 8, True, True, kernel_size=3)) == 3


### PR DESCRIPTION
Following up on #261, this PR introduces the following modifications:
- added PyTorch support of `load_pretrained_params` and `conv_sequence`
- fixed models `__init__`
- added unittests for pytorch support

_Note: IntermediateLayerGetter is already natively supported in PyTorch_

Any feedback is welcome!