### PR TITLE
fix: Removed extra 255 division

### DIFF
--- a/doctr/datasets/datasets/tensorflow.py
+++ b/doctr/datasets/datasets/tensorflow.py
@@ -29,7 +29,7 @@ class AbstractDataset(_AbstractDataset):
         else:
             img = tf.image.convert_image_dtype(img, dtype=tf.float32)
 
-        img = tf.clip_by_value(img / 255, 0, 1)
+        img = tf.clip_by_value(img, 0, 1)
 
         return img, target
 


### PR DESCRIPTION
This PR fixes a bug introduced in #367:
- `tf.image.convert_image_dtype` already performs the 255 division when it receives a float dtype.
- the extra 255 division was wrongly placed afterward and is removed in this PR

Any feedback is welcome!