### PR TITLE
fix: Fixed inverted mask in PyTorch implementation of MASTER loss

### DIFF
--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -241,7 +241,7 @@ class MASTER(_MASTER, nn.Module):
         # The "masked" first gt char is <sos>. Delete last logit of the model output.
         cce = F.cross_entropy(model_output[:, :-1, :].permute(0, 2, 1), gt[:, 1:], reduction='none')
         # Compute mask, remove 1 timestep here as well
-        mask_2d = torch.arange(input_len - 1, device=model_output.device)[None, :] < seq_len[:, None]
+        mask_2d = torch.arange(input_len - 1, device=model_output.device)[None, :] >= seq_len[:, None]
         cce[mask_2d] = 0
 
         ce_loss = cce.sum(1) / seq_len.to(dtype=model_output.dtype)


### PR DESCRIPTION
This PR fixes the mask of master loss in pytorch which was computed in the wrong way.
Any feedback is welcome!