### PR TITLE
feat: reco training script with multi paths sets

### DIFF
--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -18,7 +18,6 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from contiguous_params import ContiguousParams
 import wandb
 from pathlib import Path
-from typing import List
 
 from doctr.models import recognition
 from doctr.utils.metrics import TextMatch

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -134,21 +134,21 @@ def main(args):
         ]),
     )
 
-    # If multiple paths provided, 
+    # If multiple paths provided, merge datasets
     if len(args.train_data_path) > 1:
         for i in range(1, len(args.train_data_path)):
-                train_set.merge_dataset(
-                    RecognitionDataset(
-                        img_folder=os.path.join(args.train_data_path[i], 'images'),
-                        labels_path=os.path.join(args.train_data_path[i], 'labels.json'),
-                        sample_transforms=Compose([
-                            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
-                            # Augmentations
-                            T.RandomApply(T.ColorInversion(), .1),
-                            ColorJitter(brightness=0.3, contrast=0.3, saturation=0.3, hue=0.02),
-                        ]),
-                    )
+            train_set.merge_dataset(
+                RecognitionDataset(
+                    img_folder=os.path.join(args.train_data_path[i], 'images'),
+                    labels_path=os.path.join(args.train_data_path[i], 'labels.json'),
+                    sample_transforms=Compose([
+                        T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
+                        # Augmentations
+                        T.RandomApply(T.ColorInversion(), .1),
+                        ColorJitter(brightness=0.3, contrast=0.3, saturation=0.3, hue=0.02),
+                    ]),
                 )
+            )
 
     train_loader = DataLoader(
         train_set,

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -16,6 +16,7 @@ from collections import deque
 from pathlib import Path
 from fastprogress.fastprogress import master_bar, progress_bar
 import wandb
+from typing import List
 
 gpu_devices = tf.config.experimental.list_physical_devices('GPU')
 if any(gpu_devices):
@@ -84,10 +85,11 @@ def main(args):
 
     print(args)
 
+    # Load val data generator
     st = time.time()
     val_set = RecognitionDataset(
-        img_folder=os.path.join(args.data_path, 'val'),
-        labels_path=os.path.join(args.data_path, 'val_labels.json'),
+        img_folder=os.path.join(args.val_data_path, 'images'),
+        labels_path=os.path.join(args.val_data_path, 'labels.json'),
         sample_transforms=T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
     )
     val_loader = DataLoader(val_set, batch_size=args.batch_size, shuffle=False, drop_last=False, workers=args.workers)
@@ -121,10 +123,11 @@ def main(args):
         return
 
     st = time.time()
-    # Load both train and val data generators
+
+    # Load train data generator
     train_set = RecognitionDataset(
-        img_folder=os.path.join(args.data_path, 'train'),
-        labels_path=os.path.join(args.data_path, 'train_labels.json'),
+        img_folder=os.path.join(args.train_data_path[0], 'images'),
+        labels_path=os.path.join(args.train_data_path[0], 'labels.json'),
         sample_transforms=T.Compose([
             T.RandomApply(T.ColorInversion(), .1),
             T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
@@ -135,6 +138,26 @@ def main(args):
             T.RandomBrightness(.3),
         ]),
     )
+
+    # If multiple paths provided, 
+    if len(args.train_data_path) > 1:
+        for i in range(1, len(args.train_data_path)):
+                train_set.merge_dataset(
+                    RecognitionDataset(
+                        img_folder=os.path.join(args.train_data_path[i], 'images'),
+                        labels_path=os.path.join(args.train_data_path[i], 'labels.json'),
+                        sample_transforms=T.Compose([
+                            T.RandomApply(T.ColorInversion(), .1),
+                            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
+                            # Augmentations
+                            T.RandomJpegQuality(60),
+                            T.RandomSaturation(.3),
+                            T.RandomContrast(.3),
+                            T.RandomBrightness(.3),
+                        ]),
+                    )
+                )
+
     train_loader = DataLoader(train_set, batch_size=args.batch_size, shuffle=True, drop_last=True, workers=args.workers)
     print(f"Train set loaded in {time.time() - st:.4}s ({len(train_set)} samples in "
           f"{train_loader.num_batches} batches)")
@@ -230,6 +253,8 @@ def parse_args():
     parser = argparse.ArgumentParser(description='DocTR train text-recognition model (TensorFlow)',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
+    parser.add_argument('train_data_path', type=List[str], help='list of path(s) to train data folder')
+    parser.add_argument('val_data_path', type=str, help='path to data folder')
     parser.add_argument('data_path', type=str, help='path to data folder')
     parser.add_argument('model', type=str, help='text-recognition model to train')
     parser.add_argument('--name', type=str, default=None, help='Name of your training experiment')

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -16,7 +16,6 @@ from collections import deque
 from pathlib import Path
 from fastprogress.fastprogress import master_bar, progress_bar
 import wandb
-from typing import List
 
 gpu_devices = tf.config.experimental.list_physical_devices('GPU')
 if any(gpu_devices):

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -139,24 +139,24 @@ def main(args):
         ]),
     )
 
-    # If multiple paths provided, 
+    # If multiple paths provided, merge datasets
     if len(args.train_data_path) > 1:
         for i in range(1, len(args.train_data_path)):
-                train_set.merge_dataset(
-                    RecognitionDataset(
-                        img_folder=os.path.join(args.train_data_path[i], 'images'),
-                        labels_path=os.path.join(args.train_data_path[i], 'labels.json'),
-                        sample_transforms=T.Compose([
-                            T.RandomApply(T.ColorInversion(), .1),
-                            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
-                            # Augmentations
-                            T.RandomJpegQuality(60),
-                            T.RandomSaturation(.3),
-                            T.RandomContrast(.3),
-                            T.RandomBrightness(.3),
-                        ]),
-                    )
+            train_set.merge_dataset(
+                RecognitionDataset(
+                    img_folder=os.path.join(args.train_data_path[i], 'images'),
+                    labels_path=os.path.join(args.train_data_path[i], 'labels.json'),
+                    sample_transforms=T.Compose([
+                        T.RandomApply(T.ColorInversion(), .1),
+                        T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
+                        # Augmentations
+                        T.RandomJpegQuality(60),
+                        T.RandomSaturation(.3),
+                        T.RandomContrast(.3),
+                        T.RandomBrightness(.3),
+                    ]),
                 )
+            )
 
     train_loader = DataLoader(train_set, batch_size=args.batch_size, shuffle=True, drop_last=True, workers=args.workers)
     print(f"Train set loaded in {time.time() - st:.4}s ({len(train_set)} samples in "

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -88,8 +88,8 @@ def main(args):
     # Load val data generator
     st = time.time()
     val_set = RecognitionDataset(
-        img_folder=os.path.join(args.val_data_path, 'images'),
-        labels_path=os.path.join(args.val_data_path, 'labels.json'),
+        img_folder=os.path.join(args.val_path, 'images'),
+        labels_path=os.path.join(args.val_path, 'labels.json'),
         sample_transforms=T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
     )
     val_loader = DataLoader(val_set, batch_size=args.batch_size, shuffle=False, drop_last=False, workers=args.workers)
@@ -125,44 +125,27 @@ def main(args):
     st = time.time()
 
     # Load train data generator
-    if Path(os.path.join(args.train_data_path, 'labels.json')).is_file():
-        # Only one folder of images
-        train_set = RecognitionDataset(
-            img_folder=os.path.join(args.train_data_path, 'images'),
-            labels_path=os.path.join(args.train_data_path, 'labels.json'),
-            sample_transforms=T.Compose([
-                T.RandomApply(T.ColorInversion(), .1),
-                T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
-                # Augmentations
-                T.RandomJpegQuality(60),
-                T.RandomSaturation(.3),
-                T.RandomContrast(.3),
-                T.RandomBrightness(.3),
-            ]),
-        )
+    base_path = Path(args.train_path)
+    parts = [base_path] if base_path.joinpath('labels.json').is_file() else [
+        base_path.joinpath(sub) for sub in os.listdir(base_path)
+    ]
+    train_set = RecognitionDataset(
+        parts[0].joinpath('images'),
+        parts[0].joinpath('labels.json'),
+        sample_transforms=T.Compose([
+            T.RandomApply(T.ColorInversion(), .1),
+            T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
+            # Augmentations
+            T.RandomJpegQuality(60),
+            T.RandomSaturation(.3),
+            T.RandomContrast(.3),
+            T.RandomBrightness(.3),
+        ]),
+    )
 
-    # If multiple paths provided, merge datasets
-    else:
-        train_set = RecognitionDataset(
-            img_folder=os.path.join(args.train_data_path, os.listdir(args.train_data_path)[0], 'images'),
-            labels_path=os.path.join(args.train_data_path, os.listdir(args.train_data_path)[0], 'labels.json'),
-            sample_transforms=T.Compose([
-                T.RandomApply(T.ColorInversion(), .1),
-                T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
-                # Augmentations
-                T.RandomJpegQuality(60),
-                T.RandomSaturation(.3),
-                T.RandomContrast(.3),
-                T.RandomBrightness(.3),
-            ]),
-        )
-        for folder in os.listdir(args.train_data_path)[1:]:
-            train_set.merge_dataset(
-                RecognitionDataset(
-                    img_folder=os.path.join(args.train_data_path, folder, 'images'),
-                    labels_path=os.path.join(args.train_data_path, folder, 'labels.json'),
-                )
-            )
+    if len(parts) > 1:
+        for subfolder in parts[1:]:
+            train_set.merge_dataset(RecognitionDataset(subfolder.joinpath('images'), subfolder.joinpath('labels.json')))
 
     train_loader = DataLoader(train_set, batch_size=args.batch_size, shuffle=True, drop_last=True, workers=args.workers)
     print(f"Train set loaded in {time.time() - st:.4}s ({len(train_set)} samples in "
@@ -259,8 +242,8 @@ def parse_args():
     parser = argparse.ArgumentParser(description='DocTR train text-recognition model (TensorFlow)',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    parser.add_argument('train_data_path', type=str, help='path to train data folder(s)')
-    parser.add_argument('val_data_path', type=str, help='path to val data folder')
+    parser.add_argument('train_path', type=str, help='path to train data folder(s)')
+    parser.add_argument('val_path', type=str, help='path to val data folder')
     parser.add_argument('data_path', type=str, help='path to data folder')
     parser.add_argument('model', type=str, help='text-recognition model to train')
     parser.add_argument('--name', type=str, default=None, help='Name of your training experiment')


### PR DESCRIPTION
This PR adds the option to train recognition with multiple datasets.
the arg `data_path` in the script is replaced by a `train_data_path`, a list of 1 or more paths and `val_data_path`, a path.
The structure inside each path must be: `path/images/` and `path/labels.json`.
Any feedback is welcome!