### PR TITLE
feat: add pytorch ckpts for crnn & mobilenet_v3_large

### DIFF
--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -42,9 +42,9 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'backbone_submodule': 'features',
         'fpn_layers': ['3', '6', '12', '16'],
         'input_shape': (3, 1024, 1024),
-        'mean': (.5, .5, .5),
-        'std': (1., 1., 1.),
-        'url': None,
+        'mean': (0.798, 0.785, 0.772),
+        'std': (0.264, 0.2749, 0.287),
+        'url': 'https://github.com/mindee/doctr/releases/download/v0.3.1/db_mobilenet_v3_large-fd62154b.pt',
     },
 }
 

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -20,12 +20,12 @@ __all__ = ['CRNN', 'crnn_vgg16_bn', 'CTCPostProcessor', 'crnn_mobilenet_v3_small
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
     'crnn_vgg16_bn': {
-        'mean': (.5, .5, .5),
-        'std': (1., 1., 1.),
+        'mean': (0.694, 0.695, 0.693),
+        'std': (0.299, 0.296, 0.301),
         'backbone': vgg16_bn, 'rnn_units': 128, 'lstm_features': 512,
         'input_shape': (3, 32, 128),
         'vocab': VOCABS['legacy_french'],
-        'url': None,
+        'url': 'https://github.com/mindee/doctr/releases/download/v0.3.1/crnn_vgg16_bn-9762b0b0.pt',
     },
     'crnn_mobilenet_v3_small': {
         'mean': (.5, .5, .5),


### PR DESCRIPTION
This PR adds pytorch ckpts for crnn_vgg_16_bn and mobilenet_v3_large, here is the benchmark performed with the ckpts:

```
FUNSD
Text Detection - Recall: 80.98%, Precision: 85.28%, Mean IoU: 68.91%
Text Recognition - Accuracy: 85.85% (unicase: 86.76%)
OCR - Recall: 67.90% (unicase: 68.52%), Precision: 71.51% (unicase: 72.17%), Mean IoU: 68.91%

CORD
Text Detection - Recall: 80.48%, Precision: 66.62%, Mean IoU: 56.98%
Text Recognition - Accuracy: 92.53% (unicase: 92.92%)
OCR - Recall: 70.80% (unicase: 71.12%), Precision: 58.60% (unicase: 58.86%), Mean IoU: 56.98%

RECEIPTS
Text Detection - Recall: 84.70%, Precision: 85.62%, Mean IoU: 72.19%
Text Recognition - Accuracy: 91.70% (unicase: 92.45%)
OCR - Recall: 76.87% (unicase: 77.51%), Precision: 77.70% (unicase: 78.34%), Mean IoU: 72.19%

IDS
Text Detection - Recall: 66.32%, Precision: 59.12%, Mean IoU: 48.83%
Text Recognition - Accuracy: 64.81% (unicase: 67.50%)
OCR - Recall: 44.58% (unicase: 46.75%), Precision: 39.74% (unicase: 41.67%), Mean IoU: 48.83%

INVOICES
Text Detection - Recall: 69.46%, Precision: 72.85%, Mean IoU: 61.74%
Text Recognition - Accuracy: 90.12% (unicase: 91.59%)
OCR - Recall: 64.03% (unicase: 65.06%), Precision: 67.15% (unicase: 68.23%), Mean IoU: 61.74%

TAX FORM US
Text Detection - Recall: 80.74%, Precision: 92.92%, Mean IoU: 70.90%
Text Recognition - Accuracy: 84.30% (unicase: 84.83%)
OCR - Recall: 78.21% (unicase: 78.58%), Precision: 90.02% (unicase: 90.45%), Mean IoU: 70.90%
```
