### PR TITLE
feat: add crop functional transformation

### DIFF
--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -4,7 +4,6 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import tensorflow as tf
-from tensorflow.python.ops.gen_array_ops import empty
 import tensorflow_addons as tfa
 import numpy as np
 from typing import Tuple, Dict

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -4,12 +4,13 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import tensorflow as tf
+from tensorflow.python.ops.gen_array_ops import empty
 import tensorflow_addons as tfa
 import numpy as np
 from typing import Tuple, Dict
 from doctr.utils.geometry import rotate_boxes
 
-__all__ = ["invert_colors", "rotate"]
+__all__ = ["invert_colors", "rotate", "crop_detection"]
 
 
 def invert_colors(img: tf.Tensor, min_val: float = 0.6) -> tf.Tensor:
@@ -57,3 +58,40 @@ def rotate(
         r_boxes[:, [1, 3]] *= img.shape[0]
     target["boxes"] = r_boxes
     return rotated_img, target
+
+
+def crop_detection(
+    img: tf.Tensor,
+    boxes: np.ndarray,
+    crop_box: Tuple[int, int, int, int]
+) -> Tuple[tf.Tensor, np.ndarray]:
+    """Crop and image and associated bboxes
+
+    Args:
+        img: image to crop
+        boxes: array of boxes to clip, absolute (int) or relative (float)
+        crop_box: box (xmin, ymin, xmax, ymax) to crop the image. Absolute coords.
+
+    Returns:
+        A tuple of cropped image, cropped boxes, where the image is not resized.
+    """
+    xmin, ymin, xmax, ymax = crop_box
+    croped_img = tf.image.crop_to_bounding_box(
+        img, ymin, xmin, ymax - ymin, xmax - xmin
+    )
+    if boxes.dtype == int:  # absolute boxes
+        # Clip boxes
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin, xmax)
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin, ymax)
+    else:  # relative boxes
+        h, w = img.shape[:2]
+        # Clip boxes
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin / w, xmax / w)
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin / h, ymax / h)
+    # Remove 0-sized boxes
+    zero_height = boxes[:, 1] == boxes[:, 3]
+    zero_width = boxes[:, 0] == boxes[:, 2]
+    empty_boxes = np.logical_or(zero_height, zero_width)
+    boxes = boxes[~empty_boxes]
+
+    return croped_img, boxes

--- a/test/pytorch/test_transforms_pt.py
+++ b/test/pytorch/test_transforms_pt.py
@@ -3,7 +3,6 @@ import pytest
 import math
 import torch
 import numpy as np
-from torchvision.transforms.functional import crop
 from doctr.transforms import Resize, ColorInversion
 from doctr.transforms.functional import rotate, crop_detection
 

--- a/test/pytorch/test_transforms_pt.py
+++ b/test/pytorch/test_transforms_pt.py
@@ -3,8 +3,9 @@ import pytest
 import math
 import torch
 import numpy as np
+from torchvision.transforms.functional import crop
 from doctr.transforms import Resize, ColorInversion
-from doctr.transforms.functional import rotate
+from doctr.transforms.functional import rotate, crop_detection
 
 
 def test_resize():
@@ -87,3 +88,22 @@ def test_rotate():
     target = {"boxes": rel_boxes}
     r_img, r_target = rotate(input_t, target, angle=12.)
     assert r_target["boxes"].all() == np.array([[.5, .5, .4, .2, 12.]]).all()
+
+
+def test_crop_detection():
+    img = torch.ones((3, 50, 50), dtype=torch.float32)
+    abs_boxes = np.array([
+        [15, 20, 35, 30],
+        [5, 10, 10, 20],
+    ])
+    crop_box = (12, 23, 50, 50)
+    c_img, c_boxes = crop_detection(img, abs_boxes, crop_box)
+    assert c_img.shape == (3, 27, 38)
+    assert c_boxes.shape == (1, 4)
+    rel_boxes = np.array([
+        [.3, .4, .7, .6],
+        [.1, .2, .2, .4],
+    ])
+    c_img, c_boxes = crop_detection(img, rel_boxes, crop_box)
+    assert c_img.shape == (3, 27, 38)
+    assert c_boxes.shape == (1, 4)

--- a/test/tensorflow/test_transforms_tf.py
+++ b/test/tensorflow/test_transforms_tf.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 import tensorflow as tf
 from doctr import transforms as T
-from doctr.transforms.functional import rotate
+from doctr.transforms.functional import rotate, crop_detection
 
 
 def test_resize():
@@ -209,3 +209,22 @@ def test_rotate():
     target = {"boxes": rel_boxes}
     r_img, r_target = rotate(input_t, target, angle=12.)
     assert r_target["boxes"].all() == np.array([[.5, .5, .4, .2, 12.]]).all()
+
+
+def test_crop_detection():
+    img = tf.ones((50, 50, 3), dtype=tf.float32)
+    abs_boxes = np.array([
+        [15, 20, 35, 30],
+        [5, 10, 10, 20],
+    ])
+    crop_box = (12, 23, 50, 50)
+    c_img, c_boxes = crop_detection(img, abs_boxes, crop_box)
+    assert c_img.shape == (27, 38, 3)
+    assert c_boxes.shape == (1, 4)
+    rel_boxes = np.array([
+        [.3, .4, .7, .6],
+        [.1, .2, .2, .4],
+    ])
+    c_img, c_boxes = crop_detection(img, rel_boxes, crop_box)
+    assert c_img.shape == (27, 38, 3)
+    assert c_boxes.shape == (1, 4)


### PR DESCRIPTION
This PR adds a `crop_detection` function in both tf & pt `transforms.functional`. This function crops a tf or pt image according a given crop_box, and crops as well the given array of bboxes (relative or absolutes).
Any feedback is welcome!