### PR TITLE
refactor: Renamed MASTER feature extractor attribute

### DIFF
--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -183,7 +183,7 @@ class MASTER(_MASTER, nn.Module):
         self.vocab_size = len(vocab)
         self.num_heads = num_heads
 
-        self.feature_extractor = MAGCResnet(headers=headers)
+        self.feat_extractor = MAGCResnet(headers=headers)
         self.seq_embedding = nn.Embedding(self.vocab_size + 3, d_model)  # 3 more for EOS/SOS/PAD
 
         self.decoder = Decoder(
@@ -266,7 +266,7 @@ class MASTER(_MASTER, nn.Module):
         """
 
         # Encode
-        feature = self.feature_extractor(x, **kwargs)
+        feature = self.feat_extractor(x, **kwargs)
         b, c, h, w = (feature.size(i) for i in range(4))
         feature = torch.reshape(feature, shape=(b, c, h * w))
         feature = feature.permute(0, 2, 1)  # shape (b, h*w, c)

--- a/doctr/models/recognition/master/tensorflow.py
+++ b/doctr/models/recognition/master/tensorflow.py
@@ -206,7 +206,7 @@ class MASTER(_MASTER, Model):
         self.cfg = cfg
         self.vocab_size = len(vocab)
 
-        self.feature_extractor = MAGCResnet(headers=headers, input_shape=input_shape)
+        self.feat_extractor = MAGCResnet(headers=headers, input_shape=input_shape)
         self.seq_embedding = layers.Embedding(self.vocab_size + 3, d_model)  # 3 more classes: EOS/PAD/SOS
 
         self.decoder = Decoder(
@@ -284,7 +284,7 @@ class MASTER(_MASTER, Model):
         """
 
         # Encode
-        feature = self.feature_extractor(x, **kwargs)
+        feature = self.feat_extractor(x, **kwargs)
         b, h, w, c = (tf.shape(feature)[i] for i in range(4))
         feature = tf.reshape(feature, shape=(b, h * w, c))
         encoded = feature + self.feature_pe[:, :h * w, :]


### PR DESCRIPTION
This PR simply renames the `feature_extractor` attribute to `feat_extractor` to keep the same naming conventions across models.

Any feedback is welcome!