### PR TITLE
feat: Improved font resolution and page synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,26 @@ doc = DocumentFile.from_pdf("path/to/your/doc.pdf").as_images()
 result = model(doc)
 ```
 
-To make sense of your model's predictions, you can visualize them as follows:
+To make sense of your model's predictions, you can visualize them interactively as follows:
 
 ```python
 result.show(doc)
 ```
 
-![DocTR example](https://github.com/mindee/doctr/releases/download/v0.1.1/doctr_example_script.gif)
+![Visualization sample](https://github.com/mindee/doctr/releases/download/v0.1.1/doctr_example_script.gif)
 
-The ocr_predictor returns a `Document` object with a nested structure (with `Page`, `Block`, `Line`, `Word`, `Artefact`). 
+Or even rebuild the original document from its predictions:
+
+```python
+import matplotlib.pyplot as plt
+
+plt.imshow(result.synthesize()); plt.axis('off'); plt.show()
+```
+
+![Synthesis sample](https://github.com/mindee/doctr/releases/download/v0.3.1/synthesized_sample.png)
+
+
+The `ocr_predictor` returns a `Document` object with a nested structure (with `Page`, `Block`, `Line`, `Word`, `Artefact`). 
 To get a better understanding of our document model, check our [documentation](https://mindee.github.io/doctr/io.html#document-structure):
 
 You can also export them as a nested dict, more appropriate for JSON format:

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -14,6 +14,8 @@ Easy-to-use functions to make sense of your model's predictions.
 
 .. autofunction:: visualize_page
 
+.. autofunction:: synthesize_page
+
 
 .. _metrics:
 

--- a/doctr/datasets/classification/base.py
+++ b/doctr/datasets/classification/base.py
@@ -9,6 +9,7 @@ import logging
 import platform
 
 from doctr.io.image import tensor_from_pil
+from doctr.utils.fonts import get_font
 from ..datasets import AbstractDataset
 
 
@@ -31,16 +32,7 @@ def synthesize_char_img(char: str, size: int = 32, font_family: Optional[str] = 
     d = ImageDraw.Draw(img)
 
     # Draw the character
-    if font_family is None:
-        try:
-            font = ImageFont.truetype("FreeMono.ttf" if platform.system() == "Linux" else "Arial.ttf", size)
-        except OSError:
-            font = ImageFont.load_default()
-            logging.warning("unable to load specific font families. Loading default PIL font,"
-                            "font size issues may be expected."
-                            "To prevent this, it is recommended to specify the value of 'font_family'.")
-    else:
-        font = ImageFont.truetype(font_family, size)
+    font = get_font(font_family, size)
     d.text((4, 0), char, font=font, fill=(255, 255, 255))
 
     return img

--- a/doctr/io/elements.py
+++ b/doctr/io/elements.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from typing import Tuple, Dict, List, Any, Optional, Union
 
 from doctr.utils.geometry import resolve_enclosing_bbox, resolve_enclosing_rbbox
-from doctr.utils.visualization import visualize_page
+from doctr.utils.visualization import visualize_page, synthesize_page
 from doctr.utils.common_types import BoundingBox, RotatedBbox
 from doctr.utils.repr import NestedObject
 
@@ -244,6 +244,15 @@ class Page(Element):
         visualize_page(self.export(), page, interactive=interactive)
         plt.show(**kwargs)
 
+    def synthesize(self, **kwargs) -> np.ndarray:
+        """Synthesize the page from the predictions
+
+        Returns:
+            synthesized page
+        """
+
+        return synthesize_page(self.export(), **kwargs)
+
     @classmethod
     def from_dict(cls, save_dict: Dict[str, Any], **kwargs):
         kwargs = {k: save_dict[k] for k in cls._exported_keys}
@@ -279,6 +288,15 @@ class Document(Element):
         """
         for img, result in zip(pages, self.pages):
             result.show(img, **kwargs)
+
+    def synthesize(self, **kwargs) -> List[np.ndarray]:
+        """Synthesize all pages from their predictions
+
+        Returns:
+            list of synthesized pages
+        """
+
+        return [page.synthesize() for page in self.pages]
 
     @classmethod
     def from_dict(cls, save_dict: Dict[str, Any], **kwargs):

--- a/doctr/models/recognition/__init__.py
+++ b/doctr/models/recognition/__init__.py
@@ -4,4 +4,4 @@ from .master import *
 from .sar import *
 from .zoo import *
 
-del utils
+del utils  # type: ignore[name-defined]

--- a/doctr/utils/fonts.py
+++ b/doctr/utils/fonts.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import platform
+import logging
+from PIL import ImageFont
+from typing import Optional
+
+__all__ = ['get_font']
+
+
+def get_font(font_family: Optional[str] = None, font_size: int = 13) -> ImageFont.ImageFont:
+
+    # Font selection
+    if font_family is None:
+        try:
+            font = ImageFont.truetype("FreeMono.ttf" if platform.system() == "Linux" else "Arial.ttf", font_size)
+        except OSError:
+            font = ImageFont.load_default()
+            logging.warning("unable to load recommended font family. Loading default PIL font,"
+                            "font size issues may be expected."
+                            "To prevent this, it is recommended to specify the value of 'font_family'.")
+    else:
+        font = ImageFont.truetype(font_family, font_size)
+
+    return font

--- a/test/common/test_io_elements.py
+++ b/test/common/test_io_elements.py
@@ -196,6 +196,11 @@ def test_page():
     # Show
     page.show(np.zeros((256, 256, 3), dtype=np.uint8), block=False)
 
+    # Synthesize
+    img = page.synthesize()
+    assert isinstance(img, np.ndarray)
+    assert img.shape == (*page_size, 3)
+
 
 def test_document():
     pages = _mock_pages()
@@ -214,3 +219,7 @@ def test_document():
 
     # Show
     doc.show([np.zeros((256, 256, 3), dtype=np.uint8) for _ in range(len(pages))], block=False)
+
+    # Synthesize
+    img_list = doc.synthesize()
+    assert isinstance(img_list, list) and len(img_list) == len(pages)

--- a/test/common/test_utils_fonts.py
+++ b/test/common/test_utils_fonts.py
@@ -2,6 +2,7 @@ from PIL.ImageFont import ImageFont
 
 from doctr.utils.fonts import get_font
 
+
 def test_get_font():
 
     # Attempts to load recommended OS font

--- a/test/common/test_utils_fonts.py
+++ b/test/common/test_utils_fonts.py
@@ -1,0 +1,10 @@
+from PIL.ImageFont import ImageFont
+
+from doctr.utils.fonts import get_font
+
+def test_get_font():
+
+    # Attempts to load recommended OS font
+    font = get_font()
+
+    assert isinstance(font, ImageFont)

--- a/test/common/test_utils_visualization.py
+++ b/test/common/test_utils_visualization.py
@@ -21,10 +21,12 @@ def test_visualize_page():
         visualization.create_obj_patch((1, 2, 3, 4, 5), (100, 100))
 
 
-def test_draw_page():
+def test_synthesize_page():
     pages = _mock_pages()
-    visualization.synthetize_page(pages[0].export(), draw_proba=True)
-    visualization.synthetize_page(pages[0].export(), draw_proba=False)
+    visualization.synthesize_page(pages[0].export(), draw_proba=False)
+    render = visualization.synthesize_page(pages[0].export(), draw_proba=True)
+    assert isinstance(render, np.ndarray)
+    assert render.shape == (*pages[0].dimensions, 3)
 
 
 def test_draw_boxes():


### PR DESCRIPTION
This PR introduces the following modifications:
- refactored all font selection code into a `doctr.utils.fonts` module (for character generation & page synthesis)
- fixed typo `synthetize_page` --> `synthesize_page`
- improve page synthesis thanks to the new font module
- added a `synthesize` method to `Document` and `Page`
- added synthesis visualization sample in the README
- updated unittests
- updated documentation

As shown in the README, here is how it renders:
![synthesis sample](https://github.com/mindee/doctr/releases/download/v0.3.1/synthesized_sample.png)

Any feedback is welcome!