### PR TITLE
fix: Fixed config for mobilenet_v3_large in PyTorch

### DIFF
--- a/doctr/models/backbones/mobilenet/pytorch.py
+++ b/doctr/models/backbones/mobilenet/pytorch.py
@@ -18,7 +18,7 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
     'mobilenet_v3_large': {
         'mean': (0.694, 0.695, 0.693),
         'std': (0.299, 0.296, 0.301),
-        'input_shape': (3, 224, 224),
+        'input_shape': (3, 32, 32),
         'vocab': VOCABS['french'],
         'url': 'https://github.com/mindee/doctr/releases/download/v0.3.0/mobilenet_v3_large-a0aea820.pt',
     },


### PR DESCRIPTION
This PR simply fixes the input shape for the pretrained Mobilenet V3-Large in PyTorch

Any feedback is welcome!