### PR TITLE
feat: Added PyTorch support of ResNet-31

### DIFF
--- a/doctr/models/backbones/resnet/__init__.py
+++ b/doctr/models/backbones/resnet/__init__.py
@@ -1,0 +1,6 @@
+from doctr import is_tf_available, is_torch_available
+
+if is_tf_available():
+    from .tensorflow import *
+elif is_torch_available():
+    from .pytorch import *  # type: ignore[misc]

--- a/doctr/models/backbones/resnet/pytorch.py
+++ b/doctr/models/backbones/resnet/pytorch.py
@@ -4,7 +4,6 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 
-import torch
 from torch import nn
 from torchvision.models.resnet import BasicBlock
 

--- a/doctr/models/backbones/resnet/pytorch.py
+++ b/doctr/models/backbones/resnet/pytorch.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+
+import torch
+from torch import nn
+from torchvision.models.resnet import BasicBlock
+
+from typing import Tuple, Dict, Any, List
+from ...utils import conv_sequence_pt, load_pretrained_params
+
+__all__ = ['ResNet', 'resnet31']
+
+
+default_cfgs: Dict[str, Dict[str, Any]] = {
+    'resnet31': {'num_blocks': (1, 2, 5, 3), 'output_channels': (256, 256, 512, 512),
+                 'url': None},
+}
+
+
+def resnet_stage(in_channels: int, out_channels: int, num_blocks: int) -> List[nn.Module]:
+    _layers: List[nn.Module] = []
+
+    in_chan = in_channels
+    for _ in range(num_blocks):
+        downsample = None
+        if in_chan != out_channels:
+            downsample = nn.Sequential(*conv_sequence_pt(in_chan, out_channels, False, True, kernel_size=1))
+
+        _layers.append(BasicBlock(in_chan, out_channels, downsample=downsample))
+        in_chan = out_channels
+
+    return _layers
+
+
+class ResNet(nn.Sequential):
+    """Implements a ResNet-31 architecture from `"Show, Attend and Read:A Simple and Strong Baseline for Irregular
+    Text Recognition" <https://arxiv.org/pdf/1811.00751.pdf>`_.
+
+    Args:
+        num_blocks: number of residual blocks in each stage
+        output_channels: number of output channels in each stage
+    """
+
+    def __init__(
+        self,
+        num_blocks: Tuple[int, int, int, int],
+        output_channels: Tuple[int, int, int, int],
+    ) -> None:
+
+        _layers: List[nn.Module] = [
+            *conv_sequence_pt(3, 64, True, True, kernel_size=3, padding=1),
+            *conv_sequence_pt(64, 128, True, True, kernel_size=3, padding=1),
+            nn.MaxPool2d(2),
+            # Stage 1
+            nn.Sequential(
+                *resnet_stage(128, output_channels[0], num_blocks[0]),
+                *conv_sequence_pt(output_channels[0], output_channels[0], True, True, kernel_size=3, padding=1),
+            ),
+            nn.MaxPool2d(2),
+            # Stage 2
+            nn.Sequential(
+                *resnet_stage(output_channels[0], output_channels[1], num_blocks[1]),
+                *conv_sequence_pt(output_channels[1], output_channels[1], True, True, kernel_size=3, padding=1),
+            ),
+            nn.MaxPool2d((2, 1)),
+            # Stage 3
+            nn.Sequential(
+                *resnet_stage(output_channels[1], output_channels[2], num_blocks[2]),
+                *conv_sequence_pt(output_channels[2], output_channels[2], True, True, kernel_size=3, padding=1),
+            ),
+            # Stage 4
+            nn.Sequential(
+                *resnet_stage(output_channels[2], output_channels[3], num_blocks[3]),
+                *conv_sequence_pt(output_channels[3], output_channels[3], True, True, kernel_size=3, padding=1),
+            ),
+        ]
+
+        super().__init__(*_layers)
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+
+def _resnet(arch: str, pretrained: bool) -> ResNet:
+
+    # Build the model
+    model = ResNet(
+        default_cfgs[arch]['num_blocks'],
+        default_cfgs[arch]['output_channels'],
+    )
+    # Load pretrained parameters
+    if pretrained:
+        load_pretrained_params(model, default_cfgs[arch]['url'])
+
+    return model
+
+
+def resnet31(pretrained: bool = False) -> ResNet:
+    """Resnet31 architecture with rectangular pooling windows as described in
+    `"Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition",
+    <https://arxiv.org/pdf/1811.00751.pdf>`_. Downsizing: (H, W) --> (H/8, W/4)
+
+    Example::
+        >>> import torch
+        >>> from doctr.models import resnet31
+        >>> model = resnet31(pretrained=False)
+        >>> input_tensor = torch.rand((1, 3, 224, 224), dtype=tf.float32)
+        >>> out = model(input_tensor)
+
+    Args:
+        pretrained: boolean, True if model is pretrained
+
+    Returns:
+        A resnet31 model
+    """
+
+    return _resnet('resnet31', pretrained)

--- a/doctr/models/backbones/resnet/tensorflow.py
+++ b/doctr/models/backbones/resnet/tensorflow.py
@@ -7,9 +7,9 @@ import tensorflow as tf
 from tensorflow.keras import layers
 from tensorflow.keras.models import Sequential
 from typing import Tuple, Dict, Optional, Any, List
-from ..utils import conv_sequence, load_pretrained_params
+from ...utils import conv_sequence, load_pretrained_params
 
-__all__ = ['Resnet', 'resnet31', 'ResnetStage']
+__all__ = ['ResNet', 'resnet31', 'ResnetStage']
 
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
@@ -110,7 +110,7 @@ class ResnetStage(Sequential):
             self.add(final_block)
 
 
-class Resnet(Sequential):
+class ResNet(Sequential):
 
     """Resnet class with two convolutions and a maxpooling before the first stage
 
@@ -155,10 +155,10 @@ class Resnet(Sequential):
         super().__init__(_layers)
 
 
-def _resnet(arch: str, pretrained: bool, **kwargs: Any) -> Resnet:
+def _resnet(arch: str, pretrained: bool, **kwargs: Any) -> ResNet:
 
     # Build the model
-    model = Resnet(
+    model = ResNet(
         default_cfgs[arch]['num_blocks'],
         default_cfgs[arch]['output_channels'],
         default_cfgs[arch]['conv_seq'],
@@ -172,7 +172,7 @@ def _resnet(arch: str, pretrained: bool, **kwargs: Any) -> Resnet:
     return model
 
 
-def resnet31(pretrained: bool = False, **kwargs: Any) -> Resnet:
+def resnet31(pretrained: bool = False, **kwargs: Any) -> ResNet:
     """Resnet31 architecture with rectangular pooling windows as described in
     `"Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition",
     <https://arxiv.org/pdf/1811.00751.pdf>`_. Downsizing: (H, W) --> (H/8, W/4)

--- a/doctr/models/backbones/vgg/__init__.py
+++ b/doctr/models/backbones/vgg/__init__.py
@@ -1,0 +1,4 @@
+from doctr import is_tf_available
+
+if is_tf_available():
+    from .tensorflow import *

--- a/doctr/models/backbones/vgg/tensorflow.py
+++ b/doctr/models/backbones/vgg/tensorflow.py
@@ -7,7 +7,7 @@ from tensorflow.keras import layers
 from tensorflow.keras.models import Sequential
 from typing import Tuple, Dict, Any
 
-from ..utils import conv_sequence, load_pretrained_params
+from ...utils import conv_sequence, load_pretrained_params
 
 
 __all__ = ['VGG', 'vgg16_bn']

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -11,7 +11,7 @@ from typing import Optional, List, Any
 from ..data_utils import download_from_url
 
 
-__all__ = ['load_pretrained_params', 'conv_sequence']
+__all__ = ['load_pretrained_params', 'conv_sequence_pt']
 
 
 def load_pretrained_params(
@@ -46,7 +46,7 @@ def load_pretrained_params(
         model.load_state_dict(state_dict)
 
 
-def conv_sequence(
+def conv_sequence_pt(
     in_channels: int,
     out_channels: int,
     relu: bool = False,

--- a/test/pytorch/test_models_backbones.py
+++ b/test/pytorch/test_models_backbones.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+
+from doctr.models import backbones
+
+
+@pytest.mark.parametrize(
+    "arch_name, input_shape, output_size",
+    [
+        ["resnet31", (3, 32, 128), (512, 4, 32)],
+    ],
+)
+def test_classification_architectures(arch_name, input_shape, output_size):
+    # Model
+    batch_size = 2
+    model = backbones.__dict__[arch_name](pretrained=True)
+    # Forward
+    out = model(torch.rand((batch_size, *input_shape), dtype=tf.float32))
+    # Output checks
+    assert isinstance(out, torch.Tensor)
+    assert out.numpy().shape == (batch_size, *output_size)

--- a/test/pytorch/test_models_backbones.py
+++ b/test/pytorch/test_models_backbones.py
@@ -15,7 +15,7 @@ def test_classification_architectures(arch_name, input_shape, output_size):
     batch_size = 2
     model = backbones.__dict__[arch_name](pretrained=True)
     # Forward
-    out = model(torch.rand((batch_size, *input_shape), dtype=tf.float32))
+    out = model(torch.rand((batch_size, *input_shape), dtype=torch.float32))
     # Output checks
     assert isinstance(out, torch.Tensor)
     assert out.numpy().shape == (batch_size, *output_size)

--- a/test/pytorch/test_models_backbones.py
+++ b/test/pytorch/test_models_backbones.py
@@ -13,9 +13,10 @@ from doctr.models import backbones
 def test_classification_architectures(arch_name, input_shape, output_size):
     # Model
     batch_size = 2
-    model = backbones.__dict__[arch_name](pretrained=True)
+    model = backbones.__dict__[arch_name](pretrained=True).eval()
     # Forward
-    out = model(torch.rand((batch_size, *input_shape), dtype=torch.float32))
+    with torch.no_grad():
+        out = model(torch.rand((batch_size, *input_shape), dtype=torch.float32))
     # Output checks
     assert isinstance(out, torch.Tensor)
     assert out.numpy().shape == (batch_size, *output_size)

--- a/test/pytorch/test_models_utils.py
+++ b/test/pytorch/test_models_utils.py
@@ -23,7 +23,7 @@ def test_load_pretrained_params(tmpdir_factory):
 
 def test_conv_sequence():
 
-    assert len(utils.conv_sequence(3, 8, kernel_size=3)) == 1
-    assert len(utils.conv_sequence(3, 8, True, kernel_size=3)) == 2
-    assert len(utils.conv_sequence(3, 8, False, True, kernel_size=3)) == 2
-    assert len(utils.conv_sequence(3, 8, True, True, kernel_size=3)) == 3
+    assert len(utils.conv_sequence_pt(3, 8, kernel_size=3)) == 1
+    assert len(utils.conv_sequence_pt(3, 8, True, kernel_size=3)) == 2
+    assert len(utils.conv_sequence_pt(3, 8, False, True, kernel_size=3)) == 2
+    assert len(utils.conv_sequence_pt(3, 8, True, True, kernel_size=3)) == 3


### PR DESCRIPTION
Following up on #261, this PR introduces the following modifications:
- added support of `resnet31` as Pytorch backbone
- renamed base `Resnet` class to `ResNet`
- renamed `conv_sequence` Pytorch version to `conv_sequence_pt`
- updated unittests

Any feedback is welcome!