### PR TITLE
feat: Added dynamic sequence encoding

### DIFF
--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -74,12 +74,13 @@ def decode_sequence(
         mapping: vocabulary (string), the encoding is given by the indexing of the character sequence
 
     Returns:
-        A string, decoded from input_array"""
+        A string, decoded from input_array
+    """
 
     if not input_array.dtype == np.int_ or input_array.max() >= len(mapping):
         raise AssertionError("Input must be an array of int, with max less than mapping size")
-    decoded = ''.join(mapping[idx] for idx in input_array)
-    return decoded
+
+    return ''.join(map(mapping.__getitem__, input_array))
 
 
 def encode_sequences(


### PR DESCRIPTION
This PR introduces the following modifications:
- renamed `encode_sequence` into `encode_string`
- improved speed of all encoding but leveraging `map`
- fixed sequence size resolution (missing EOS count)
- added option to have a soft target_size (taking the minimum between specified size and dynamic seq length)
- updates unittests accordingly

Resolves #387

Any feedback is welcome!