### PR TITLE
fix: Removed PDF forced square resize from demo & analysis script

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -47,7 +47,7 @@ def main():
     uploaded_file = st.sidebar.file_uploader("Upload files", type=['pdf', 'png', 'jpeg', 'jpg'])
     if uploaded_file is not None:
         if uploaded_file.name.endswith('.pdf'):
-            doc = DocumentFile.from_pdf(uploaded_file.read()).as_images(output_size=(1024, 1024))
+            doc = DocumentFile.from_pdf(uploaded_file.read()).as_images()
         else:
             doc = DocumentFile.from_images(uploaded_file.read())
         cols[0].image(doc[0], width=640)

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -22,7 +22,7 @@ def main(args):
 
     model = ocr_predictor(args.detection, args.recognition, pretrained=True)
     if args.path.endswith(".pdf"):
-        doc = DocumentFile.from_pdf(args.path).as_images(output_size=(1024, 1024))
+        doc = DocumentFile.from_pdf(args.path).as_images()
     else:
         doc = DocumentFile.from_images(args.path)
 


### PR DESCRIPTION
This PR removes the resizing step of PDF image rendering to square images. The reason behind that is that while it's indeed optimized if the predictor target size is that specific size if there are multiple preprocessors inside, it yields double interpolation.

Any feedback is welcome!