### PR TITLE
fix: Fixed framework alignment on MobileNet V3 implementations

### DIFF
--- a/doctr/models/backbones/mobilenet/tensorflow.py
+++ b/doctr/models/backbones/mobilenet/tensorflow.py
@@ -165,7 +165,7 @@ class MobileNetV3(Sequential):
         _layers.append(
             Sequential(
                 conv_sequence(6 * layout[-1].out_channels, hard_swish, True, kernel_size=1),
-                name="last_conv"
+                name="final_block"
             )
         )
 

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -34,7 +34,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'mean': (0.798, 0.785, 0.772),
         'std': (0.264, 0.2749, 0.287),
         'backbone': 'mobilenet_v3_small',
-        'fpn_layers': ["inverted_0", "inverted_2", "inverted_7", "last_conv"],
+        'fpn_layers': ["inverted_0", "inverted_2", "inverted_7", "final_block"],
         'fpn_channels': 128,
         'input_shape': (1024, 1024, 3),
         'rotated_bbox': False,
@@ -291,6 +291,7 @@ def _db_mobilenet(arch: str, pretrained: bool, input_shape: Tuple[int, int, int]
     feat_extractor = IntermediateLayerGetter(
         backbones.__dict__[_cfg['backbone']](
             input_shape=_cfg['input_shape'],
+            include_top=False,
         ),
         _cfg['fpn_layers'],
     )

--- a/doctr/models/utils/tensorflow.py
+++ b/doctr/models/utils/tensorflow.py
@@ -115,7 +115,7 @@ class IntermediateLayerGetter(Model):
         model: Model,
         layer_names: List[str]
     ) -> None:
-        intermediate_fmaps = [model.get_layer(layer_name).output for layer_name in layer_names]
+        intermediate_fmaps = [model.get_layer(layer_name).get_output_at(0) for layer_name in layer_names]
         super().__init__(model.input, outputs=intermediate_fmaps)
 
     def __repr__(self) -> str:

--- a/test/tensorflow/test_models_backbones_tf.py
+++ b/test/tensorflow/test_models_backbones_tf.py
@@ -16,7 +16,7 @@ from doctr.models import backbones
 def test_classification_architectures(arch_name, top_implemented, input_shape, output_size):
     # Model
     batch_size = 2
-    model = backbones.__dict__[arch_name](pretrained=True)
+    model = backbones.__dict__[arch_name](pretrained=True, input_shape=input_shape)
     # Forward
     out = model(tf.random.uniform(shape=[batch_size, *input_shape], maxval=1, dtype=tf.float32))
     # Output checks


### PR DESCRIPTION
This PR introduces the following modifications:
- fixed the implementation of mobilenetV3 versions
- passes the input shape for a proper model build in the unittests of backbones

Any feedback is welcome!