### PR TITLE
fix: Torch loss dimension

### DIFF
--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -245,7 +245,7 @@ class MASTER(_MASTER, nn.Module):
         cce[mask_2d] = 0
 
         ce_loss = cce.sum(1) / seq_len.to(dtype=torch.float32)
-        return torch.mean(ce_loss)
+        return ce_loss.mean()
 
     def forward(
         self,

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -245,7 +245,7 @@ class MASTER(_MASTER, nn.Module):
         cce[mask_2d] = 0
 
         ce_loss = cce.sum(1) / seq_len.to(dtype=torch.float32)
-        return ce_loss.unsqueeze(1)
+        return torch.mean(ce_loss)
 
     def forward(
         self,

--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -242,7 +242,7 @@ class SAR(nn.Module, RecognitionModel):
         cce[mask_2d] = 0
 
         ce_loss = cce.sum(1) / seq_len.to(dtype=torch.float32)
-        return ce_loss.unsqueeze(1)
+        return torch.mean(ce_loss)
 
 
 class SARPostProcessor(RecognitionPostProcessor):

--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -242,7 +242,7 @@ class SAR(nn.Module, RecognitionModel):
         cce[mask_2d] = 0
 
         ce_loss = cce.sum(1) / seq_len.to(dtype=torch.float32)
-        return torch.mean(ce_loss)
+        return ce_loss.mean()
 
 
 class SARPostProcessor(RecognitionPostProcessor):


### PR DESCRIPTION
This PR fixes both SAR & MASTER loss in pytorch which were composed of more than 1 scalar, which was triggering an error when training:
`RuntimeError: grad can be implicitly created only for scalar outputs`