### PR TITLE
fix: Fixed cropping mode in predictor

### DIFF
--- a/doctr/models/core.py
+++ b/doctr/models/core.py
@@ -10,7 +10,7 @@ from typing import List, Any, Tuple, Dict
 from .detection import DetectionPredictor
 from .recognition import RecognitionPredictor
 from ._utils import extract_crops, extract_rcrops
-from doctr.file_utils import is_torch_available
+from doctr.file_utils import is_tf_available
 from doctr.io.elements import Word, Line, Block, Page, Document
 from doctr.utils.repr import NestedObject
 from doctr.utils.geometry import resolve_enclosing_bbox, resolve_enclosing_rbbox, rotate_boxes, rotate_image
@@ -54,7 +54,7 @@ class OCRPredictor(NestedObject):
         boxes = self.det_predictor(pages, **kwargs)
         # Check whether crop mode should be switched to channels first
         crop_kwargs = {}
-        if len(pages) > 0 and not isinstance(pages[0], np.ndarray) and is_torch_available():
+        if len(pages) > 0 and not isinstance(pages[0], np.ndarray) and not is_tf_available():
             crop_kwargs['channels_last'] = False
         # Crop images, rotate page if necessary
         if self.doc_builder.rotated_bbox:


### PR DESCRIPTION
This PR fixes the cropping mode when both frameworks are available. #458 introduced an issue occurring for users with both frameworks installed. SInce the priority (default framework mode) is TensorFlow, this PR switches the condition to ensure proper cropping.

Any feedback is welcome!