### PR TITLE
fix: Fixed GPU selection in PyTorch training scripts

### DIFF
--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -122,6 +122,10 @@ def main(args):
             raise AssertionError("PyTorch cannot access your GPU. Please investigate!")
         if args.device >= torch.cuda.device_count():
             raise ValueError("Invalid device index")
+    # Silent default switch to GPU if available
+    elif torch.cuda.is_available():
+        args.device = 0
+    if torch.cuda.is_available():
         torch.cuda.set_device(args.device)
         model = model.cuda()
 

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -9,6 +9,7 @@ os.environ['USE_TORCH'] = '1'
 
 import time
 import datetime
+import logging
 import multiprocessing as mp
 import numpy as np
 from fastprogress.fastprogress import master_bar, progress_bar
@@ -125,6 +126,8 @@ def main(args):
     # Silent default switch to GPU if available
     elif torch.cuda.is_available():
         args.device = 0
+    else:
+        logging.warning("No accessible GPU, targe device set to CPU.")
     if torch.cuda.is_available():
         torch.cuda.set_device(args.device)
         model = model.cuda()

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -7,6 +7,7 @@ import os
 
 os.environ['USE_TORCH'] = '1'
 
+import logging
 import time
 import datetime
 import multiprocessing as mp


### PR DESCRIPTION
This PR introduces the following modifications:
- added GPU selection by default if available in PyTorch scripts
- added console warning when running on CPU
- fixed missing GPU support on text recognition training (considerable speedup)

Resolves #409

Any feedback is welcome!