### PR TITLE
feat: Optimized data loading for PyTorch

### DIFF
--- a/doctr/datasets/datasets/pytorch.py
+++ b/doctr/datasets/datasets/pytorch.py
@@ -6,7 +6,8 @@
 import os
 from typing import List, Any, Tuple
 import torch
-from torchvision.io.image import read_image, ImageReadMode
+from PIL import Image
+from torchvision.transforms.functional import to_tensor
 
 from .base import _AbstractDataset, _VisionDataset
 
@@ -23,7 +24,7 @@ class AbstractDataset(_AbstractDataset):
     def _read_sample(self, index: int) -> Tuple[torch.Tensor, Any]:
         img_name, target = self.data[index]
         # Read image
-        img = read_image(os.path.join(self.root, img_name), mode=ImageReadMode.RGB)
+        img = to_tensor(Image.open(os.path.join(self.root, img_name), mode='r').convert('RGB'))
 
         return img, target
 

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -87,10 +87,7 @@ def main(args):
     val_set = DetectionDataset(
         img_folder=os.path.join(args.data_path, 'val'),
         label_folder=os.path.join(args.data_path, 'val_labels'),
-        sample_transforms=Compose([
-            Lambda(lambda x: x / 255),
-            T.Resize((args.input_size, args.input_size)),
-        ]),
+        sample_transforms=T.Resize((args.input_size, args.input_size)),
         rotated_bbox=args.rotation
     )
     val_loader = DataLoader(
@@ -141,7 +138,6 @@ def main(args):
         img_folder=os.path.join(args.data_path, 'train'),
         label_folder=os.path.join(args.data_path, 'train_labels'),
         sample_transforms=Compose([
-            Lambda(lambda x: x / 255),
             T.Resize((args.input_size, args.input_size)),
             # Augmentations
             T.RandomApply(T.ColorInversion(), .1),

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -9,6 +9,7 @@ os.environ['USE_TORCH'] = '1'
 
 import time
 import datetime
+import multiprocessing as mp
 import numpy as np
 from fastprogress.fastprogress import master_bar, progress_bar
 import torch
@@ -76,6 +77,9 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
 def main(args):
 
     print(args)
+
+    if not isinstance(args.workers, int):
+        args.workers = min(16, mp.cpu_count())
 
     torch.backends.cudnn.benchmark = True
 
@@ -240,7 +244,7 @@ def parse_args():
     parser.add_argument('--input_size', type=int, default=1024, help='model input size, H = W')
     parser.add_argument('--lr', type=float, default=0.001, help='learning rate for the optimizer (Adam)')
     parser.add_argument('--wd', '--weight-decay', default=0, type=float, help='weight decay', dest='weight_decay')
-    parser.add_argument('-j', '--workers', type=int, default=4, help='number of workers used for dataloading')
+    parser.add_argument('-j', '--workers', type=int, default=None, help='number of workers used for dataloading')
     parser.add_argument('--resume', type=str, default=None, help='Path to your checkpoint')
     parser.add_argument("--test-only", dest='test_only', action='store_true', help="Run the validation loop")
     parser.add_argument('--freeze-backbone', dest='freeze_backbone', action='store_true',

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -9,6 +9,7 @@ os.environ['USE_TORCH'] = '1'
 
 import time
 import datetime
+import multiprocessing as mp
 import numpy as np
 from fastprogress.fastprogress import master_bar, progress_bar
 import torch
@@ -73,6 +74,9 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
 def main(args):
 
     print(args)
+
+    if not isinstance(args.workers, int):
+        args.workers = min(16, mp.cpu_count())
 
     torch.backends.cudnn.benchmark = True
 
@@ -219,7 +223,7 @@ def parse_args():
     parser.add_argument('--input_size', type=int, default=32, help='input size H for the model, W = 4*H')
     parser.add_argument('--lr', type=float, default=0.001, help='learning rate for the optimizer (Adam)')
     parser.add_argument('--wd', '--weight-decay', default=0, type=float, help='weight decay', dest='weight_decay')
-    parser.add_argument('-j', '--workers', type=int, default=4, help='number of workers used for dataloading')
+    parser.add_argument('-j', '--workers', type=int, default=None, help='number of workers used for dataloading')
     parser.add_argument('--resume', type=str, default=None, help='Path to your checkpoint')
     parser.add_argument("--test-only", dest='test_only', action='store_true', help="Run the validation loop")
     parser.add_argument('--show-samples', dest='show_samples', action='store_true',

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -84,10 +84,7 @@ def main(args):
     val_set = RecognitionDataset(
         img_folder=os.path.join(args.data_path, 'val'),
         labels_path=os.path.join(args.data_path, 'val_labels.json'),
-        sample_transforms=Compose([
-            Lambda(lambda x: x / 255),
-            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
-        ]),
+        sample_transforms=T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
     )
     val_loader = DataLoader(
         val_set,
@@ -127,7 +124,6 @@ def main(args):
         img_folder=os.path.join(args.data_path, 'train'),
         labels_path=os.path.join(args.data_path, 'train_labels.json'),
         sample_transforms=Compose([
-            Lambda(lambda x: x / 255),
             T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
             # Augmentations
             T.RandomApply(T.ColorInversion(), .1),

--- a/requirements-pt.txt
+++ b/requirements-pt.txt
@@ -10,5 +10,5 @@ weasyprint>=52.2
 unidecode>=1.0.0
 torch>=1.8.0
 torchvision>=0.9.0
-Pillow>=8.0.0
+Pillow>=8.0.0,<8.3.0
 tqdm>=4.30.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ _deps = [
     "tensorflow-cpu>=2.4.0",
     "torch>=1.8.0",
     "torchvision>=0.9.0",
-    "Pillow>=8.0.0",
+    "Pillow>=8.0.0,<8.3.0",  # cf. https://github.com/python-pillow/Pillow/issues/5571
     "tqdm>=4.30.0",
 ]
 


### PR DESCRIPTION
Following up on #190, this PR introduces the following modifications:
- added automatic workers number selection for PyTorch trainings
- switched image reading backend from torchvision to PIL + tensor conversion
- reflected changes on training scripts
- had to update PIL requirements due to https://github.com/python-pillow/Pillow/issues/5571

Iterating with the dataloader on FUNSD gets a 25%+ speedup with the same number of workers (3X compared to the original default number of workers)

Closes #190

Any feedback is welcome!