### PR TITLE
fix: transform test bug in CI

### DIFF
--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -51,7 +51,7 @@ def rotate(
         _boxes[:, [0, 2]] = _boxes[:, [0, 2]] / img.shape[2]
         _boxes[:, [1, 3]] = _boxes[:, [1, 3]] / img.shape[1]
     # Compute rotated bboxes: xmin, ymin, xmax, ymax --> x, y, w, h, alpha
-    r_boxes = rotate_boxes(_boxes, angle=angle, min_angle=1)
+    r_boxes = rotate_boxes(_boxes, angle=angle, min_angle=0)
     if boxes.dtype == int:
         # Back to absolute boxes
         r_boxes[:, [0, 2]] *= img.shape[2]

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -51,7 +51,7 @@ def rotate(
         _boxes[:, [0, 2]] = _boxes[:, [0, 2]] / img.shape[1]
         _boxes[:, [1, 3]] = _boxes[:, [1, 3]] / img.shape[0]
     # Compute rotated bboxes: xmin, ymin, xmax, ymax --> x, y, w, h, alpha
-    r_boxes = rotate_boxes(_boxes, angle=angle, min_angle=1)
+    r_boxes = rotate_boxes(_boxes, angle=angle, min_angle=0)
     if boxes.dtype == int:
         # Back to absolute boxes
         r_boxes[:, [0, 2]] *= img.shape[1]


### PR DESCRIPTION
This PR fixes the rotation in the transform module.
(When `min_angle` > 0, if the angle was less than `min_angle` boxes were not rotated and returned in a straight way (4 coords), now boxes are always composed of 5 coords, even if the angle is 0.)