### PR TITLE
feat: add rotate in transforms

### DIFF
--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -9,7 +9,7 @@ from math import floor
 from typing import List
 from statistics import median_low
 
-__all__ = ['estimate_orientation', 'extract_crops', 'extract_rcrops', 'rotate_page', 'get_bitmap_angle', 'rotate_boxes']
+__all__ = ['estimate_orientation', 'extract_crops', 'extract_rcrops', 'rotate_page', 'get_bitmap_angle']
 
 
 def extract_crops(img: np.ndarray, boxes: np.ndarray) -> List[np.ndarray]:
@@ -199,37 +199,3 @@ def get_bitmap_angle(bitmap: np.ndarray, n_ct: int = 20, std_max: float = 3.) ->
             angle = 90 + angle
 
     return angle
-
-
-def rotate_boxes(
-    boxes: np.ndarray,
-    angle: float = 0.,
-    min_angle: float = 1.
-) -> np.ndarray:
-    """Rotate a batch of straight bounding boxes (xmin, ymin, xmax, ymax) of an angle,
-    if angle > min_angle, around the center of the page.
-
-    Args:
-        boxes: (N, 4) array of (relative) boxes
-        angle: angle between -90 and +90 degrees
-        min_angle: minimum angle to rotate boxes
-
-    Returns:
-        A batch of rotated boxes (N, 5): (x, y, w, h, alpha) or a batch of straight bounding boxes
-    """
-    # If small angle, return boxes (no rotation)
-    if abs(angle) < min_angle or abs(angle) > 90 - min_angle:
-        return boxes
-    # Compute rotation matrix
-    angle_rad = angle * np.pi / 180.  # compute radian angle for np functions
-    rotation_mat = np.array([[np.cos(angle_rad), -np.sin(angle_rad)], [np.sin(angle_rad), np.cos(angle_rad)]])
-    # Compute unrotated boxes
-    x_unrotated, y_unrotated = (boxes[:, 0] + boxes[:, 2]) / 2, (boxes[:, 1] + boxes[:, 3]) / 2
-    width, height = boxes[:, 2] - boxes[:, 0], boxes[:, 3] - boxes[:, 1]
-    # Rotate centers
-    centers = np.stack((x_unrotated, y_unrotated), axis=-1)
-    rotated_centers = .5 + np.matmul(centers - .5, np.transpose(rotation_mat))
-    x_center, y_center = rotated_centers[:, 0], rotated_centers[:, 1]
-    # Compute rotated boxes
-    rotated_boxes = np.stack((x_center, y_center, width, height, angle * np.ones_like(boxes[:, 0])), axis=1)
-    return rotated_boxes

--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -9,10 +9,10 @@ from scipy.cluster.hierarchy import fclusterdata
 from typing import List, Any, Tuple, Dict
 from .detection import DetectionPredictor
 from .recognition import RecognitionPredictor
-from ._utils import extract_crops, extract_rcrops, rotate_page, rotate_boxes
+from ._utils import extract_crops, extract_rcrops, rotate_page
 from doctr.documents.elements import Word, Line, Block, Page, Document
 from doctr.utils.repr import NestedObject
-from doctr.utils.geometry import resolve_enclosing_bbox, resolve_enclosing_rbbox
+from doctr.utils.geometry import resolve_enclosing_bbox, resolve_enclosing_rbbox, rotate_boxes
 
 __all__ = ['OCRPredictor', 'DocumentBuilder']
 

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -271,7 +271,7 @@ class _DBNet:
             abs_boxes[:, [1, 3]] *= output_shape[-2]
             abs_boxes = abs_boxes.round().astype(np.int32)
 
-            if self.rotated_bbox:
+            if self.rotated_bbox or abs_boxes.shape[1] == 5:
                 boxes_size = np.minimum(abs_boxes[:, 2], abs_boxes[:, 3])
                 polys = np.stack([
                     rbbox_to_polygon(tuple(rbbox)) for rbbox in abs_boxes  # type: ignore[arg-type]

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -271,7 +271,7 @@ class _DBNet:
             abs_boxes[:, [1, 3]] *= output_shape[-2]
             abs_boxes = abs_boxes.round().astype(np.int32)
 
-            if self.rotated_bbox or abs_boxes.shape[1] == 5:
+            if abs_boxes.shape[1] == 5:
                 boxes_size = np.minimum(abs_boxes[:, 2], abs_boxes[:, 3])
                 polys = np.stack([
                     rbbox_to_polygon(tuple(rbbox)) for rbbox in abs_boxes  # type: ignore[arg-type]

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -128,7 +128,7 @@ class _LinkNet(DetectionModel):
             abs_boxes[:, [1, 3]] *= output_shape[-2]
             abs_boxes = abs_boxes.round().astype(np.int32)
 
-            if self.rotated_bbox or abs_boxes.shape[1] == 5:
+            if abs_boxes.shape[1] == 5:
                 boxes_size = np.minimum(abs_boxes[:, 2], abs_boxes[:, 3])
                 polys = np.stack([
                     rbbox_to_polygon(tuple(rbbox)) for rbbox in abs_boxes  # type: ignore[arg-type]

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -128,7 +128,7 @@ class _LinkNet(DetectionModel):
             abs_boxes[:, [1, 3]] *= output_shape[-2]
             abs_boxes = abs_boxes.round().astype(np.int32)
 
-            if self.rotated_bbox:
+            if self.rotated_bbox or abs_boxes.shape[1] == 5:
                 boxes_size = np.minimum(abs_boxes[:, 2], abs_boxes[:, 3])
                 polys = np.stack([
                     rbbox_to_polygon(tuple(rbbox)) for rbbox in abs_boxes  # type: ignore[arg-type]

--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -5,9 +5,11 @@
 
 import torch
 from torchvision.transforms import functional as F
+import numpy as np
+from typing import Dict, Tuple
+from doctr.utils.geometry import rotate_boxes
 
-
-__all__ = ["invert_colors"]
+__all__ = ["invert_colors", "rotate"]
 
 
 def invert_colors(img: torch.Tensor, min_val: float = 0.6) -> torch.Tensor:
@@ -23,3 +25,35 @@ def invert_colors(img: torch.Tensor, min_val: float = 0.6) -> torch.Tensor:
     # Inverse the color
     out = 255 - out if out.dtype == torch.uint8 else 1 - out
     return out
+
+
+def rotate(
+    img: torch.Tensor,
+    target: Dict[str, np.ndarray],
+    angle: float
+) -> Tuple[torch.Tensor, Dict[str, np.ndarray]]:
+    """Rotate image around the center, interpolation=NEAREST, pad with 0 (black)
+
+    Args:
+        img: image to rotate
+        target: dict with array of boxes to rotate as well, and array of flags
+        angle: angle in degrees. +: counter-clockwise, -: clockwise
+
+    Returns:
+        A tuple of rotated img (tensor), rotated target (dict)
+    """
+    rotated_img = F.rotate(img, angle=angle, fill=0)  # Interpolation NEAREST by default
+    boxes = target["boxes"]
+    if target["boxes"].dtype == int:
+        # Compute relative boxes
+        boxes = boxes.astype(float)
+        boxes[:, [0, 2]] = boxes[:, [0, 2]] / img.shape[2]
+        boxes[:, [1, 3]] = boxes[:, [1, 3]] / img.shape[1]
+    # Compute rotated bboxes: xmin, ymin, xmax, ymax --> x, y, w, h, alpha
+    r_boxes = rotate_boxes(boxes, angle=angle, min_angle=1)
+    if target["boxes"].dtype == int:
+        # Back to absolute boxes
+        r_boxes[:, [0, 2]] *= img.shape[2]
+        r_boxes[:, [1, 3]] *= img.shape[1]
+    target["boxes"] = r_boxes
+    return rotated_img, target

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -4,9 +4,12 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import tensorflow as tf
+import tensorflow_addons as tfa
+import numpy as np
+from typing import Tuple, Dict
+from doctr.utils.geometry import rotate_boxes
 
-
-__all__ = ["invert_colors"]
+__all__ = ["invert_colors", "rotate"]
 
 
 def invert_colors(img: tf.Tensor, min_val: float = 0.6) -> tf.Tensor:
@@ -22,3 +25,35 @@ def invert_colors(img: tf.Tensor, min_val: float = 0.6) -> tf.Tensor:
     # Inverse the color
     out = 255 - out if out.dtype == tf.uint8 else 1 - out
     return out
+
+
+def rotate(
+    img: tf.Tensor,
+    target: Dict[str, np.ndarray],
+    angle: float
+) -> Tuple[tf.Tensor, Dict[str, np.ndarray]]:
+    """Rotate image around the center, interpolation=NEAREST, pad with 0 (black)
+
+    Args:
+        img: image to rotate
+        target: dict with array of boxes to rotate as well, and array of flags
+        angle: angle in degrees. +: counter-clockwise, -: clockwise
+
+    Returns:
+        A tuple of rotated img (tensor), rotated target (dict)
+    """
+    rotated_img = tfa.image.rotate(img, angles=angle, fill_value=0.0)  # Interpolation NEAREST by default
+    boxes = target["boxes"]
+    if target["boxes"].dtype == int:
+        # Compute relative boxes
+        boxes = boxes.astype(float)
+        boxes[:, [0, 2]] = boxes[:, [0, 2]] / img.shape[1]
+        boxes[:, [1, 3]] = boxes[:, [1, 3]] / img.shape[0]
+    # Compute rotated bboxes: xmin, ymin, xmax, ymax --> x, y, w, h, alpha
+    r_boxes = rotate_boxes(boxes, angle=angle, min_angle=1)
+    if target["boxes"].dtype == int:
+        # Back to absolute boxes
+        r_boxes[:, [0, 2]] *= img.shape[1]
+        r_boxes[:, [1, 3]] *= img.shape[0]
+    target["boxes"] = r_boxes
+    return rotated_img, target

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ unidecode>=1.0.0
 tensorflow>=2.4.0
 Pillow>=8.0.0
 tqdm>=4.30.0
+tensorflow-addons>=0.13.0

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,8 @@ install_requires = [
 ]
 
 extras = {}
-extras["tf"] = deps_list("tensorflow")
-extras["tf-cpu"] = deps_list("tensorflow-cpu")
-extras["tfa"] = deps_list("tensorflow-addons")
+extras["tf"] = deps_list("tensorflow", "tensorflow-addons")
+extras["tf-cpu"] = deps_list("tensorflow-cpu", "tensorflow-addons")
 extras["torch"] = deps_list("torch", "torchvision")
 extras["all"] = (
     extras["tf"]

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ _deps = [
     "torchvision>=0.9.0",
     "Pillow>=8.0.0",
     "tqdm>=4.30.0",
+    "tensorflow-addons>=0.13.0"
 ]
 
 deps = {b: a for a, b in (re.findall(r"^(([^!=<>]+)(?:[!=<>].*)?$)", x)[0] for x in _deps)}
@@ -84,6 +85,7 @@ install_requires = [
 extras = {}
 extras["tf"] = deps_list("tensorflow")
 extras["tf-cpu"] = deps_list("tensorflow-cpu")
+extras["tfa"] = deps_list("tensorflow-addons")
 extras["torch"] = deps_list("torch", "torchvision")
 extras["all"] = (
     extras["tf"]

--- a/test/common/test_models.py
+++ b/test/common/test_models.py
@@ -157,17 +157,3 @@ def test_estimate_orientation(mock_image):
 def test_rotate_page(mock_bitmap):
     rotated = models.rotate_page(mock_bitmap, -30.)
     assert abs(models.get_bitmap_angle(rotated) - 0.) < 1.
-
-
-def test_rotate_boxes():
-    boxes = np.array([[0.1, 0.1, 0.8, 0.3]])
-    # Angle = 0
-    rotated = models.rotate_boxes(boxes, angle=0.)
-    assert rotated.all() == boxes.all()
-    # Angle < 1:
-    rotated = models.rotate_boxes(boxes, angle=0.5)
-    assert rotated.all() == boxes.all()
-    # Angle = 30
-    rotated = models.rotate_boxes(boxes, angle=30)
-    assert rotated.shape == (1, 5)
-    assert rotated[0, 4] == 30.

--- a/test/common/test_utils_geometry.py
+++ b/test/common/test_utils_geometry.py
@@ -32,3 +32,17 @@ def test_resolve_enclosing_rbbox():
     pred = geometry.resolve_enclosing_rbbox([(.2, .2, .05, .05, 0), (.2, .2, .2, .2, 0)])[:4]
     target = (.2, .2, .2, .2)
     assert all(abs(i - j) <= 1e-7 for (i, j) in zip(pred, target))
+
+
+def test_rotate_boxes():
+    boxes = np.array([[0.1, 0.1, 0.8, 0.3]])
+    # Angle = 0
+    rotated = geometry.rotate_boxes(boxes, angle=0.)
+    assert rotated.all() == boxes.all()
+    # Angle < 1:
+    rotated = geometry.rotate_boxes(boxes, angle=0.5)
+    assert rotated.all() == boxes.all()
+    # Angle = 30
+    rotated = geometry.rotate_boxes(boxes, angle=30)
+    assert rotated.shape == (1, 5)
+    assert rotated[0, 4] == 30.

--- a/test/pytorch/test_transforms_pt.py
+++ b/test/pytorch/test_transforms_pt.py
@@ -2,7 +2,9 @@ import pytest
 
 import math
 import torch
+import numpy as np
 from doctr.transforms import Resize, ColorInversion
+from doctr.transforms.functional import rotate
 
 
 def test_resize():
@@ -61,3 +63,21 @@ def test_invert_colorize(rgb_min):
     out = transfo(input_t)
     assert torch.all(out <= int(math.ceil(255 * (1 - rgb_min + 1e-4))))
     assert torch.all(out >= 0)
+
+
+def test_rotate():
+    input_t = torch.ones((3, 50, 50), dtype=torch.float32)
+    boxes = np.array([
+        [15, 20, 35, 30]
+    ])
+    target = {"boxes": boxes}
+    r_img, r_target = rotate(input_t, target, angle=12.)
+    assert r_img.shape == (3, 50, 50)
+    assert r_img[0, 0, 0] == 0.
+    assert r_target["boxes"].all() == np.array([[25., 25., 20., 10., 12.]]).all()
+    rel_boxes = np.array([
+        [.3, .4, .7, .6]
+    ])
+    target = {"boxes": rel_boxes}
+    r_img, r_target = rotate(input_t, target, angle=12.)
+    assert r_target["boxes"].all() == np.array([[.5, .5, .4, .2, 12.]]).all()

--- a/test/tensorflow/test_transforms_tf.py
+++ b/test/tensorflow/test_transforms_tf.py
@@ -1,8 +1,9 @@
 import pytest
 import math
-
+import numpy as np
 import tensorflow as tf
 from doctr import transforms as T
+from doctr.transforms.functional import rotate
 
 
 def test_resize():
@@ -190,3 +191,21 @@ def test_randomapply():
     input_t = tf.cast(tf.fill([8, 32, 32, 3], 2.), dtype=tf.float32)
     out = T.RandomApply(transfo, p=1.)(input_t)
     assert (tf.reduce_all(out >= 1.6) and tf.reduce_all(out <= 4.))
+
+
+def test_rotate():
+    input_t = tf.ones((50, 50, 3), dtype=tf.float32)
+    boxes = np.array([
+        [15, 20, 35, 30]
+    ])
+    target = {"boxes": boxes}
+    r_img, r_target = rotate(input_t, target, angle=12.)
+    assert r_img.shape == (50, 50, 3)
+    assert r_img[0, 0, 0] == 0.
+    assert r_target["boxes"].all() == np.array([[25., 25., 20., 10., 12.]]).all()
+    rel_boxes = np.array([
+        [.3, .4, .7, .6]
+    ])
+    target = {"boxes": rel_boxes}
+    r_img, r_target = rotate(input_t, target, angle=12.)
+    assert r_target["boxes"].all() == np.array([[.5, .5, .4, .2, 12.]]).all()


### PR DESCRIPTION
This PR adds a rotate functional transformation in both pt and tf transforms modules.
The function `rotate_boxes` is moved to `utils/geometry.py`, since it is no longer useful only for models (otherwise we need to deal with circular imports).
Updated unitests as well.

Any feedback is welcome!

linked to #352 