### PR TITLE
fix: Fixed PyTorch param loading

### DIFF
--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -262,7 +262,7 @@ def _dbnet(arch: str, pretrained: bool, pretrained_backbone: bool = False, **kwa
     model = DBNet(feat_extractor, default_cfgs[arch]['fpn_channels'], cfg=default_cfgs[arch], **kwargs)
     # Load pretrained parameters
     if pretrained:
-        load_pretrained_params(model, _cfg['url'])
+        load_pretrained_params(model, default_cfgs[arch]['url'])
 
     return model
 

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -12,6 +12,7 @@ from torchvision.models import resnet34, resnet50, mobilenet_v3_large
 from typing import List, Dict, Any, Optional
 
 from .base import DBPostProcessor, _DBNet
+from ...utils import load_pretrained_params
 
 __all__ = ['DBNet', 'db_resnet50', 'db_resnet34', 'db_mobilenet_v3']
 

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -261,7 +261,7 @@ def _dbnet(arch: str, pretrained: bool, pretrained_backbone: bool = False, **kwa
     model = DBNet(feat_extractor, default_cfgs[arch]['fpn_channels'], cfg=default_cfgs[arch], **kwargs)
     # Load pretrained parameters
     if pretrained:
-        raise NotImplementedError
+        load_pretrained_params(model, _cfg['url'])
 
     return model
 

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -250,7 +250,7 @@ def _linknet(arch: str, pretrained: bool, **kwargs: Any) -> LinkNet:
     model = LinkNet(_cfg['layout'], cfg=_cfg, **kwargs)
     # Load pretrained parameters
     if pretrained:
-        raise ValueError
+        load_pretrained_params(model, _cfg['url'])
 
     return model
 

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -11,6 +11,7 @@ from torchvision.models._utils import IntermediateLayerGetter
 from typing import List, Dict, Any, Optional
 
 from .base import LinkNetPostProcessor, _LinkNet
+from ...utils import load_pretrained_params
 
 __all__ = ['LinkNet', 'linknet16']
 

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -12,6 +12,7 @@ from torchvision.models import mobilenet_v3_small
 from typing import Tuple, Dict, Any, Optional, List
 
 from ... import backbones
+from ...utils import load_pretrained_params
 from ..core import RecognitionModel, RecognitionPostProcessor
 from ....datasets import VOCABS
 

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -253,7 +253,7 @@ def _crnn_mobilenet(
     model = CRNN(feat_extractor, cfg=_cfg, **kwargs)
     # Load pretrained parameters
     if pretrained:
-        raise NotImplementedError
+        load_pretrained_params(model, _cfg['url'])
 
     return model
 

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -225,7 +225,7 @@ def _crnn(arch: str, pretrained: bool, input_shape: Optional[Tuple[int, int, int
     model = CRNN(feat_extractor, cfg=_cfg, **kwargs)
     # Load pretrained parameters
     if pretrained:
-        raise NotImplementedError
+        load_pretrained_params(model, _cfg['url'])
 
     return model
 


### PR DESCRIPTION
Following up on #422, this PR switches back to the common parameter loading mechanism. 

Previously, some pytorch models' factory functions were throwing errors when `pretrained=True`. With this PR, it throws a warning and proceeds with param initialization when no checkpoint is available.

Any feedback is welcome!