### PR TITLE
chore: Removed some CI jobs with macOS

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python: [3.7, 3.8]
     steps:
       - if: matrix.os == 'macos-latest'

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python: [3.7, 3.8]
         framework: [tensorflow, pytorch]
     steps:
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python: [3.7, 3.8]
         framework: [tensorflow, pytorch]
     steps:


### PR DESCRIPTION
Unfortunately, the CI is getting slower by the way and the suspect is mostly macOS jobs. This PR keeps macOS jobs to build the project and collect environment but removes the rest to speed up PR CI jobs.

Any feedback is welcome!