### PR TITLE
chore: Updated Pillow version constraints to avoid vulnerability

### DIFF
--- a/requirements-pt.txt
+++ b/requirements-pt.txt
@@ -10,5 +10,5 @@ weasyprint>=52.2
 unidecode>=1.0.0
 torch>=1.8.0
 torchvision>=0.9.0
-Pillow>=8.0.0,<8.3.0
+Pillow>=8.3.2
 tqdm>=4.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ mplcursors>=0.3
 weasyprint>=52.2,<53.0
 unidecode>=1.0.0
 tensorflow>=2.4.0
-Pillow>=8.0.0
+Pillow>=8.3.2
 tqdm>=4.30.0
 tensorflow-addons>=0.13.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ _deps = [
     "tensorflow-cpu>=2.4.0",
     "torch>=1.8.0",
     "torchvision>=0.9.0",
-    "Pillow>=8.0.0,<8.3.0",  # cf. https://github.com/python-pillow/Pillow/issues/5571
+    "Pillow>=8.3.2",  # cf. https://github.com/advisories/GHSA-98vv-pw6r-q6q4
     "tqdm>=4.30.0",
     "tensorflow-addons>=0.13.0"
 ]


### PR DESCRIPTION
This PR fixes a vulnerability spotted in https://github.com/advisories/GHSA-98vv-pw6r-q6q4 regarding previous versions of Pillow, by constraining the allowed versions of Pillow to recent releases.

Any feedback is welcome!