### PR TITLE
chore: Fixed dataset submodule import

### DIFF
--- a/doctr/__init__.py
+++ b/doctr/__init__.py
@@ -1,9 +1,7 @@
 from .file_utils import is_tf_available, is_torch_available
 from .version import __version__  # noqa: F401
+from . import datasets
 from . import io
 from . import transforms
 from . import utils
 from . import models
-
-if is_tf_available():
-    from . import datasets


### PR DESCRIPTION
This PR fixes a conditional import of the submodule `doctr.datasets` that was wrongly exclusive to Tensorflow.

Any feedback is welcome!