### PR TITLE
refactor: Deprecated crnn_resnet31 and sar_vgg16_bn

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -21,7 +21,7 @@ from doctr.models import ocr_predictor
 from doctr.utils.visualization import synthetize_page, visualize_page
 
 DET_ARCHS = ["db_resnet50"]
-RECO_ARCHS = ["crnn_vgg16_bn", "master", "crnn_resnet31", "sar_vgg16_bn", "sar_resnet31"]
+RECO_ARCHS = ["crnn_vgg16_bn", "master", "sar_resnet31"]
 
 
 def main():

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -121,7 +121,6 @@ Models expect a TensorFlow tensor as input and produces one in return. DocTR inc
 
 .. autofunction:: doctr.models.recognition.crnn_vgg16_bn
 .. autofunction:: doctr.models.recognition.crnn_mobilenet_v3_large
-.. autofunction:: doctr.models.recognition.sar_vgg16_bn
 .. autofunction:: doctr.models.recognition.sar_resnet31
 .. autofunction:: doctr.models.recognition.master
 
@@ -145,8 +144,6 @@ Predictors that localize and identify text elements in images
 | db_resnet50 + crnn_vgg16_bn | 71.25      | 76.02         | 0.85    | 83.99      |   81.42       | 1.6     |
 +-----------------------------+------------+---------------+---------+------------+---------------+---------+
 | db_resnet50 + master        | 71.26      | 76.03         |         | 84.61      |   82.02       |         |
-+-----------------------------+------------+---------------+---------+------------+---------------+---------+
-| db_resnet50 + sar_vgg16_bn  | N/A        | N/A           | 0.49    | N/A        | N/A           | 1.0     |
 +-----------------------------+------------+---------------+---------+------------+---------------+---------+
 | db_resnet50 + sar_resnet31  | 71.48      | 76.26         | 0.27    | 84.66      | **82.07**     | 0.83    |
 +-----------------------------+------------+---------------+---------+------------+---------------+---------+

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -16,7 +16,7 @@ from ...utils import load_pretrained_params
 from ..core import RecognitionModel, RecognitionPostProcessor
 from ....datasets import VOCABS
 
-__all__ = ['CRNN', 'crnn_vgg16_bn', 'crnn_resnet31', 'CTCPostProcessor', 'crnn_mobilenet_v3_small',
+__all__ = ['CRNN', 'crnn_vgg16_bn', 'CTCPostProcessor', 'crnn_mobilenet_v3_small',
            'crnn_mobilenet_v3_large']
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
@@ -24,14 +24,6 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'mean': (.5, .5, .5),
         'std': (1., 1., 1.),
         'backbone': vgg16_bn, 'rnn_units': 128, 'lstm_features': 512,
-        'input_shape': (3, 32, 128),
-        'vocab': VOCABS['french'],
-        'url': None,
-    },
-    'crnn_resnet31': {
-        'mean': (.5, .5, .5),
-        'std': (1., 1., 1.),
-        'backbone': resnet31, 'rnn_units': 128, 'lstm_features': 4 * 512,
         'input_shape': (3, 32, 128),
         'vocab': VOCABS['french'],
         'url': None,
@@ -274,27 +266,6 @@ def crnn_vgg16_bn(pretrained: bool = False, **kwargs: Any) -> CRNN:
     """
 
     return _crnn('crnn_vgg16_bn', pretrained, **kwargs)
-
-
-def crnn_resnet31(pretrained: bool = False, **kwargs: Any) -> CRNN:
-    """CRNN with a ResNet-31 backbone as described in `"An End-to-End Trainable Neural Network for Image-based
-    Sequence Recognition and Its Application to Scene Text Recognition" <https://arxiv.org/pdf/1507.05717.pdf>`_.
-
-    Example::
-        >>> import torch
-        >>> from doctr.models import crnn_resnet31
-        >>> model = crnn_resnet31(pretrained=True)
-        >>> input_tensor = torch.rand(1, 3, 32, 128)
-        >>> out = model(input_tensor)
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
-
-    Returns:
-        text recognition architecture
-    """
-
-    return _crnn('crnn_resnet31', pretrained, **kwargs)
 
 
 def crnn_mobilenet_v3_small(pretrained: bool = False, **kwargs: Any) -> CRNN:

--- a/doctr/models/recognition/crnn/tensorflow.py
+++ b/doctr/models/recognition/crnn/tensorflow.py
@@ -14,7 +14,7 @@ from ...utils import load_pretrained_params
 from ..core import RecognitionModel, RecognitionPostProcessor
 from ....datasets import VOCABS
 
-__all__ = ['CRNN', 'crnn_vgg16_bn', 'crnn_resnet31', 'CTCPostProcessor', 'crnn_mobilenet_v3_small',
+__all__ = ['CRNN', 'crnn_vgg16_bn', 'CTCPostProcessor', 'crnn_mobilenet_v3_small',
            'crnn_mobilenet_v3_large']
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
@@ -25,15 +25,6 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'input_shape': (32, 128, 3),
         'vocab': VOCABS['french'],
         'url': 'https://github.com/mindee/doctr/releases/download/v0.3.0/crnn_vgg16_bn-76b7f2c6.zip',
-    },
-    'crnn_resnet31': {
-        'mean': (0.694, 0.695, 0.693),
-        'std': (0.299, 0.296, 0.301),
-        'backbone': resnet31, 'rnn_units': 128,
-        'input_shape': (32, 128, 3),
-        'vocab': ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-'
-                  'kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l'),
-        'url': 'https://github.com/mindee/doctr/releases/download/v0.1.1/crnn_resnet31-69ab71db.zip',
     },
     'crnn_mobilenet_v3_small': {
         'mean': (0.694, 0.695, 0.693),
@@ -248,27 +239,6 @@ def crnn_vgg16_bn(pretrained: bool = False, **kwargs: Any) -> CRNN:
     """
 
     return _crnn('crnn_vgg16_bn', pretrained, **kwargs)
-
-
-def crnn_resnet31(pretrained: bool = False, **kwargs: Any) -> CRNN:
-    """CRNN with a resnet31 backbone as described in `"An End-to-End Trainable Neural Network for Image-based
-    Sequence Recognition and Its Application to Scene Text Recognition" <https://arxiv.org/pdf/1507.05717.pdf>`_.
-
-    Example::
-        >>> import tensorflow as tf
-        >>> from doctr.models import crnn_resnet31
-        >>> model = crnn_resnet31(pretrained=True)
-        >>> input_tensor = tf.random.uniform(shape=[1, 32, 128, 3], maxval=1, dtype=tf.float32)
-        >>> out = model(input_tensor)
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
-
-    Returns:
-        text recognition architecture
-    """
-
-    return _crnn('crnn_resnet31', pretrained, **kwargs)
 
 
 def crnn_mobilenet_v3_small(pretrained: bool = False, **kwargs: Any) -> CRNN:

--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -15,17 +15,9 @@ from ..core import RecognitionModel, RecognitionPostProcessor
 from ....datasets import VOCABS
 
 
-__all__ = ['SAR', 'sar_vgg16_bn', 'sar_resnet31']
+__all__ = ['SAR', 'sar_resnet31']
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
-    'sar_vgg16_bn': {
-        'mean': (.5, .5, .5),
-        'std': (1., 1., 1.),
-        'backbone': vgg16_bn, 'rnn_units': 512, 'max_length': 30, 'num_decoders': 2,
-        'input_shape': (3, 32, 128),
-        'vocab': VOCABS['french'],
-        'url': None,
-    },
     'sar_resnet31': {
         'mean': (.5, .5, .5),
         'std': (1., 1., 1.),
@@ -307,27 +299,6 @@ def _sar(
         load_pretrained_params(model, default_cfgs[arch]['url'])
 
     return model
-
-
-def sar_vgg16_bn(pretrained: bool = False, **kwargs: Any) -> SAR:
-    """SAR with a VGG16 feature extractor as described in `"Show, Attend and Read:A Simple and Strong
-    Baseline for Irregular Text Recognition" <https://arxiv.org/pdf/1811.00751.pdf>`_.
-
-    Example::
-        >>> import torch
-        >>> from doctr.models import sar_vgg16_bn
-        >>> model = sar_vgg16_bn(pretrained=False)
-        >>> input_tensor = torch.rand((1, 3, 32, 128))
-        >>> out = model(input_tensor)
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
-
-    Returns:
-        text recognition architecture
-    """
-
-    return _sar('sar_vgg16_bn', pretrained, **kwargs)
 
 
 def sar_resnet31(pretrained: bool = False, **kwargs: Any) -> SAR:

--- a/doctr/models/recognition/sar/tensorflow.py
+++ b/doctr/models/recognition/sar/tensorflow.py
@@ -14,18 +14,9 @@ from ..core import RecognitionModel, RecognitionPostProcessor
 from doctr.utils.repr import NestedObject
 from ....datasets import VOCABS
 
-__all__ = ['SAR', 'SARPostProcessor', 'sar_vgg16_bn', 'sar_resnet31']
+__all__ = ['SAR', 'SARPostProcessor', 'sar_resnet31']
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
-    'sar_vgg16_bn': {
-        'mean': (.5, .5, .5),
-        'std': (1., 1., 1.),
-        'backbone': vgg16_bn, 'rnn_units': 512, 'max_length': 30, 'num_decoders': 2,
-        'input_shape': (32, 128, 3),
-        'vocab': ('3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|za1ù8,OG€P-'
-                  'kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l'),
-        'url': 'https://github.com/mindee/doctr/releases/download/v0.1-models/sar_vgg16bn-0d7e2c26.zip',
-    },
     'sar_resnet31': {
         'mean': (0.694, 0.695, 0.693),
         'std': (0.299, 0.296, 0.301),
@@ -355,27 +346,6 @@ def _sar(
         load_pretrained_params(model, default_cfgs[arch]['url'])
 
     return model
-
-
-def sar_vgg16_bn(pretrained: bool = False, **kwargs: Any) -> SAR:
-    """SAR with a VGG16 feature extractor as described in `"Show, Attend and Read:A Simple and Strong
-    Baseline for Irregular Text Recognition" <https://arxiv.org/pdf/1811.00751.pdf>`_.
-
-    Example::
-        >>> import tensorflow as tf
-        >>> from doctr.models import sar_vgg16_bn
-        >>> model = sar_vgg16_bn(pretrained=False)
-        >>> input_tensor = tf.random.uniform(shape=[1, 64, 256, 3], maxval=1, dtype=tf.float32)
-        >>> out = model(input_tensor)
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
-
-    Returns:
-        text recognition architecture
-    """
-
-    return _sar('sar_vgg16_bn', pretrained, **kwargs)
 
 
 def sar_resnet31(pretrained: bool = False, **kwargs: Any) -> SAR:

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -14,8 +14,7 @@ from .. import recognition
 __all__ = ["recognition_predictor"]
 
 
-ARCHS = ['crnn_vgg16_bn', 'crnn_resnet31', 'crnn_mobilenet_v3_small', 'crnn_mobilenet_v3_large',
-         'sar_vgg16_bn', 'sar_resnet31', 'master']
+ARCHS = ['crnn_vgg16_bn', 'crnn_mobilenet_v3_small', 'crnn_mobilenet_v3_large', 'sar_resnet31', 'master']
 
 
 def _predictor(arch: str, pretrained: bool, **kwargs: Any) -> RecognitionPredictor:

--- a/test/pytorch/test_models_recognition_pt.py
+++ b/test/pytorch/test_models_recognition_pt.py
@@ -8,10 +8,8 @@ from doctr.models import recognition
     "arch_name, input_shape",
     [
         ["crnn_vgg16_bn", (3, 32, 128)],
-        ["crnn_resnet31", (3, 32, 128)],
         ["crnn_mobilenet_v3_small", (3, 32, 128)],
         ["crnn_mobilenet_v3_large", (3, 32, 128)],
-        ["sar_vgg16_bn", (3, 32, 128)],
         ["sar_resnet31", (3, 32, 128)],
         ["master", (3, 48, 160)],
     ],
@@ -59,10 +57,8 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
     "arch_name",
     [
         "crnn_vgg16_bn",
-        "crnn_resnet31",
         "crnn_mobilenet_v3_small",
         "crnn_mobilenet_v3_large",
-        "sar_vgg16_bn",
         "sar_resnet31",
         "master"
     ],

--- a/test/tensorflow/test_models_recognition_tf.py
+++ b/test/tensorflow/test_models_recognition_tf.py
@@ -10,10 +10,8 @@ from doctr.io import DocumentFile
     "arch_name, input_shape",
     [
         ["crnn_vgg16_bn", (32, 128, 3)],
-        ["crnn_resnet31", (32, 128, 3)],
         ["crnn_mobilenet_v3_small", (32, 128, 3)],
         ["crnn_mobilenet_v3_large", (32, 128, 3)],
-        ["sar_vgg16_bn", (32, 128, 3)],
         ["sar_resnet31", (32, 128, 3)],
         ["master", (32, 128, 3)],
     ],
@@ -87,10 +85,8 @@ def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
     "arch_name",
     [
         "crnn_vgg16_bn",
-        "crnn_resnet31",
         "crnn_mobilenet_v3_small",
         "crnn_mobilenet_v3_large",
-        "sar_vgg16_bn",
         "sar_resnet31",
         "master"
     ],

--- a/test/tensorflow/test_models_tf.py
+++ b/test/tensorflow/test_models_tf.py
@@ -41,10 +41,8 @@ def test_ocrpredictor(
 @pytest.mark.parametrize(
     "det_arch, reco_arch",
     [
-        ["db_resnet50", "sar_vgg16_bn"],
         ["db_resnet50", "crnn_vgg16_bn"],
         ["db_resnet50", "sar_resnet31"],
-        ["db_resnet50", "crnn_resnet31"],
     ],
 )
 def test_zoo_models(det_arch, reco_arch):


### PR DESCRIPTION
This PR introduces the following modifications:
- deprecated `crnn_resnet31` and `sar_vgg16_bn` and they use combinations of backbones that aren't recommended by their respective paper and do not bring about perf or speed boost.
- updated documentation accordingly
- updated unittests accordingly
- updated demo reco model selection

Any feedback is welcome!