### PR TITLE
refactor: Cleaned import and typing annotations

### DIFF
--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -81,7 +81,7 @@ class CORD(VisionDataset):
 
             self.data.append((
                 img_path,
-                dict(boxes=np.asarray(box_targets, dtype=np.int).clip(min=0), labels=text_targets)
+                dict(boxes=np.asarray(box_targets, dtype=int).clip(min=0), labels=text_targets)
             ))
 
     def extra_repr(self) -> str:

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -71,7 +71,7 @@ class FUNSD(VisionDataset):
                     ] for box in box_targets
                 ]
 
-            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=np.int), labels=text_targets)))
+            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=int), labels=text_targets)))
 
     def extra_repr(self) -> str:
         return f"train={self.train}"

--- a/doctr/models/backbones/vgg/pytorch.py
+++ b/doctr/models/backbones/vgg/pytorch.py
@@ -5,7 +5,7 @@
 
 from torch import nn
 from torchvision.models import vgg as tv_vgg
-from typing import Tuple, Dict, Any
+from typing import Dict, Any
 
 from ...utils import load_pretrained_params
 

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -114,7 +114,7 @@ class _LinkNet(DetectionModel):
         else:
             seg_target = np.zeros(output_shape, dtype=bool)
             edge_mask = np.zeros(output_shape, dtype=bool)
-        seg_mask = np.ones(output_shape, dtype=np.bool)
+        seg_mask = np.ones(output_shape, dtype=bool)
 
         for idx, _target in enumerate(target):
             # Draw each polygon on gt

--- a/doctr/models/preprocessor/pytorch.py
+++ b/doctr/models/preprocessor/pytorch.py
@@ -82,7 +82,7 @@ class PreProcessor(nn.Module):
             processed_batches = [x]
         elif isinstance(x, list):
             # Resize (and eventually pad) the inputs
-            images: List[torch.Tensor] = [self.resize(torch.from_numpy(sample).permute(2, 0, 1)) for sample in x]
+            images: List[torch.Tensor] = [self.resize(torch.from_numpy(sample.copy()).permute(2, 0, 1)) for sample in x]
             # Batch them
             processed_batches = self.batch_inputs(images)  # type: ignore[assignment]
         else:

--- a/doctr/models/recognition/core.py
+++ b/doctr/models/recognition/core.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-from typing import Tuple, List, Any, Optional, Dict
+from typing import Tuple, List, Any
 import numpy as np
 
 from ..preprocessor import PreProcessor

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -272,7 +272,7 @@ class MASTER(_MASTER, nn.Module):
 
         ys = torch.ones((b, self.max_length - 1), dtype=torch.long) * self.vocab_size  # padding symbol
         start_vector = torch.ones((b, 1), dtype=torch.long) * self.vocab_size + 1  # SOS
-        ys = torch.cat((start_vector, ys), axis=-1)
+        ys = torch.cat((start_vector, ys), dim=-1)
 
         final_logits = torch.zeros((b, self.max_length - 1, self.vocab_size + 1), dtype=torch.long)  # EOS
         # max_len = len + 2

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -47,9 +47,8 @@ class MAGC(nn.Module):
         inplanes: int,
         headers: int = 1,
         att_scale: bool = False,
-        **kwargs
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__()
 
         self.headers = headers  # h
         self.inplanes = inplanes  # C
@@ -67,7 +66,7 @@ class MAGC(nn.Module):
             nn.Conv2d(self.inplanes, self.inplanes, kernel_size=1)
         )
 
-    def forward(self, inputs: torch.Tensor, **kwargs) -> torch.Tensor:
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
 
         batch, _, height, width = inputs.size()
         # [N*headers, C', H , W] C = headers * C'
@@ -270,8 +269,8 @@ class MASTER(_MASTER, nn.Module):
         feature = feature.permute(0, 2, 1)  # shape (b, h*w, c)
         encoded = feature + self.feature_pe[:, :h * w, :]
 
-        ys = torch.ones((b, self.max_length - 1), dtype=torch.long) * self.vocab_size  # padding symbol
-        start_vector = torch.ones((b, 1), dtype=torch.long) * self.vocab_size + 1  # SOS
+        ys = torch.full((b, self.max_length - 1), self.vocab_size, dtype=torch.long)  # padding symbol
+        start_vector = torch.full((b, 1), self.vocab_size + 1, dtype=torch.long)  # SOS
         ys = torch.cat((start_vector, ys), dim=-1)
 
         final_logits = torch.zeros((b, self.max_length - 1, self.vocab_size + 1), dtype=torch.long)  # EOS

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -240,7 +240,7 @@ class MASTER(_MASTER, nn.Module):
 
         if target is not None:
             # Compute target: tensor of gts and sequence lengths
-            gt, seq_len = self.compute_target(target)
+            gt, _ = self.compute_target(target)
             tgt_mask = self.make_mask(torch.from_numpy(gt))
             # Compute logits
             output = self.decoder(torch.from_numpy(gt), encoded, tgt_mask, None)

--- a/doctr/models/recognition/transformer/pytorch.py
+++ b/doctr/models/recognition/transformer/pytorch.py
@@ -23,10 +23,10 @@ def positional_encoding(position: int, d_model: int = 512) -> torch.Tensor:
         2D positional encoding as described in Transformer paper.
     """
     pe = torch.zeros(position, d_model)
-    position = torch.arange(0, position, dtype=torch.float).unsqueeze(1)
+    pos = torch.arange(0, position, dtype=torch.float).unsqueeze(1)
     div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
-    pe[:, 0::2] = torch.sin(position * div_term)
-    pe[:, 1::2] = torch.cos(position * div_term)
+    pe[:, 0::2] = torch.sin(pos * div_term)
+    pe[:, 1::2] = torch.cos(pos * div_term)
     return pe.unsqueeze(0)
 
 
@@ -65,7 +65,7 @@ class Decoder(nn.Module):
         enc_output: torch.Tensor,
         look_ahead_mask: torch.Tensor,
         padding_mask: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
 
         seq_len = x.shape[1]  # Batch first = True
 

--- a/doctr/transforms/modules/tensorflow.py
+++ b/doctr/transforms/modules/tensorflow.py
@@ -8,7 +8,6 @@ import tensorflow as tf
 from typing import List, Any, Tuple, Callable
 
 from doctr.utils.repr import NestedObject
-from .. import functional as F
 
 
 __all__ = ['Compose', 'Resize', 'Normalize', 'LambdaTransformation', 'ToGray', 'RandomBrightness',


### PR DESCRIPTION
This PR introduces the following modifications:
- silenced numpy & pytorch dtype warnings
- removed unused imports and variables
- fixed MASTER forward tensor concatenation
- fixed typing annotations in MASTER & transformer

Any feedback is welcome!