### PR TITLE
Misc fixed to Streamlit demo

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -4,7 +4,9 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
+import cv2
 import streamlit as st
+import tensorflow as tf
 import matplotlib.pyplot as plt
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"

--- a/demo/app.py
+++ b/demo/app.py
@@ -4,9 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
-import cv2
 import streamlit as st
-import tensorflow as tf
 import matplotlib.pyplot as plt
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,4 +1,2 @@
--e git+https://github.com/mindee/doctr.git#egg=doctr
-tensorflow
-tensorflow-addons
+-e git+https://github.com/mindee/doctr.git#egg=doctr[tf]
 streamlit>=0.65.0

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,2 +1,2 @@
-doctr
+doctr[tf]
 streamlit>=0.65.0

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,2 +1,4 @@
-doctr[tf]
+-e git+https://github.com/mindee/doctr.git#egg=doctr
+tensorflow
+tensorflow-addons
 streamlit>=0.65.0


### PR DESCRIPTION
Hello!

I built a Space demo hosting your Streamlit example (link at https://huggingface.co/spaces/osanseviero/doctr). It works great and is much faster than I expected.

I did face some issues during the development. I hope this PR fixes them:

1. You suggest to install `doctr` in the `requirements` but I think that's actually an unrelated package, it should be `python-doctr`.
2. But then `out.pages[0].synthesize()` threw an error saying `Page` class has no `synthesize` method. This was introduced in #472 so I don't think it's in the recent release. 

Given 1 and 2, and that #472 will probably be soon in a release, maybe we could change `requirements.txt` to install `python-doctr[tf]` instead of installing directly from GitHub. WDYT?