### PR TITLE
feat: add multi-folders support for recognition datasets

### DIFF
--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -20,7 +20,7 @@ class _AbstractDataset:
 
     def __init__(
         self,
-        root: Union[str, Path, List[str]],
+        root: Union[str, Path],
         fp16: bool = False,
     ) -> None:
         self.root = root

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -20,7 +20,7 @@ class _AbstractDataset:
 
     def __init__(
         self,
-        root: Union[str, Path],
+        root: Union[str, Path, List[str]],
         fp16: bool = False,
     ) -> None:
         self.root = root

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -5,7 +5,7 @@
 
 import os
 import json
-from typing import Tuple, List, Optional, Callable, Any, Union
+from typing import Tuple, List, Optional, Callable, Any
 
 from .datasets import AbstractDataset
 
@@ -27,8 +27,8 @@ class RecognitionDataset(AbstractDataset):
     """
     def __init__(
         self,
-        img_folder: Union[str, List[str]],
-        labels_path: Union[str, List[str]],
+        img_folder: str,
+        labels_path: str,
         sample_transforms: Optional[Callable[[Any], Any]] = None,
         **kwargs: Any,
     ) -> None:
@@ -36,31 +36,14 @@ class RecognitionDataset(AbstractDataset):
         self.sample_transforms = (lambda x: x) if sample_transforms is None else sample_transforms
 
         self.data: List[Tuple[str, str]] = []
-        if isinstance(labels_path, str):
-            with open(labels_path) as f:
-                labels = json.load(f)
-        else:
-            labels = dict()
-            for labelfile in labels_path:
-                with open(labelfile) as f:
-                    labels.update(json.load(f))
+        with open(labels_path) as f:
+            labels = json.load(f)
 
-        if isinstance(img_folder, str):
-            for img_path in os.listdir(self.root):
-                # File existence check
-                if not os.path.exists(os.path.join(self.root, img_path)):
-                    raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_path)}")
-                label = labels.get(img_path)
-                if not isinstance(label, str):
-                    raise KeyError("Image is not in referenced in label file")
-                self.data.append((img_path, label))
-        else:
-            for folder_path in self.root:
-                for img_path in os.listdir(folder_path):
-                    # File existence check
-                    if not os.path.exists(os.path.join(self.root, img_path)):
-                        raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_path)}")
-                    label = labels.get(img_path)
-                    if not isinstance(label, str):
-                        raise KeyError("Image is not in referenced in label file")
-                    self.data.append((img_path, label))
+        for img_path in os.listdir(self.root):
+            # File existence check
+            if not os.path.exists(os.path.join(self.root, img_path)):
+                raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_path)}")
+            label = labels.get(img_path)
+            if not isinstance(label, str):
+                raise KeyError("Image is not in referenced in label file")
+            self.data.append((img_path, label))

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -22,7 +22,7 @@ class RecognitionDataset(AbstractDataset):
         >>> img, target = train_set[0]
 
     Args:
-        data_folder: folder containing folder(s) of images and labels as json files, each image folder 
+        data_folder: folder containing folder(s) of images and labels as json files, each image folder
         must be named "images" and be in the same subdirectory than the corresponding "labels.json"
         sample_transforms: composable transformations that will be applied to each image
     """

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -21,8 +21,8 @@ class RecognitionDataset(AbstractDataset):
         >>> img, target = train_set[0]
 
     Args:
-        img_folder: path to the images folder (or list of paths)
-        labels_path: path to the json file containing all labels (character sequences), or list of paths
+        img_folder: path to the images folder
+        labels_path: path to the json file containing all labels (character sequences)
         sample_transforms: composable transformations that will be applied to each image
     """
     def __init__(
@@ -38,7 +38,6 @@ class RecognitionDataset(AbstractDataset):
         self.data: List[Tuple[str, str]] = []
         with open(labels_path) as f:
             labels = json.load(f)
-
         for img_path in os.listdir(self.root):
             # File existence check
             if not os.path.exists(os.path.join(self.root, img_path)):

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -6,6 +6,7 @@
 import os
 import json
 from typing import Tuple, List, Optional, Callable, Any
+from pathlib import Path, PurePath
 
 from .datasets import AbstractDataset
 
@@ -17,32 +18,35 @@ class RecognitionDataset(AbstractDataset):
 
     Example::
         >>> from doctr.datasets import RecognitionDataset
-        >>> train_set = RecognitionDataset(img_folder=True, labels_path="/path/to/labels.json")
+        >>> train_set = RecognitionDataset(data_folder="/path/to/folder")
         >>> img, target = train_set[0]
 
     Args:
-        img_folder: path to the images folder
-        labels_path: path to the json file containing all labels (character sequences)
+        data_folder: folder containing folder(s) of images and labels as json files, each image folder 
+        must be named "images" and be in the same subdirectory than the corresponding "labels.json"
         sample_transforms: composable transformations that will be applied to each image
     """
     def __init__(
         self,
-        img_folder: str,
-        labels_path: str,
+        data_folder: str,
         sample_transforms: Optional[Callable[[Any], Any]] = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(img_folder, **kwargs)
+        super().__init__(data_folder, **kwargs)
         self.sample_transforms = (lambda x: x) if sample_transforms is None else sample_transforms
 
         self.data: List[Tuple[str, str]] = []
-        with open(labels_path) as f:
-            labels = json.load(f)
-        for img_path in os.listdir(self.root):
-            # File existence check
-            if not os.path.exists(os.path.join(self.root, img_path)):
-                raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_path)}")
-            label = labels.get(img_path)
-            if not isinstance(label, str):
-                raise KeyError("Image is not in referenced in label file")
-            self.data.append((img_path, label))
+        # Recursively find json files
+        json_files = Path(self.root).glob('**/*.json')
+        for json_file in json_files:
+            with json_file.open() as f:
+                labels = json.load(f)
+            imgs_path = PurePath(PurePath.parent(json_file), "images")
+            for img_path in os.listdir(imgs_path):
+                # File existence check
+                if not os.path.exists(os.path.join(imgs_path, img_path)):
+                    raise FileNotFoundError(f"unable to locate {os.path.join(imgs_path, img_path)}")
+                label = labels.get(img_path)
+                if not isinstance(label, str):
+                    raise KeyError("Image is not in referenced in label file")
+                self.data.append((img_path, label))


### PR DESCRIPTION
Since recognition datasets are composed of one-word images, they usually contain millions of images. It is very had to deal with such datasets in one folder only, because it requires to copy/load/move a huge amount of files when we manipulate the data. It is far more easier to split the dataset in "small" portions to store/share and manipulate it. 
Thus we need to be able to load a dataset for a training from a list of img_paths and label_paths, this the new feature of this PR.

Any feedback is welcome, antoher way to do it would be to keep one-folder datasets and merge them afterwards,at the beginning of the training script.
