### PR TITLE
feat: Added FP16 support to doctr.datasets

### DIFF
--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -18,6 +18,15 @@ class _AbstractDataset:
 
     data: List[Any] = []
     root: str
+    fp16: bool
+
+    def __init__(
+        self,
+        root: str,
+        fp16: bool = False,
+    ) -> None:
+        self.root = root
+        self.fp16 = fp16
 
     def __len__(self) -> int:
         return len(self.data)
@@ -60,6 +69,7 @@ class _VisionDataset(_AbstractDataset):
         extract_archive: whether the downloaded file is an archive to be extracted
         download: whether the dataset should be downloaded if not present on disk
         overwrite: whether the archive should be re-extracted
+        fp16: should FP precision be switched to FP16
     """
 
     def __init__(
@@ -70,6 +80,7 @@ class _VisionDataset(_AbstractDataset):
         extract_archive: bool = False,
         download: bool = False,
         overwrite: bool = False,
+        fp16: bool = False,
     ) -> None:
 
         dataset_cache = os.path.join(os.path.expanduser('~'), '.cache', 'doctr', 'datasets')
@@ -91,6 +102,4 @@ class _VisionDataset(_AbstractDataset):
                 with ZipFile(archive_path, 'r') as f:
                     f.extractall(path=dataset_path)
 
-        # List images
-        self._root = dataset_path if extract_archive else archive_path
-        self.data: List[Any] = []
+        super().__init__(dataset_path if extract_archive else archive_path, fp16)

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -17,12 +17,10 @@ __all__ = ['_AbstractDataset', '_VisionDataset']
 class _AbstractDataset:
 
     data: List[Any] = []
-    root: str
-    fp16: bool
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         fp16: bool = False,
     ) -> None:
         self.root = root

--- a/doctr/datasets/datasets/pytorch.py
+++ b/doctr/datasets/datasets/pytorch.py
@@ -5,8 +5,9 @@
 
 import os
 from typing import List, Any, Tuple
-import torch
+import numpy as np
 from PIL import Image
+import torch
 from torchvision.transforms.functional import to_tensor
 
 from .base import _AbstractDataset, _VisionDataset
@@ -24,7 +25,18 @@ class AbstractDataset(_AbstractDataset):
     def _read_sample(self, index: int) -> Tuple[torch.Tensor, Any]:
         img_name, target = self.data[index]
         # Read image
-        img = to_tensor(Image.open(os.path.join(self.root, img_name), mode='r').convert('RGB'))
+        pil_img = Image.open(os.path.join(self.root, img_name), mode='r').convert('RGB')
+        if self.fp16:
+            img = torch.from_numpy(
+                np.array(pil_img, np.uint8, copy=True)
+            )
+            img = img.view(pil_img.size[1], pil_img.size[0], len(pil_img.getbands()))
+            # put it from HWC to CHW format
+            img = img.permute((2, 0, 1)).contiguous()
+            # Switch to FP16
+            img = img.to(dtype=torch.float16).div(255)
+        else:
+            img = to_tensor(pil_img)
 
         return img, target
 

--- a/doctr/datasets/datasets/tensorflow.py
+++ b/doctr/datasets/datasets/tensorflow.py
@@ -26,6 +26,10 @@ class AbstractDataset(_AbstractDataset):
         img = tf.image.decode_jpeg(img, channels=3)
         if self.fp16:
             img = tf.image.convert_image_dtype(img, dtype=tf.float16)
+        else:
+            img = tf.image.convert_image_dtype(img, dtype=tf.float32)
+
+        img = tf.clip_by_value(img / 255, 0, 1)
 
         return img, target
 

--- a/doctr/datasets/datasets/tensorflow.py
+++ b/doctr/datasets/datasets/tensorflow.py
@@ -24,6 +24,8 @@ class AbstractDataset(_AbstractDataset):
         # Read image
         img = tf.io.read_file(os.path.join(self.root, img_name))
         img = tf.image.decode_jpeg(img, channels=3)
+        if self.fp16:
+            img = tf.image.convert_image_dtype(img, dtype=tf.float16)
 
         return img, target
 

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -34,21 +34,23 @@ class DetectionDataset(AbstractDataset):
         label_folder: str,
         sample_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
+        **kwargs: Any,
     ) -> None:
+        super().__init__(img_folder, **kwargs)
         self.sample_transforms = sample_transforms
-        self.root = img_folder
 
         self.data: List[Tuple[str, Dict[str, Any]]] = []
+        np_dtype = np.float16 if self.fp16 else np.float32
         for img_path in os.listdir(self.root):
             # File existence check
             if not os.path.exists(os.path.join(self.root, img_path)):
                 raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_path)}")
             with open(os.path.join(label_folder, img_path + '.json'), 'rb') as f:
                 boxes = json.load(f)
-            bboxes = np.asarray(boxes["boxes_1"] + boxes["boxes_2"] + boxes["boxes_3"], dtype=np.float32)
+            bboxes = np.asarray(boxes["boxes_1"] + boxes["boxes_2"] + boxes["boxes_3"], dtype=np_dtype)
             if rotated_bbox:
                 # Switch to rotated rects
-                bboxes = np.asarray([list(fit_rbbox(box)) for box in bboxes], dtype=np.float32)
+                bboxes = np.asarray([list(fit_rbbox(box)) for box in bboxes], dtype=np_dtype)
             else:
                 # Switch to xmin, ymin, xmax, ymax
                 bboxes = np.concatenate((bboxes.min(axis=1), bboxes.max(axis=1)), axis=1)

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -50,14 +50,14 @@ class FUNSD(VisionDataset):
         subfolder = os.path.join('dataset', 'training_data' if train else 'testing_data')
 
         # # List images
-        self.root = os.path.join(self._root, subfolder, 'images')
+        tmp_root = os.path.join(self.root, subfolder, 'images')
         self.data: List[Tuple[str, Dict[str, Any]]] = []
-        for img_path in os.listdir(self.root):
+        for img_path in os.listdir(tmp_root):
             # File existence check
-            if not os.path.exists(os.path.join(self.root, img_path)):
-                raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_path)}")
+            if not os.path.exists(os.path.join(tmp_root, img_path)):
+                raise FileNotFoundError(f"unable to locate {os.path.join(tmp_root, img_path)}")
             stem = Path(img_path).stem
-            with open(os.path.join(self._root, subfolder, 'annotations', f"{stem}.json"), 'rb') as f:
+            with open(os.path.join(self.root, subfolder, 'annotations', f"{stem}.json"), 'rb') as f:
                 data = json.load(f)
 
             _targets = [(word['text'], word['box']) for block in data['form']
@@ -72,6 +72,8 @@ class FUNSD(VisionDataset):
                 ]
 
             self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=int), labels=text_targets)))
+
+        self.root = tmp_root
 
     def extra_repr(self) -> str:
         return f"train={self.train}"

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -30,9 +30,10 @@ class RecognitionDataset(AbstractDataset):
         img_folder: str,
         labels_path: str,
         sample_transforms: Optional[Callable[[Any], Any]] = None,
+        **kwargs: Any,
     ) -> None:
+        super().__init__(img_folder, **kwargs)
         self.sample_transforms = (lambda x: x) if sample_transforms is None else sample_transforms
-        self.root = img_folder
 
         self.data: List[Tuple[str, str]] = []
         with open(labels_path) as f:

--- a/doctr/datasets/sroie.py
+++ b/doctr/datasets/sroie.py
@@ -52,15 +52,16 @@ class SROIE(VisionDataset):
             raise NotImplementedError
 
         # # List images
-        self.root = os.path.join(self._root, 'images')
+        tmp_root = os.path.join(self.root, 'images')
         self.data: List[Tuple[str, Dict[str, Any]]] = []
-        for img_path in os.listdir(self.root):
+        np_dtype = np.float16 if self.fp16 else np.float32
+        for img_path in os.listdir(tmp_root):
             # File existence check
-            if not os.path.exists(os.path.join(self.root, img_path)):
-                raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_path)}")
+            if not os.path.exists(os.path.join(tmp_root, img_path)):
+                raise FileNotFoundError(f"unable to locate {os.path.join(tmp_root, img_path)}")
             stem = Path(img_path).stem
             _targets = []
-            with open(os.path.join(self._root, 'annotations', f"{stem}.txt"), encoding='latin') as f:
+            with open(os.path.join(self.root, 'annotations', f"{stem}.txt"), encoding='latin') as f:
                 for row in csv.reader(f, delimiter=','):
                     # Safeguard for blank lines
                     if len(row) > 0:
@@ -75,7 +76,8 @@ class SROIE(VisionDataset):
 
             text_targets, box_targets = zip(*_targets)
 
-            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=np.float32), labels=text_targets)))
+            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=np_dtype), labels=text_targets)))
+        self.root = tmp_root
 
     def extra_repr(self) -> str:
         return f"train={self.train}"

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -87,10 +87,7 @@ def main(args):
     val_set = DetectionDataset(
         img_folder=os.path.join(args.data_path, 'val'),
         label_folder=os.path.join(args.data_path, 'val_labels'),
-        sample_transforms=T.Compose([
-            T.LambdaTransformation(lambda x: x / 255),
-            T.Resize((args.input_size, args.input_size)),
-        ]),
+        sample_transforms=T.Resize((args.input_size, args.input_size)),
         rotated_bbox=args.rotation
     )
     val_loader = DataLoader(val_set, batch_size=args.batch_size, shuffle=False, drop_last=False, workers=args.workers)
@@ -142,7 +139,6 @@ def main(args):
         img_folder=os.path.join(args.data_path, 'train'),
         label_folder=os.path.join(args.data_path, 'train_labels'),
         sample_transforms=T.Compose([
-            T.LambdaTransformation(lambda x: x / 255),
             T.Resize((args.input_size, args.input_size)),
             # Augmentations
             T.RandomApply(T.ColorInversion(), .1),

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -88,10 +88,7 @@ def main(args):
     val_set = RecognitionDataset(
         img_folder=os.path.join(args.data_path, 'val'),
         labels_path=os.path.join(args.data_path, 'val_labels.json'),
-        sample_transforms=T.Compose([
-            T.LambdaTransformation(lambda x: x / 255),
-            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
-        ]),
+        sample_transforms=T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
     )
     val_loader = DataLoader(val_set, batch_size=args.batch_size, shuffle=False, drop_last=False, workers=args.workers)
     print(f"Validation set loaded in {time.time() - st:.4}s ({len(val_set)} samples in "
@@ -141,7 +138,6 @@ def main(args):
         img_folder=os.path.join(args.data_path, 'train'),
         labels_path=os.path.join(args.data_path, 'train_labels.json'),
         sample_transforms=T.Compose([
-            T.LambdaTransformation(lambda x: x / 255),
             T.RandomApply(T.ColorInversion(), .1),
             T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
             # Augmentations

--- a/test/pytorch/test_datasets_pt.py
+++ b/test/pytorch/test_datasets_pt.py
@@ -37,7 +37,7 @@ def test_dataset(dataset_name, train, input_size, size, rotate):
     assert len(ds) == size
     assert repr(ds) == f"{dataset_name}(train={train})"
     img, target = ds[0]
-    assert isinstance(img, torch.Tensor) 
+    assert isinstance(img, torch.Tensor)
     assert img.shape == (3, *input_size)
     assert img.dtype == torch.float32
     assert isinstance(target, dict)

--- a/test/tensorflow/test_datasets_tf.py
+++ b/test/tensorflow/test_datasets_tf.py
@@ -57,7 +57,7 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     img, target = ds[0]
     assert isinstance(img, tf.Tensor)
     assert img.shape[:2] == input_size
-    assert img.dtype = tf.float32
+    assert img.dtype == tf.float32
     # Bounding boxes
     assert isinstance(target['boxes'], np.ndarray) and target['boxes'].dtype == np.float32
     assert np.all(np.logical_and(target['boxes'][:, :4] >= 0, target['boxes'][:, :4] <= 1))
@@ -85,7 +85,7 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     # FP16
     ds = datasets.DetectionDataset(img_folder=mock_image_folder, label_folder=mock_detection_label, fp16=True)
     img, target = ds[0]
-    assert img.dtype = tf.float16
+    assert img.dtype == tf.float16
     assert target['boxes'].dtype == np.float16
 
 

--- a/test/tensorflow/test_datasets_tf.py
+++ b/test/tensorflow/test_datasets_tf.py
@@ -27,13 +27,20 @@ def test_dataset(dataset_name, train, input_size, size, rotate):
     assert len(ds) == size
     assert repr(ds) == f"{dataset_name}(train={train})"
     img, target = ds[0]
-    assert isinstance(img, tf.Tensor) and img.shape == (*input_size, 3)
+    assert isinstance(img, tf.Tensor)
+    assert img.shape == (*input_size, 3)
+    assert img.dtype == tf.float32
     assert isinstance(target, dict)
 
     loader = datasets.DataLoader(ds, batch_size=2)
     images, targets = next(iter(loader))
     assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
     assert isinstance(targets, list) and all(isinstance(elt, dict) for elt in targets)
+
+    # FP16
+    ds = datasets.__dict__[dataset_name](train=train, download=True, fp16=True)
+    img, target = ds[0]
+    assert img.dtype == tf.float16
 
 
 def test_detection_dataset(mock_image_folder, mock_detection_label):
@@ -50,6 +57,7 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     img, target = ds[0]
     assert isinstance(img, tf.Tensor)
     assert img.shape[:2] == input_size
+    assert img.dtype = tf.float32
     # Bounding boxes
     assert isinstance(target['boxes'], np.ndarray) and target['boxes'].dtype == np.float32
     assert np.all(np.logical_and(target['boxes'][:, :4] >= 0, target['boxes'][:, :4] <= 1))
@@ -74,6 +82,12 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     _, r_target = rotated_ds[0]
     assert r_target['boxes'].shape[1] == 5
 
+    # FP16
+    ds = datasets.DetectionDataset(img_folder=mock_image_folder, label_folder=mock_detection_label, fp16=True)
+    img, target = ds[0]
+    assert img.dtype = tf.float16
+    assert target['boxes'].dtype == np.float16
+
 
 def test_recognition_dataset(mock_image_folder, mock_recognition_label):
     input_size = (32, 128)
@@ -86,12 +100,18 @@ def test_recognition_dataset(mock_image_folder, mock_recognition_label):
     image, label = ds[0]
     assert isinstance(image, tf.Tensor)
     assert image.shape[:2] == input_size
+    assert image.dtype == tf.float32
     assert isinstance(label, str)
 
     loader = DataLoader(ds, batch_size=2)
     images, labels = next(iter(loader))
     assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
     assert isinstance(labels, list) and all(isinstance(elt, str) for elt in labels)
+
+    # FP16
+    ds = datasets.RecognitionDataset(img_folder=mock_image_folder, labels_path=mock_recognition_label, fp16=True)
+    image, _ = ds[0]
+    assert image.dtype == tf.float16
 
 
 def test_ocrdataset(mock_ocrdataset):
@@ -110,6 +130,7 @@ def test_ocrdataset(mock_ocrdataset):
     assert len(ds) == 5
     img, target = ds[0]
     assert isinstance(img, tf.Tensor)
+    assert img.dtype == tf.float32
     assert img.shape[:2] == input_size
     # Bounding boxes
     assert isinstance(target['boxes'], np.ndarray) and target['boxes'].dtype == np.float32
@@ -126,3 +147,9 @@ def test_ocrdataset(mock_ocrdataset):
     images, targets = next(iter(loader))
     assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
     assert isinstance(targets, list) and all(isinstance(elt, dict) for elt in targets)
+
+    # FP16
+    ds = datasets.OCRDataset(*mock_ocrdataset, fp16=True)
+    img, target = ds[0]
+    assert img.dtype == tf.float16
+    assert target['boxes'].dtype == np.float16


### PR DESCRIPTION
Following up on #263, this PR introduces the following modifications:
- switched default image dtype of TF datasets to FP32 (before it was `tf.uint8`)
- added FP16 mode on all datasets
- added corresponding unittests
- updated references script to reflect changes (no need to perform 255 division manually anymore)


Please note that there is a breaking change here, the default image dtype of datasets in TF has been switched from `tf.uint8` (between 0 and 255) to `tf.float32` (between 0 and 1).

Any feedback is welcome!