### PR TITLE
fix: Fixed recognition model PyTorch versions and added GPU compatibility

### DIFF
--- a/doctr/models/backbones/resnet/tensorflow.py
+++ b/doctr/models/backbones/resnet/tensorflow.py
@@ -120,7 +120,6 @@ class ResNet(Sequential):
         conv_seq: wether to add a conv_sequence after each stage
         pooling: pooling to add after each stage (if None, no pooling)
         input_shape: shape of inputs
-        include_top: whether the classifier head should be added
     """
 
     def __init__(
@@ -135,8 +134,6 @@ class ResNet(Sequential):
             Optional[Tuple[int, int]]
         ],
         input_shape: Tuple[int, int, int] = (640, 640, 3),
-        include_top: bool = False,
-
     ) -> None:
 
         _layers = [
@@ -150,8 +147,6 @@ class ResNet(Sequential):
                 _layers.extend(conv_sequence(out_channels, activation='relu', bn=True, kernel_size=3))
             if pool:
                 _layers.append(layers.MaxPool2D(pool_size=pool, strides=pool, padding='valid'))
-        if include_top:
-            raise NotImplementedError
         super().__init__(_layers)
 
 

--- a/doctr/models/backbones/vgg/tensorflow.py
+++ b/doctr/models/backbones/vgg/tensorflow.py
@@ -28,7 +28,6 @@ class VGG(Sequential):
         num_blocks: number of convolutional block in each stage
         planes: number of output channels in each stage
         rect_pools: whether pooling square kernels should be replace with rectangular ones
-        include_top: whether the classifier head should be added
         input_shape: shapes of the input tensor
     """
     def __init__(
@@ -36,7 +35,6 @@ class VGG(Sequential):
         num_blocks: Tuple[int, int, int, int, int],
         planes: Tuple[int, int, int, int, int],
         rect_pools: Tuple[bool, bool, bool, bool, bool],
-        include_top: bool = False,
         input_shape: Tuple[int, int, int] = (512, 512, 3),
     ) -> None:
 
@@ -48,8 +46,6 @@ class VGG(Sequential):
                 _layers.extend(conv_sequence(out_chan, 'relu', True, kernel_size=3, **kwargs))  # type: ignore[arg-type]
                 kwargs = {}
             _layers.append(layers.MaxPooling2D((2, 1 if rect_pool else 2)))
-        if include_top:
-            raise NotImplementedError
         super().__init__(_layers)
 
 

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -14,13 +14,21 @@ from ... import backbones
 from ..core import RecognitionModel, RecognitionPostProcessor
 from ....datasets import VOCABS
 
-__all__ = ['CRNN', 'crnn_vgg16_bn', 'CTCPostProcessor']
+__all__ = ['CRNN', 'crnn_vgg16_bn', 'crnn_resnet31', 'CTCPostProcessor']
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
     'crnn_vgg16_bn': {
         'mean': (.5, .5, .5),
         'std': (1., 1., 1.),
         'backbone': 'vgg16_bn', 'rnn_units': 128, 'lstm_features': 512,
+        'input_shape': (3, 32, 128),
+        'vocab': VOCABS['french'],
+        'url': None,
+    },
+    'crnn_resnet31': {
+        'mean': (.5, .5, .5),
+        'std': (1., 1., 1.),
+        'backbone': 'resnet31', 'rnn_units': 128, 'lstm_features': 4 * 512,
         'input_shape': (3, 32, 128),
         'vocab': VOCABS['french'],
         'url': None,
@@ -234,3 +242,24 @@ def crnn_vgg16_bn(pretrained: bool = False, **kwargs: Any) -> CRNN:
     """
 
     return _crnn('crnn_vgg16_bn', pretrained, **kwargs)
+
+
+def crnn_resnet31(pretrained: bool = False, **kwargs: Any) -> CRNN:
+    """CRNN with a ResNet-31 backbone as described in `"An End-to-End Trainable Neural Network for Image-based
+    Sequence Recognition and Its Application to Scene Text Recognition" <https://arxiv.org/pdf/1507.05717.pdf>`_.
+
+    Example::
+        >>> import torch
+        >>> from doctr.models import crnn_resnet31
+        >>> model = crnn_resnet31(pretrained=True)
+        >>> input_tensor = torch.rand(1, 3, 32, 128)
+        >>> out = model(input_tensor)
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
+
+    Returns:
+        text recognition architecture
+    """
+
+    return _crnn('crnn_resnet31', pretrained, **kwargs)

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -20,7 +20,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
     'crnn_vgg16_bn': {
         'mean': (.5, .5, .5),
         'std': (1., 1., 1.),
-        'backbone': 'vgg16_bn', 'rnn_units': 128,
+        'backbone': 'vgg16_bn', 'rnn_units': 128, 'lstm_features': 512,
         'input_shape': (3, 32, 128),
         'vocab': VOCABS['french'],
         'url': None,
@@ -103,6 +103,7 @@ class CRNN(RecognitionModel, nn.Module):
         self,
         feature_extractor: nn.Module,
         vocab: str,
+        lstm_features: int,
         rnn_units: int = 128,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -113,7 +114,7 @@ class CRNN(RecognitionModel, nn.Module):
         self.feat_extractor = feature_extractor
 
         self.decoder = nn.LSTM(
-            input_size=1 * 512, hidden_size=rnn_units, batch_first=True, num_layers=2, bidirectional=True
+            input_size=lstm_features, hidden_size=rnn_units, batch_first=True, num_layers=2, bidirectional=True
         )
 
         # features units = 2 * rnn_units because bidirectional layers
@@ -203,6 +204,7 @@ def _crnn(arch: str, pretrained: bool, input_shape: Optional[Tuple[int, int, int
 
     kwargs['vocab'] = _cfg['vocab']
     kwargs['rnn_units'] = _cfg['rnn_units']
+    kwargs['lstm_features'] = _cfg['lstm_features']
 
     # Build the model
     model = CRNN(feat_extractor, cfg=_cfg, **kwargs)

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -205,9 +205,7 @@ def _crnn(arch: str, pretrained: bool, input_shape: Optional[Tuple[int, int, int
     _cfg['rnn_units'] = kwargs.get('rnn_units', _cfg['rnn_units'])
 
     # Feature extractor
-    feat_extractor = backbones.__dict__[_cfg['backbone']](
-        include_top=False,
-    )
+    feat_extractor = backbones.__dict__[_cfg['backbone']]()
 
     kwargs['vocab'] = _cfg['vocab']
     kwargs['rnn_units'] = _cfg['rnn_units']

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -172,15 +172,14 @@ class CRNN(RecognitionModel, nn.Module):
         target: Optional[List[str]] = None,
         return_model_output: bool = False,
         return_preds: bool = False,
-        **kwargs: Any,
     ) -> Dict[str, Any]:
 
-        features = self.feat_extractor(x, **kwargs)
+        features = self.feat_extractor(x)
         # B x C x H x W --> B x C*H x W --> B x W x C*H
         c, h, w = features.shape[1], features.shape[2], features.shape[3]
         features_seq = torch.reshape(features, shape=(-1, h * c, w))
         features_seq = torch.transpose(features_seq, 1, 2)
-        logits, _ = self.decoder(features_seq, **kwargs)
+        logits, _ = self.decoder(features_seq)
         logits = self.linear(logits)
 
         out: Dict[str, Any] = {}

--- a/doctr/models/recognition/crnn/tensorflow.py
+++ b/doctr/models/recognition/crnn/tensorflow.py
@@ -188,7 +188,6 @@ def _crnn(arch: str, pretrained: bool, input_shape: Optional[Tuple[int, int, int
     # Feature extractor
     feat_extractor = backbones.__dict__[_cfg['backbone']](
         input_shape=_cfg['input_shape'],
-        include_top=False,
     )
 
     kwargs['vocab'] = _cfg['vocab']

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -162,6 +162,8 @@ class MASTER(_MASTER, nn.Module):
         input_size: size of the image inputs
     """
 
+    feature_pe: torch.Tensor
+
     def __init__(
         self,
         vocab: str,

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -209,7 +209,7 @@ class MASTER(_MASTER, nn.Module):
 
     def make_mask(self, target: torch.Tensor) -> torch.Tensor:
         size = target.size(1)
-        look_ahead_mask = ~ (torch.triu(torch.ones(size, size)) == 1).transpose(0, 1)[:, None]
+        look_ahead_mask = ~ (torch.triu(torch.ones(size, size, device=target.device)) == 1).transpose(0, 1)[:, None]
         target_padding_mask = ~ torch.eq(target, self.vocab_size + 2)  # Pad symbol
         combined_mask = target_padding_mask & look_ahead_mask
         return torch.tile(combined_mask.permute(1, 0, 2), (self.num_heads, 1, 1))
@@ -239,7 +239,7 @@ class MASTER(_MASTER, nn.Module):
         # The "masked" first gt char is <sos>. Delete last logit of the model output.
         cce = F.cross_entropy(model_output[:, :-1, :].permute(0, 2, 1), gt[:, 1:], reduction='none')
         # Compute mask, remove 1 timestep here as well
-        mask_2d = torch.arange(input_len - 1)[None, :] < seq_len[:, None]
+        mask_2d = torch.arange(input_len - 1, device=model_output.device)[None, :] < seq_len[:, None]
         cce[mask_2d] = 0
 
         ce_loss = cce.sum(1) / seq_len.to(dtype=torch.float32)
@@ -277,6 +277,7 @@ class MASTER(_MASTER, nn.Module):
             # Compute target: tensor of gts and sequence lengths
             _gt, _seq_len = self.compute_target(target)
             gt, seq_len = torch.from_numpy(_gt).to(dtype=torch.long), torch.tensor(_seq_len)
+            gt, seq_len = gt.to(x.device), seq_len.to(x.device)
 
         if self.training:
             if target is None:
@@ -312,11 +313,13 @@ class MASTER(_MASTER, nn.Module):
         """
         b = encoded.size(0)
 
-        ys = torch.full((b, self.max_length - 1), self.vocab_size + 2, dtype=torch.long)  # padding symbol
-        start_vector = torch.full((b, 1), self.vocab_size + 1, dtype=torch.long)  # SOS
+        # Padding symbol
+        ys = torch.full((b, self.max_length - 1), self.vocab_size + 2, dtype=torch.long, device=encoded.device)
+        start_vector = torch.full((b, 1), self.vocab_size + 1, dtype=torch.long, device=encoded.device)  # SOS
         ys = torch.cat((start_vector, ys), dim=-1)
 
-        logits = torch.zeros((b, self.max_length - 1, self.vocab_size + 3), dtype=torch.long)  # EOS/SOS/PAD
+        # Final dimension include EOS/SOS/PAD
+        logits = torch.zeros((b, self.max_length - 1, self.vocab_size + 3), dtype=torch.long, device=encoded.device)
         # max_len = len + 2
         for i in range(self.max_length - 1):
             ys_mask = self.make_mask(ys)
@@ -343,14 +346,15 @@ class MASTERPostProcessor(_MASTERPostProcessor):
         # N x L
         probs = torch.gather(torch.softmax(logits, -1), -1, out_idxs.unsqueeze(-1)).squeeze(-1)
         # Take the minimum confidence of the sequence
-        probs = probs.min(dim=1).values
+        probs = probs.min(dim=1).values.detach().cpu()
 
         # Manual decoding
         word_values = [
-            ''.join(self._embedding[idx] for idx in encoded_seq).split("<eos>")[0] for encoded_seq in out_idxs.numpy()
+            ''.join(self._embedding[idx] for idx in encoded_seq).split("<eos>")[0]
+            for encoded_seq in out_idxs.cpu().numpy()
         ]
 
-        return list(zip(word_values, probs.detach().numpy().tolist()))
+        return list(zip(word_values, probs.numpy().tolist()))
 
 
 def _master(arch: str, pretrained: bool, input_shape: Tuple[int, int, int] = None, **kwargs: Any) -> MASTER:

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -195,7 +195,7 @@ class MASTER(_MASTER, nn.Module):
             maximum_position_encoding=max_length,
             dropout=dropout,
         )
-        self.feature_pe = positional_encoding(input_shape[1] * input_shape[2], d_model)
+        self.register_buffer('feature_pe', positional_encoding(input_shape[1] * input_shape[2], d_model))
         self.linear = nn.Linear(d_model, self.vocab_size + 3)
 
         self.postprocessor = MASTERPostProcessor(vocab=self.vocab)

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -251,7 +251,6 @@ class MASTER(_MASTER, nn.Module):
         target: Optional[List[str]] = None,
         return_model_output: bool = False,
         return_preds: bool = False,
-        **kwargs: Any,
     ) -> Dict[str, Any]:
         """Call function for training
 
@@ -266,7 +265,7 @@ class MASTER(_MASTER, nn.Module):
         """
 
         # Encode
-        feature = self.feat_extractor(x, **kwargs)
+        feature = self.feat_extractor(x)
         b, c, h, w = (feature.size(i) for i in range(4))
         feature = torch.reshape(feature, shape=(b, c, h * w))
         feature = feature.permute(0, 2, 1)  # shape (b, h*w, c)

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -23,7 +23,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
     'master': {
         'mean': (.5, .5, .5),
         'std': (1., 1., 1.),
-        'input_shape': (48, 160, 3),
+        'input_shape': (3, 48, 160),
         'vocab': VOCABS['french'],
         'url': None,
     },

--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -107,7 +107,7 @@ class SARDecoder(nn.Module):
         # initialize states (each of shape (N, rnn_units))
         hx = [None, None]
         # Initialize with the index of virtual START symbol (placed after <eos>)
-        symbol = torch.zeros((features.shape[0], self.vocab_size + 1))
+        symbol = torch.zeros((features.shape[0], self.vocab_size + 1), device=features.device)
         logits_list = []
         for t in range(self.max_length + 1):  # keep 1 step for <eos>
 
@@ -198,6 +198,7 @@ class SAR(nn.Module, RecognitionModel):
         if target is not None:
             gt, seq_len = self.compute_target(target)
             gt, seq_len = torch.from_numpy(gt).to(dtype=torch.long), torch.tensor(seq_len)  # type: ignore[assignment]
+            gt, seq_len = gt.to(x.device), seq_len.to(x.device)
         decoded_features = self.decoder(features, encoded, gt=None if target is None else gt)
 
         out: Dict[str, Any] = {}
@@ -237,7 +238,7 @@ class SAR(nn.Module, RecognitionModel):
         # Compute loss
         cce = F.cross_entropy(model_output.permute(0, 2, 1), gt, reduction='none')
         # Compute mask
-        mask_2d = torch.arange(input_len)[None, :] < seq_len[:, None]
+        mask_2d = torch.arange(input_len, device=model_output.device)[None, :] < seq_len[:, None]
         cce[mask_2d] = 0
 
         ce_loss = cce.sum(1) / seq_len.to(dtype=torch.float32)
@@ -256,14 +257,15 @@ class SARPostProcessor(RecognitionPostProcessor):
         # N x L
         probs = torch.gather(torch.softmax(logits, -1), -1, out_idxs.unsqueeze(-1)).squeeze(-1)
         # Take the minimum confidence of the sequence
-        probs = probs.min(dim=1).values
+        probs = probs.min(dim=1).values.detach().cpu()
 
         # Manual decoding
         word_values = [
-            ''.join(self._embedding[idx] for idx in encoded_seq).split("<eos>")[0] for encoded_seq in out_idxs.numpy()
+            ''.join(self._embedding[idx] for idx in encoded_seq).split("<eos>")[0]
+            for encoded_seq in out_idxs.detach().cpu().numpy()
         ]
 
-        return list(zip(word_values, probs.detach().numpy().tolist()))
+        return list(zip(word_values, probs.numpy().tolist()))
 
 
 def _sar(arch: str, pretrained: bool, input_shape: Tuple[int, int, int] = None, **kwargs: Any) -> SAR:

--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -196,8 +196,8 @@ class SAR(nn.Module, RecognitionModel):
         _, (encoded, _) = self.encoder(pooled_features)
         encoded = encoded[-1]
         if target is not None:
-            gt, seq_len = self.compute_target(target)
-            gt, seq_len = torch.from_numpy(gt).to(dtype=torch.long), torch.tensor(seq_len)  # type: ignore[assignment]
+            _gt, _seq_len = self.compute_target(target)
+            gt, seq_len = torch.from_numpy(_gt).to(dtype=torch.long), torch.tensor(_seq_len)  # type: ignore[assignment]
             gt, seq_len = gt.to(x.device), seq_len.to(x.device)
         decoded_features = self.decoder(features, encoded, gt=None if target is None else gt)
 

--- a/doctr/models/recognition/sar/tensorflow.py
+++ b/doctr/models/recognition/sar/tensorflow.py
@@ -329,7 +329,6 @@ def _sar(arch: str, pretrained: bool, input_shape: Tuple[int, int, int] = None, 
     # Feature extractor
     feat_extractor = backbones.__dict__[default_cfgs[arch]['backbone']](
         input_shape=_cfg['input_shape'],
-        include_top=False,
     )
 
     kwargs['vocab'] = _cfg['vocab']

--- a/doctr/models/recognition/transformer/pytorch.py
+++ b/doctr/models/recognition/transformer/pytorch.py
@@ -6,7 +6,7 @@
 import math
 import torch
 from torch import nn
-from typing import Tuple, Optional
+from typing import Optional
 
 __all__ = ['Decoder', 'positional_encoding']
 

--- a/doctr/models/recognition/transformer/pytorch.py
+++ b/doctr/models/recognition/transformer/pytorch.py
@@ -32,6 +32,8 @@ def positional_encoding(position: int, d_model: int = 512) -> torch.Tensor:
 
 class Decoder(nn.Module):
 
+    pos_encoding: torch.Tensor
+
     def __init__(
         self,
         num_layers: int = 3,

--- a/doctr/models/recognition/transformer/pytorch.py
+++ b/doctr/models/recognition/transformer/pytorch.py
@@ -42,15 +42,15 @@ class Decoder(nn.Module):
         maximum_position_encoding: int = 50,
         dropout: float = 0.2,
     ) -> None:
-        super(Decoder, self).__init__()
+        super().__init__()
 
         self.d_model = d_model
         self.num_layers = num_layers
 
         self.embedding = nn.Embedding(vocab_size + 3, d_model)  # 3 more classes EOS/SOS/PAD
-        self.pos_encoding = positional_encoding(maximum_position_encoding, d_model)
+        self.register_buffer('pos_encoding', positional_encoding(maximum_position_encoding, d_model))
 
-        self.dec_layers = [
+        self.dec_layers = nn.ModuleList([
             nn.TransformerDecoderLayer(
                 d_model=d_model,
                 nhead=num_heads,
@@ -58,7 +58,7 @@ class Decoder(nn.Module):
                 dropout=dropout,
                 activation='relu',
             ) for _ in range(num_layers)
-        ]
+        ])
 
         self.dropout = nn.Dropout(dropout)
 

--- a/doctr/models/recognition/transformer/pytorch.py
+++ b/doctr/models/recognition/transformer/pytorch.py
@@ -6,7 +6,7 @@
 import math
 import torch
 from torch import nn
-from typing import Tuple
+from typing import Tuple, Optional
 
 __all__ = ['Decoder', 'positional_encoding']
 
@@ -67,7 +67,7 @@ class Decoder(nn.Module):
         x: torch.Tensor,
         enc_output: torch.Tensor,
         look_ahead_mask: torch.Tensor,
-        padding_mask: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
         seq_len = x.shape[1]  # Batch first = True

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from doctr.file_utils import is_tf_available, is_torch_available
+from doctr import is_tf_available
 from .core import RecognitionPredictor
 from ..preprocessor import PreProcessor
 from .. import recognition
@@ -14,10 +14,7 @@ from .. import recognition
 __all__ = ["recognition_predictor"]
 
 
-if is_tf_available():
-    ARCHS = ['crnn_vgg16_bn', 'crnn_resnet31', 'sar_vgg16_bn', 'sar_resnet31', 'master']
-elif is_torch_available():
-    ARCHS = ['crnn_vgg16_bn', 'crnn_resnet31', 'sar_vgg16_bn', 'sar_resnet31']
+ARCHS = ['crnn_vgg16_bn', 'crnn_resnet31', 'sar_vgg16_bn', 'sar_resnet31', 'master']
 
 
 def _predictor(arch: str, pretrained: bool, **kwargs: Any) -> RecognitionPredictor:
@@ -29,8 +26,9 @@ def _predictor(arch: str, pretrained: bool, **kwargs: Any) -> RecognitionPredict
     kwargs['mean'] = kwargs.get('mean', _model.cfg['mean'])
     kwargs['std'] = kwargs.get('std', _model.cfg['std'])
     kwargs['batch_size'] = kwargs.get('batch_size', 32)
+    input_shape = _model.cfg['input_shape'][:2] if is_tf_available() else _model.cfg['input_shape'][-2:]
     predictor = RecognitionPredictor(
-        PreProcessor(_model.cfg['input_shape'][:2], preserve_aspect_ratio=True, **kwargs),
+        PreProcessor(input_shape, preserve_aspect_ratio=True, **kwargs),
         _model
     )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,7 @@
 import pytest
-import os
 import json
 import requests
 from io import BytesIO
-
-# Disable GPU for testing
-os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
 
 @pytest.fixture(scope="session")

--- a/test/pytorch/test_models_detection_pt.py
+++ b/test/pytorch/test_models_detection_pt.py
@@ -60,8 +60,3 @@ def test_detection_zoo(arch_name):
     assert all(isinstance(out_img, tuple) for out_img in out)
     all_boxes, _ = zip(*out)
     assert all(isinstance(boxes, np.ndarray) and boxes.shape[1] == 5 for boxes in all_boxes)
-
-
-def test_detection_zoo_error():
-    with pytest.raises(ValueError):
-        _ = detection.zoo.detection_predictor("my_fancy_model", pretrained=False)

--- a/test/pytorch/test_models_detection_pt.py
+++ b/test/pytorch/test_models_detection_pt.py
@@ -23,6 +23,9 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
         dict(boxes=np.array([[.5, .5, 1, 1], [0.5, 0.5, .8, .8]], dtype=np.float32), flags=[True, False]),
         dict(boxes=np.array([[.5, .5, 1, 1], [0.5, 0.5, .8, .9]], dtype=np.float32), flags=[True, False])
     ]
+    if torch.cuda.is_available():
+        model.cuda()
+        input_tensor = input_tensor.cuda()
     out = model(input_tensor, target, return_model_output=True, return_boxes=True)
     assert isinstance(out, dict)
     assert len(out) == 3
@@ -55,6 +58,10 @@ def test_detection_zoo(arch_name):
     # object check
     assert isinstance(predictor, detection.DetectionPredictor)
     input_tensor = torch.rand((2, 3, 1024, 1024))
+    if torch.cuda.is_available():
+        predictor.model.cuda()
+        input_tensor = input_tensor.cuda()
+
     with torch.no_grad():
         out = predictor(input_tensor)
     assert all(isinstance(out_img, tuple) for out_img in out)

--- a/test/pytorch/test_models_recognition_pt.py
+++ b/test/pytorch/test_models_recognition_pt.py
@@ -20,6 +20,9 @@ def test_recognition_models(arch_name, input_shape, mock_vocab):
     input_tensor = torch.rand((batch_size, *input_shape))
     target = ["i", "am", "a", "jedi"]
 
+    if torch.cuda.is_available():
+        model.cuda()
+        input_tensor = input_tensor.cuda()
     out = model(input_tensor, target, return_model_output=True, return_preds=True)
     assert isinstance(out, dict)
     assert len(out) == 3
@@ -66,6 +69,10 @@ def test_recognition_zoo(arch_name):
     # object check
     assert isinstance(predictor, recognition.RecognitionPredictor)
     input_tensor = torch.rand((batch_size, 3, 128, 128))
+    if torch.cuda.is_available():
+        predictor.model.cuda()
+        input_tensor = input_tensor.cuda()
+
     with torch.no_grad():
         out = predictor(input_tensor)
     out = predictor(input_tensor)

--- a/test/pytorch/test_models_recognition_pt.py
+++ b/test/pytorch/test_models_recognition_pt.py
@@ -8,18 +8,19 @@ from doctr.models import recognition
     "arch_name, input_shape",
     [
         ["crnn_vgg16_bn", (3, 32, 128)],
+        ["crnn_resnet31", (3, 32, 128)],
         ["sar_resnet31", (3, 32, 128)],
-        ["master", (3, 32, 128)],
+        ["master", (3, 48, 160)],
     ],
 )
 def test_recognition_models(arch_name, input_shape, mock_vocab):
     batch_size = 4
-    reco_model = recognition.__dict__[arch_name](vocab=mock_vocab, pretrained=False, input_shape=input_shape).eval()
-    assert isinstance(reco_model, torch.nn.Module)
+    model = recognition.__dict__[arch_name](vocab=mock_vocab, pretrained=False, input_shape=input_shape).eval()
+    assert isinstance(model, torch.nn.Module)
     input_tensor = torch.rand((batch_size, *input_shape))
     target = ["i", "am", "a", "jedi"]
 
-    out = reco_model(input_tensor, target, return_model_output=True, return_preds=True)
+    out = model(input_tensor, target, return_model_output=True, return_preds=True)
     assert isinstance(out, dict)
     assert len(out) == 3
     assert isinstance(out['preds'], list)
@@ -45,3 +46,28 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
     assert all(char in mock_vocab for word, _ in decoded for char in word)
     # Repr
     assert repr(processor) == f'{post_processor}(vocab_size={len(mock_vocab)})'
+
+
+@pytest.mark.parametrize(
+    "arch_name",
+    [
+        "crnn_vgg16_bn",
+        "sar_vgg16_bn",
+        "sar_resnet31",
+        "crnn_resnet31",
+        "master"
+    ],
+)
+def test_recognition_zoo(arch_name):
+    batch_size = 2
+    # Model
+    predictor = recognition.zoo.recognition_predictor(arch_name, pretrained=False)
+    predictor.model.eval()
+    # object check
+    assert isinstance(predictor, recognition.RecognitionPredictor)
+    input_tensor = torch.rand((batch_size, 3, 128, 128))
+    with torch.no_grad():
+        out = predictor(input_tensor)
+    out = predictor(input_tensor)
+    assert isinstance(out, list) and len(out) == batch_size
+    assert all(isinstance(word, str) and isinstance(conf, float) for word, conf in out)

--- a/test/tensorflow/test_models_backbones_tf.py
+++ b/test/tensorflow/test_models_backbones_tf.py
@@ -12,11 +12,6 @@ from doctr.models import backbones
     ],
 )
 def test_classification_architectures(arch_name, top_implemented, input_shape, output_size):
-    # Head not implemented yet
-    if not top_implemented:
-        with pytest.raises(NotImplementedError):
-            backbones.__dict__[arch_name](include_top=True)
-
     # Model
     batch_size = 2
     model = backbones.__dict__[arch_name](pretrained=True)

--- a/test/tensorflow/test_models_recognition_tf.py
+++ b/test/tensorflow/test_models_recognition_tf.py
@@ -97,7 +97,7 @@ def test_recognition_zoo(arch_name):
     predictor = recognition.zoo.recognition_predictor(arch_name, pretrained=False)
     # object check
     assert isinstance(predictor, recognition.RecognitionPredictor)
-    input_tensor = tf.random.uniform(shape=[batch_size, 1024, 1024, 3], minval=0, maxval=1)
+    input_tensor = tf.random.uniform(shape=[batch_size, 128, 128, 3], minval=0, maxval=1)
     out = predictor(input_tensor)
     assert isinstance(out, list) and len(out) == batch_size
     assert all(isinstance(word, str) and isinstance(conf, float) for word, conf in out)


### PR DESCRIPTION
Following up on #261, this PR introduces the following modifications:
- fixed MASTER input_shape (causes failure for predictor)
- fixed multiple buffer registration (otherwise changing device doesn't propagate to this tensor)
- fixed LSTM dimensioning in CRNN (needed to be dynamic with backbone output shape)
- added `crnn_resnet31` which was missing from PyTorch support
- removed `include_top` constructor argument from backbones
- fixed compatibility with GPU input
- re-enabled GPU for unittests (when CUDA available)
- added missing tests for recognition zoo

Any feedback is welcome!