### PR TITLE
refactor: Specified imports of file_utils in __init__.py

### DIFF
--- a/doctr/models/backbones/resnet/__init__.py
+++ b/doctr/models/backbones/resnet/__init__.py
@@ -1,4 +1,4 @@
-from doctr import is_tf_available, is_torch_available
+from doctr.file_utils import is_tf_available, is_torch_available
 
 if is_tf_available():
     from .tensorflow import *

--- a/doctr/models/backbones/vgg/__init__.py
+++ b/doctr/models/backbones/vgg/__init__.py
@@ -1,4 +1,4 @@
-from doctr import is_tf_available, is_torch_available
+from doctr.file_utils import is_tf_available, is_torch_available
 
 if is_tf_available():
     from .tensorflow import *

--- a/doctr/models/recognition/sar/__init__.py
+++ b/doctr/models/recognition/sar/__init__.py
@@ -1,4 +1,4 @@
-from doctr import is_tf_available, is_torch_available
+from doctr.file_utils import is_tf_available, is_torch_available
 
 if is_tf_available():
     from .tensorflow import *


### PR DESCRIPTION
Fixed error while importing functions like `is_tf_available` and `is_torch_available` because it is in `file_utils.py` file.