### PR TITLE
fix: Prevents rounding errors in RandomCrop

### DIFF
--- a/doctr/transforms/modules/base.py
+++ b/doctr/transforms/modules/base.py
@@ -126,11 +126,16 @@ class RandomCrop(NestedObject):
 
     def __call__(self, img: Any, target: Dict[str, np.ndarray]) -> Tuple[Any, Dict[str, np.ndarray]]:
         h, w = img.shape[:2]
-        random_scale = random.uniform(self.scale[0], self.scale[1])
-        random_ratio = random.uniform(self.ratio[0], self.ratio[1])
-        crop_h = math.sqrt(random_scale * random_ratio)
-        crop_w = math.sqrt(random_scale / random_ratio)
+        scale = random.uniform(self.scale[0], self.scale[1])
+        ratio = random.uniform(self.ratio[0], self.ratio[1])
+        crop_h = math.sqrt(scale * ratio)
+        crop_w = math.sqrt(scale / ratio)
         start_x, start_y = random.uniform(0, 1 - crop_w), random.uniform(0, 1 - crop_h)
-        crop_box = (int(start_x * w), int(start_y * h), int((start_x + crop_w) * w), int((start_y + crop_h) * h))
+        crop_box = (
+            max(0, int(round(start_x * w))),
+            max(0, int(round(start_y * h))),
+            min(int(round((start_x + crop_w) * w)), w - 1),
+            min(int(round((start_y + crop_h) * h)), h - 1)
+        )
         croped_img, crop_boxes = F.crop_detection(img, target["boxes"], crop_box)
         return croped_img, dict(boxes=crop_boxes)


### PR DESCRIPTION
In very rare cases, the generated coordinates of the crop from `RandomCrop` were out of bounds (negative usually). This PR ensures that proper rounding is used and adds clipping to avoid issues.

Any feedback is welcome!