### PR TITLE
chore: Fixed requirements for the API template & training scripts

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
 fastapi>=0.65.2
 uvicorn>=0.11.1
 python-multipart==0.0.5
-python-doctr>=0.1.1
+python-doctr>=0.2.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
 fastapi>=0.65.2
 uvicorn>=0.11.1
 python-multipart==0.0.5
-doctr>=0.1.1
+python-doctr>=0.1.1

--- a/references/requirements.txt
+++ b/references/requirements.txt
@@ -1,3 +1,3 @@
-doctr
+-e git+https://github.com/mindee/doctr.git#egg=doctr
 fastprogress>=0.1.21
 wandb>=0.10.31


### PR DESCRIPTION
This PR introduces the following changes:
- fixes the requirements of the API (in case the user installs the demo reqs without Docker, it was fetching the pypi index named "doctr" which is a different project). Using a git branch installation would have required to modify the Dockerfile to add git.
- fixes the training script requirements (since this will most often not be done in a docker container, we can assume the user has git, hence the git branch installation)

Any feedback is welcome!

cc @jonathanMindee 