### PR TITLE
feat: Added PyTorch & torchvision to environment collection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,8 @@ python collect_env.py
 ```
 
  - DocTR Version (e.g., 0.1.0):
- - TensorFlow Version (e.g., 2.4.0):
+ - TensorFlow Version (e.g., 2.5.0):
+ - PyTorch & torchvision versions (e.g., 1.8.0 & 0.9.0):
  - OpenCV Version (e.g., 4.5.1):
  - OS (e.g., Linux):
  - How you installed DocTR (`conda`, `pip`, source):


### PR DESCRIPTION
This PR extends the scope of environment collection to PyTorch and Torchvision and updates the issue template accordingly.

Running
```shell
python scripts/collect_env.py
```

yields something similar to :
```shell
Collecting environment information...

DocTR version: 0.3.0a0
TensorFlow version: 2.5.0
PyTorch version: 1.8.0 (torchvision: 0.9.0)
OpenCV version: 4.5.1
OS: Ubuntu 20.04.2 LTS
Python version: 3.8
Is CUDA available (TensorFlow): No
Is CUDA available (PyTorch): No
CUDA runtime version: 11.2.152
GPU models and configuration: Could not collect
Nvidia driver version: Could not collect
cuDNN version: Probably one of the following:
/usr/lib/x86_64-linux-gnu/libcudnn.so.8.2.0
/usr/lib/x86_64-linux-gnu/libcudnn_adv_infer.so.8.2.0
/usr/lib/x86_64-linux-gnu/libcudnn_adv_train.so.8.2.0
/usr/lib/x86_64-linux-gnu/libcudnn_cnn_infer.so.8.2.0
/usr/lib/x86_64-linux-gnu/libcudnn_cnn_train.so.8.2.0
/usr/lib/x86_64-linux-gnu/libcudnn_ops_infer.so.8.2.0
/usr/lib/x86_64-linux-gnu/libcudnn_ops_train.so.8.2.0
```

now

Any feedback is welcome!