### PR TITLE
fix: bug in MASTER loss

### DIFF
--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -50,7 +50,7 @@ def translate(
 def encode_sequence(
     input_string: str,
     vocab: str,
-) -> List[str]:
+) -> List[int]:
     """Given a predefined mapping, encode the string to a sequence of numbers
 
     Args:

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -109,13 +109,16 @@ def encode_sequences(
         raise ValueError("argument 'eos' needs to be outside of vocab possible indices")
 
     if not isinstance(target_size, int):
-        target_size = max(len(w) for w in sequences) + 1  # One more for eos
+        target_size = max(len(w) for w in sequences)
         if sos:
+            target_size += 1
+        if pad:
             target_size += 1
 
     # Pad all sequences
     if pad:  # pad with padding symbol
-        assert 0 <= pad < len(vocab)
+        assert not 0 <= pad < len(vocab)
+        # In that case, add EOS at the end of the word before padding
         encoded_data = np.full([len(sequences), target_size], pad, dtype=np.int32)
     else:  # pad with eos symbol
         encoded_data = np.full([len(sequences), target_size], eos, dtype=np.int32)
@@ -123,11 +126,11 @@ def encode_sequences(
     for idx, seq in enumerate(sequences):
         encoded_seq = encode_sequence(seq, vocab)
         if pad:  # add eos at the end of the sequence
-            encoded_seq += [eos]
+            encoded_seq.append(eos)
         encoded_data[idx, :min(len(encoded_seq), target_size)] = encoded_seq[:min(len(encoded_seq), target_size)]
 
     if sos:  # place eos symbol at the beginning of each sequence
-        assert 0 <= sos < len(vocab)
+        assert not 0 <= sos < len(vocab)
         encoded_data = np.roll(encoded_data, 1)
         encoded_data[:, 0] = sos
 

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -88,6 +88,7 @@ def encode_sequences(
     target_size: Optional[int] = None,
     eos: int = -1,
     sos: Optional[int] = None,
+    pad: Optional[int] = None,
     **kwargs: Any,
 ) -> np.ndarray:
     """Encode character sequences using a given vocab as mapping
@@ -98,6 +99,7 @@ def encode_sequences(
         target_size: maximum length of the encoded data
         eos: encoding of End Of String
         sos: optional encoding of Start Of String
+        pad: optional encoding for padding. In case of padding, all sequences are followed by 1 EOS then PAD
 
     Returns:
         the padded encoded data as a tensor
@@ -107,18 +109,25 @@ def encode_sequences(
         raise ValueError("argument 'eos' needs to be outside of vocab possible indices")
 
     if not isinstance(target_size, int):
-        target_size = max(len(w) for w in sequences)
+        target_size = max(len(w) for w in sequences) + 1  # One more for eos
         if sos:
             target_size += 1
 
     # Pad all sequences
-    encoded_data = np.full([len(sequences), target_size], eos, dtype=np.int32)
+    if pad:  # pad with padding symbol
+        assert 0 <= pad < len(vocab)
+        encoded_data = np.full([len(sequences), target_size], pad, dtype=np.int32)
+    else:  # pad with eos symbol
+        encoded_data = np.full([len(sequences), target_size], eos, dtype=np.int32)
 
     for idx, seq in enumerate(sequences):
         encoded_seq = encode_sequence(seq, vocab)
+        if pad:  # add eos at the end of the sequence
+            encoded_seq += [eos]
         encoded_data[idx, :min(len(encoded_seq), target_size)] = encoded_seq[:min(len(encoded_seq), target_size)]
 
-    if sos:
+    if sos:  # place eos symbol at the beginning of each sequence
+        assert 0 <= sos < len(vocab)
         encoded_data = np.roll(encoded_data, 1)
         encoded_data[:, 0] = sos
 

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -117,7 +117,8 @@ def encode_sequences(
 
     # Pad all sequences
     if pad:  # pad with padding symbol
-        assert not 0 <= pad < len(vocab)
+        if 0 <= pad < len(vocab):
+            raise ValueError("argument 'pad' needs to be outside of vocab possible indices")
         # In that case, add EOS at the end of the word before padding
         encoded_data = np.full([len(sequences), target_size], pad, dtype=np.int32)
     else:  # pad with eos symbol
@@ -130,7 +131,8 @@ def encode_sequences(
         encoded_data[idx, :min(len(encoded_seq), target_size)] = encoded_seq[:min(len(encoded_seq), target_size)]
 
     if sos:  # place eos symbol at the beginning of each sequence
-        assert not 0 <= sos < len(vocab)
+        if 0 <= sos < len(vocab):
+            raise ValueError("argument 'sos' needs to be outside of vocab possible indices")
         encoded_data = np.roll(encoded_data, 1)
         encoded_data[:, 0] = sos
 

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -56,7 +56,7 @@ class RecognitionPostProcessor(NestedObject):
     ) -> None:
 
         self.vocab = vocab
-        self._embedding = list(self.vocab) + ['<eos>'] + ['<sos>'] + ['<pad>']
+        self._embedding = list(self.vocab) + ['<eos>']
 
     def extra_repr(self) -> str:
         return f"vocab_size={len(self.vocab)}"

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -56,7 +56,7 @@ class RecognitionPostProcessor(NestedObject):
     ) -> None:
 
         self.vocab = vocab
-        self._embedding = list(self.vocab) + ['<eos>']
+        self._embedding = list(self.vocab) + ['<eos>'] + ['<sos>'] + ['<pad>']
 
     def extra_repr(self) -> str:
         return f"vocab_size={len(self.vocab)}"

--- a/doctr/models/recognition/master/base.py
+++ b/doctr/models/recognition/master/base.py
@@ -53,6 +53,3 @@ class _MASTERPostProcessor(RecognitionPostProcessor):
 
         super().__init__(vocab)
         self._embedding = list(vocab) + ['<eos>'] + ['<sos>'] + ['<pad>']
-
-    def extra_repr(self) -> str:
-        return f"vocab_size={len(self.vocab)}"

--- a/doctr/models/recognition/master/base.py
+++ b/doctr/models/recognition/master/base.py
@@ -36,3 +36,22 @@ class _MASTER:
         )
         seq_len = [len(word) for word in gts]
         return encoded, seq_len
+
+
+class _MASTERPostProcessor:
+    """Abstract class to postprocess the raw output of the model
+
+    Args:
+        vocab: string containing the ordered sequence of supported characters
+    """
+
+    def __init__(
+        self,
+        vocab: str,
+    ) -> None:
+
+        self.vocab = vocab
+        self._embedding = list(self.vocab) + ['<eos>'] + ['<sos>'] + ['<pad>']
+
+    def extra_repr(self) -> str:
+        return f"vocab_size={len(self.vocab)}"

--- a/doctr/models/recognition/master/base.py
+++ b/doctr/models/recognition/master/base.py
@@ -32,6 +32,7 @@ class _MASTER:
             target_size=self.max_length,
             eos=len(self.vocab),
             sos=len(self.vocab) + 1,
+            pad=len(self.vocab) + 2,
         )
         seq_len = [len(word) for word in gts]
         return encoded, seq_len

--- a/doctr/models/recognition/master/base.py
+++ b/doctr/models/recognition/master/base.py
@@ -6,6 +6,7 @@
 import numpy as np
 from typing import List, Tuple
 from ....datasets import encode_sequences
+from ..core import RecognitionPostProcessor
 
 
 class _MASTER:
@@ -38,7 +39,7 @@ class _MASTER:
         return encoded, seq_len
 
 
-class _MASTERPostProcessor:
+class _MASTERPostProcessor(RecognitionPostProcessor):
     """Abstract class to postprocess the raw output of the model
 
     Args:
@@ -50,8 +51,8 @@ class _MASTERPostProcessor:
         vocab: str,
     ) -> None:
 
-        self.vocab = vocab
-        self._embedding = list(self.vocab) + ['<eos>'] + ['<sos>'] + ['<pad>']
+        super().__init__(vocab)
+        self._embedding = list(vocab) + ['<eos>'] + ['<sos>'] + ['<pad>']
 
     def extra_repr(self) -> str:
         return f"vocab_size={len(self.vocab)}"

--- a/doctr/models/recognition/master/tensorflow.py
+++ b/doctr/models/recognition/master/tensorflow.py
@@ -293,17 +293,17 @@ class MASTER(_MASTER, Model):
             gt, seq_len = self.compute_target(target)
 
         if kwargs.get('training', False):
-            # When not training, we want to compute logits in with the decoder, although
-            # we have access to gts (we need gts to compute the loss, but not in the decoder)
-            _, logits = self.decode(encoded, **kwargs)
-
-        else:
             if target is None:
                 raise AssertionError("In training mode, you need to pass a value to 'target'")
             tgt_mask = self.make_mask(gt)
             # Compute logits
             output = self.decoder(gt, encoded, tgt_mask, None, **kwargs)
             logits = self.linear(output, **kwargs)
+
+        else:
+            # When not training, we want to compute logits in with the decoder, although
+            # we have access to gts (we need gts to compute the loss, but not in the decoder)
+            _, logits = self.decode(encoded, **kwargs)
 
         if target is not None:
             out['loss'] = self.compute_loss(logits, gt, seq_len)

--- a/doctr/models/recognition/master/tensorflow.py
+++ b/doctr/models/recognition/master/tensorflow.py
@@ -266,7 +266,7 @@ class MASTER(_MASTER, Model):
         target: Optional[List[str]] = None,
         return_model_output: bool = False,
         return_preds: bool = False,
-        training: bool = True,
+        training: bool = False,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Call function for training

--- a/doctr/models/recognition/master/tensorflow.py
+++ b/doctr/models/recognition/master/tensorflow.py
@@ -13,7 +13,7 @@ from ...backbones.resnet import ResnetStage
 from ...utils import conv_sequence, load_pretrained_params
 from ..transformer import Decoder, positional_encoding, create_look_ahead_mask, create_padding_mask
 from ....datasets import VOCABS
-from .base import _MASTER
+from .base import _MASTER, _MASTERPostProcessor
 
 
 __all__ = ['MASTER', 'MASTERPostProcessor', 'master']
@@ -359,7 +359,7 @@ class MASTER(_MASTER, Model):
         return ys, final_logits
 
 
-class MASTERPostProcessor(RecognitionPostProcessor):
+class MASTERPostProcessor(_MASTERPostProcessor):
     """Post processor for MASTER architectures
     Args:
         vocab: string containing the ordered sequence of supported characters

--- a/doctr/models/recognition/master/tensorflow.py
+++ b/doctr/models/recognition/master/tensorflow.py
@@ -204,7 +204,7 @@ class MASTER(_MASTER, Model):
         self.vocab_size = len(vocab)
 
         self.feature_extractor = MAGCResnet(headers=headers, input_shape=input_shape)
-        self.seq_embedding = layers.Embedding(self.vocab_size + 1, d_model)  # One additional class for EOS
+        self.seq_embedding = layers.Embedding(self.vocab_size + 3, d_model)  # 3 more classes: EOS/PAD/SOS
 
         self.decoder = Decoder(
             num_layers=num_layers,
@@ -215,14 +215,14 @@ class MASTER(_MASTER, Model):
             maximum_position_encoding=max_length,
         )
         self.feature_pe = positional_encoding(input_shape[0] * input_shape[1], d_model)
-        self.linear = layers.Dense(self.vocab_size + 1, kernel_initializer=tf.initializers.he_uniform())
+        self.linear = layers.Dense(self.vocab_size + 3, kernel_initializer=tf.initializers.he_uniform())
 
         self.postprocessor = MASTERPostProcessor(vocab=self.vocab)
 
     @tf.function
     def make_mask(self, target: tf.Tensor) -> tf.Tensor:
         look_ahead_mask = create_look_ahead_mask(tf.shape(target)[1])
-        target_padding_mask = create_padding_mask(target, self.vocab_size)  # Pad with EOS
+        target_padding_mask = create_padding_mask(target, self.vocab_size + 2)  # Pad symbol
         combined_mask = tf.maximum(target_padding_mask, look_ahead_mask)
         return combined_mask
 
@@ -245,15 +245,16 @@ class MASTER(_MASTER, Model):
         """
         # Input length : number of timesteps
         input_len = tf.shape(model_output)[1]
-        # Add one for additional <eos> token
+        # Add one for additional <eos> token (sos disappear in shift!)
         seq_len = tf.cast(seq_len, tf.int32) + 1
         # One-hot gt labels
         oh_gt = tf.one_hot(gt, depth=model_output.shape[2])
-        # Compute loss
-        cce = tf.nn.softmax_cross_entropy_with_logits(oh_gt, model_output)
+        # Compute loss: don't forget to shift gt! Otherwise the model learns to output the gt[t-1]!
+        # The "masked" first gt char is <sos>. Delete last logit of the model output.
+        cce = tf.nn.softmax_cross_entropy_with_logits(oh_gt[:, 1:, :], model_output[:, :-1, :])
         # Compute mask
         mask_values = tf.zeros_like(cce)
-        mask_2d = tf.sequence_mask(seq_len, input_len)
+        mask_2d = tf.sequence_mask(seq_len, input_len - 1)  # delete the last mask timestep as well
         masked_loss = tf.where(mask_2d, cce, mask_values)
         ce_loss = tf.math.divide(tf.reduce_sum(masked_loss, axis=1), tf.cast(seq_len, tf.float32))
 
@@ -265,6 +266,7 @@ class MASTER(_MASTER, Model):
         target: Optional[List[str]] = None,
         return_model_output: bool = False,
         return_preds: bool = False,
+        training: bool = True,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Call function for training
@@ -290,6 +292,9 @@ class MASTER(_MASTER, Model):
         if target is not None:
             # Compute target: tensor of gts and sequence lengths
             gt, seq_len = self.compute_target(target)
+
+        if training:
+            assert target is not None
             tgt_mask = self.make_mask(gt)
             # Compute logits
             output = self.decoder(gt, encoded, tgt_mask, None, training=True)
@@ -298,7 +303,12 @@ class MASTER(_MASTER, Model):
             out['loss'] = self.compute_loss(logits, gt, seq_len)
 
         else:
+            # When not training, we want to compute logits in with the decoder, although
+            # we have access to gts (we need gts to compute the loss, but not in the decoder)
             _, logits = self.decode(encoded)
+
+            if target is not None:
+                out['loss'] = self.compute_loss(logits, gt, seq_len)
 
         if return_model_output:
             out['out_map'] = logits
@@ -309,7 +319,6 @@ class MASTER(_MASTER, Model):
 
         return out
 
-    @tf.function
     def decode(self, encoded: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
         """Decode function for prediction
 
@@ -321,22 +330,21 @@ class MASTER(_MASTER, Model):
         """
         b = tf.shape(encoded)[0]
         max_len = tf.constant(self.max_length, dtype=tf.int32)
-        start_symbol = tf.constant(self.vocab_size + 1, dtype=tf.int32)  # SOS (EOS = vocab_size)
-        padding_symbol = tf.constant(self.vocab_size, dtype=tf.int32)
+        start_symbol = tf.constant(self.vocab_size + 1, dtype=tf.int32)  # SOS
+        padding_symbol = tf.constant(self.vocab_size + 2, dtype=tf.int32)  # PAD
 
         ys = tf.fill(dims=(b, max_len - 1), value=padding_symbol)
         start_vector = tf.fill(dims=(b, 1), value=start_symbol)
         ys = tf.concat([start_vector, ys], axis=-1)
 
-        final_logits = tf.zeros(shape=(b, max_len - 1, self.vocab_size + 1), dtype=tf.float32)  # don't fgt EOS
-        # max_len = len + 2
+        final_logits = tf.zeros(shape=(b, max_len - 1, self.vocab_size + 3), dtype=tf.float32)  # 3 symbols
+        # max_len = len + 2 (sos + eos)
         for i in range(self.max_length - 1):
             ys_mask = self.make_mask(ys)
             output = self.decoder(ys, encoded, ys_mask, None, training=False)
             logits = self.linear(output)
             prob = tf.nn.softmax(logits, axis=-1)
             next_word = tf.argmax(prob, axis=-1, output_type=ys.dtype)
-
             # ys.shape = B, T
             i_mesh, j_mesh = tf.meshgrid(tf.range(b), tf.range(max_len), indexing='ij')
             indices = tf.stack([i_mesh[:, i + 1], j_mesh[:, i + 1]], axis=1)
@@ -346,7 +354,8 @@ class MASTER(_MASTER, Model):
             if i == (self.max_length - 2):
                 final_logits = logits
 
-        # ys predictions of shape B x max_length, final_logits of shape B x max_length x vocab_size + 1
+        # ys predictions of shape B x max_length (including sos)
+        # final_logits of shape B x max_length - 1 x vocab_size + 1 (whithout sos)
         return ys, final_logits
 
 

--- a/doctr/models/recognition/transformer/pytorch.py
+++ b/doctr/models/recognition/transformer/pytorch.py
@@ -46,7 +46,7 @@ class Decoder(nn.Module):
         self.d_model = d_model
         self.num_layers = num_layers
 
-        self.embedding = nn.Embedding(vocab_size + 2, d_model)  # 2 more classes EOS/SOS
+        self.embedding = nn.Embedding(vocab_size + 3, d_model)  # 3 more classes EOS/SOS/PAD
         self.pos_encoding = positional_encoding(maximum_position_encoding, d_model)
 
         self.dec_layers = [

--- a/doctr/models/recognition/transformer/tensorflow.py
+++ b/doctr/models/recognition/transformer/tensorflow.py
@@ -210,7 +210,7 @@ class Decoder(tf.keras.layers.Layer):
         self.d_model = d_model
         self.num_layers = num_layers
 
-        self.embedding = tf.keras.layers.Embedding(vocab_size + 2, d_model)  # 2 more classes EOS/SOS
+        self.embedding = tf.keras.layers.Embedding(vocab_size + 3, d_model)  # 3 more classes EOS/SOS/PAD
         self.pos_encoding = positional_encoding(maximum_position_encoding, d_model)
 
         self.dec_layers = [DecoderLayer(d_model, num_heads, dff)

--- a/doctr/models/recognition/transformer/tensorflow.py
+++ b/doctr/models/recognition/transformer/tensorflow.py
@@ -7,7 +7,7 @@
 # https://www.tensorflow.org/text/tutorials/transformer
 
 
-from typing import Tuple
+from typing import Tuple, Any
 
 import tensorflow as tf
 import numpy as np
@@ -124,12 +124,20 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         x = tf.reshape(x, (batch_size, -1, self.num_heads, self.depth))
         return tf.transpose(x, perm=[0, 2, 1, 3])
 
-    def call(self, v: tf.Tensor, k: tf.Tensor, q: tf.Tensor, mask: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
+    def call(
+        self,
+        v: tf.Tensor,
+        k: tf.Tensor,
+        q: tf.Tensor,
+        mask: tf.Tensor,
+        **kwargs: Any,
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
+
         batch_size = tf.shape(q)[0]
 
-        q = self.wq(q)  # (batch_size, seq_len, d_model)
-        k = self.wk(k)  # (batch_size, seq_len, d_model)
-        v = self.wv(v)  # (batch_size, seq_len, d_model)
+        q = self.wq(q, **kwargs)  # (batch_size, seq_len, d_model)
+        k = self.wk(k, **kwargs)  # (batch_size, seq_len, d_model)
+        v = self.wv(v, **kwargs)  # (batch_size, seq_len, d_model)
 
         q = self.split_heads(q, batch_size)  # (batch_size, num_heads, seq_len_q, depth)
         k = self.split_heads(k, batch_size)  # (batch_size, num_heads, seq_len_k, depth)
@@ -144,7 +152,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         concat_attention = tf.reshape(scaled_attention,
                                       (batch_size, -1, self.d_model))  # (batch_size, seq_len_q, d_model)
 
-        output = self.dense(concat_attention)  # (batch_size, seq_len_q, d_model)
+        output = self.dense(concat_attention, **kwargs)  # (batch_size, seq_len_q, d_model)
 
         return output
 
@@ -176,20 +184,20 @@ class DecoderLayer(tf.keras.layers.Layer):
         self,
         x: tf.Tensor,
         enc_output: tf.Tensor,
-        training: bool,
         look_ahead_mask: tf.Tensor,
-        padding_mask: tf.Tensor
+        padding_mask: tf.Tensor,
+        **kwargs: Any,
     ) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
         # enc_output.shape == (batch_size, input_seq_len, d_model)
 
-        attn1 = self.mha1(x, x, x, look_ahead_mask)  # (batch_size, target_seq_len, d_model)
-        out1 = self.layernorm1(attn1 + x)
+        attn1 = self.mha1(x, x, x, look_ahead_mask, **kwargs)  # (batch_size, target_seq_len, d_model)
+        out1 = self.layernorm1(attn1 + x, **kwargs)
 
-        attn2 = self.mha2(enc_output, enc_output, out1, padding_mask)  # (batch_size, target_seq_len, d_model)
-        out2 = self.layernorm2(attn2 + out1)  # (batch_size, target_seq_len, d_model)
+        attn2 = self.mha2(enc_output, enc_output, out1, padding_mask, **kwargs)  # (batch_size, target_seq_len, d_model)
+        out2 = self.layernorm2(attn2 + out1, **kwargs)  # (batch_size, target_seq_len, d_model)
 
-        ffn_output = self.ffn(out2)  # (batch_size, target_seq_len, d_model)
-        out3 = self.layernorm3(ffn_output + out2)  # (batch_size, target_seq_len, d_model)
+        ffn_output = self.ffn(out2, **kwargs)  # (batch_size, target_seq_len, d_model)
+        out3 = self.layernorm3(ffn_output + out2, **kwargs)  # (batch_size, target_seq_len, d_model)
 
         return out3
 
@@ -222,18 +230,18 @@ class Decoder(tf.keras.layers.Layer):
         enc_output: tf.Tensor,
         look_ahead_mask: tf.Tensor,
         padding_mask: tf.Tensor,
-        training: bool = False,
+        **kwargs: Any,
     ) -> Tuple[tf.Tensor, tf.Tensor]:
 
         seq_len = tf.shape(x)[1]
 
-        x = self.embedding(x)  # (batch_size, target_seq_len, d_model)
+        x = self.embedding(x, **kwargs)  # (batch_size, target_seq_len, d_model)
         x *= tf.math.sqrt(tf.cast(self.d_model, tf.float32))
         x += self.pos_encoding[:, :seq_len, :]
 
         for i in range(self.num_layers):
             x = self.dec_layers[i](
-                x, enc_output, training, look_ahead_mask, padding_mask
+                x, enc_output, look_ahead_mask, padding_mask, **kwargs
             )
 
         # x.shape == (batch_size, target_seq_len, d_model)

--- a/test/pytorch/test_models_recognition.py
+++ b/test/pytorch/test_models_recognition.py
@@ -51,9 +51,9 @@ def test_master(mock_vocab, max_len=50, batch_size=4):
     target = ["i", "am", "a", "jedi"]
     logits = master(input_tensor, target, return_model_output=True)['out_map']
     assert isinstance(logits, torch.Tensor)
-    assert logits.shape == (batch_size, max_len, 1 + len(mock_vocab))  # 1 more for EOS
+    assert logits.shape == (batch_size, max_len, 3 + len(mock_vocab))
     prediction, logits = master.decode(input_tensor)
     assert isinstance(prediction, torch.Tensor)
     assert isinstance(logits, torch.Tensor)
     assert prediction.shape == (batch_size, max_len)
-    assert logits.shape == (batch_size, max_len, 1 + len(mock_vocab))
+    assert logits.shape == (batch_size, max_len, 3 + len(mock_vocab))

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -56,6 +56,5 @@ def test_encode_sequences(sequences, vocab, target_size, eos, sos, pad, error, o
     else:
         out = utils.encode_sequences(sequences, vocab, target_size, eos, sos, pad)
         assert isinstance(out, np.ndarray)
-        print(out)
         assert out.shape == out_shape
         assert np.all(out == np.asarray(gts)), print(out, gts)

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -38,22 +38,24 @@ def test_encode_decode(input_str):
 
 
 @pytest.mark.parametrize(
-    "sequences, vocab, target_size, eos, sos, error, out_shape, gts",
+    "sequences, vocab, target_size, eos, sos, pad, error, out_shape, gts",
     [
-        [['cba'], 'abcdef', None, 1, None, True, (1, 3), [[2, 1, 0]]],
-        [['cba', 'a'], 'abcdef', None, -1, None, False, (2, 3), [[2, 1, 0], [0, -1, -1]]],
-        [['cba', 'a'], 'abcdef', None, 6, None, False, (2, 3), [[2, 1, 0], [0, 6, 6]]],
-        [['cba', 'a'], 'abcdef', 2, -1, None, False, (2, 2), [[2, 1], [0, -1]]],
-        [['cba', 'a'], 'abcdef', 4, -1, None, False, (2, 4), [[2, 1, 0, -1], [0, -1, -1, -1]]],
-        [['cba', 'a'], 'abcdef', 5, -1, 7, False, (2, 5), [[7, 2, 1, 0, -1], [7, 0, -1, -1, -1]]],
+        [['cba'], 'abcdef', None, 1, None, None, True, (1, 3), [[2, 1, 0]]],
+        [['cba', 'a'], 'abcdef', None, -1, None, None, False, (2, 3), [[2, 1, 0], [0, -1, -1]]],
+        [['cba', 'a'], 'abcdef', None, 6, None, None, False, (2, 3), [[2, 1, 0], [0, 6, 6]]],
+        [['cba', 'a'], 'abcdef', 2, -1, None, None, False, (2, 2), [[2, 1], [0, -1]]],
+        [['cba', 'a'], 'abcdef', 4, -1, None, None, False, (2, 4), [[2, 1, 0, -1], [0, -1, -1, -1]]],
+        [['cba', 'a'], 'abcdef', 5, -1, 7, None, False, (2, 5), [[7, 2, 1, 0, -1], [7, 0, -1, -1, -1]]],
+        [['cba', 'a'], 'abcdef', None, -1, 7, 9, False, (2, 5), [[7, 2, 1, 0, -1], [7, 0, -1, 9, 9]]],
     ],
 )
-def test_encode_sequences(sequences, vocab, target_size, eos, sos, error, out_shape, gts):
+def test_encode_sequences(sequences, vocab, target_size, eos, sos, pad, error, out_shape, gts):
     if error:
         with pytest.raises(ValueError):
-            _ = utils.encode_sequences(sequences, vocab, target_size, eos, sos)
+            _ = utils.encode_sequences(sequences, vocab, target_size, eos, sos, pad)
     else:
-        out = utils.encode_sequences(sequences, vocab, target_size, eos, sos)
+        out = utils.encode_sequences(sequences, vocab, target_size, eos, sos, pad)
         assert isinstance(out, np.ndarray)
+        print(out)
         assert out.shape == out_shape
         assert np.all(out == np.asarray(gts)), print(out, gts)


### PR DESCRIPTION
MASTER model was not trained properly due to a misalignment in the loss function, this is now fixed. More precisely:

- Loss function is updated (right shift for gt sequences)
- `encode_sequences` is  improved to support not only `EOS` but also `SOS` and `PAD` symbols, which are mandatory to train MASTER (`SOS` to shift gt to the right, and `PAD` because we need to mask where `PAD` in the loss but nos `EOS`). It is important to note that default behavior of this function is NOT modified, when pad and sos arguments are left to `None`, the function still pad with `EOS` at the end of each sequence. When `PAD` is provided, sequences are concatenated with `EOS` before adding `PAD` to fill the matrix.
- Updated corresponding unitests.
- When gt are given in the call, but `training=False`, the model is now using the prediction decoder to compute the loss, instead of using gts to feed the decoder. This is a more accurate way to evaluate the model and to be sure that we are training the model 'properly': we can check at evaluation time if it is able to predict _from the images only_ the right labels.

Any feedback is welcome!