### PR TITLE
fix: Fixed support of characters out of latin-1 in page synthesis

### DIFF
--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -11,6 +11,7 @@ from PIL import ImageFont, ImageDraw, Image
 from copy import deepcopy
 import numpy as np
 import cv2
+from unidecode import unidecode
 from typing import Tuple, List, Dict, Any, Union, Optional
 
 from .common_types import BoundingBox, RotatedBbox
@@ -279,7 +280,11 @@ def synthesize_page(
                 img = Image.new('RGB', (xmax - xmin, ymax - ymin), color=(255, 255, 255))
                 d = ImageDraw.Draw(img)
                 # Draw in black the value of the word
-                d.text((0, 0), word["value"], font=font, fill=(0, 0, 0))
+                try:
+                    d.text((0, 0), word["value"], font=font, fill=(0, 0, 0))
+                except UnicodeEncodeError:
+                    # When character cannot be encoded, use its unidecode version
+                    d.text((0, 0), unidecode(word["value"]), font=font, fill=(0, 0, 0))
 
                 # Colorize if draw_proba
                 if draw_proba:


### PR DESCRIPTION
This PR fixes the page synthesis feature. Up until now, we have relied on the support of text drawing using Pillow. However as pointed out by #495, this support is limited. 

This snippet crashes:
```python
from PIL import Image, ImageDraw
img = Image.new('RGB', (100, 100), color=(255, 255, 255))
d = ImageDraw.Draw(img)
d.text((0, 0), '€', fill=(0, 0, 0))
```

this PR changes this by catching the `UnicodeEncodeError` and normalizing the string as follows:
```python
from PIL import Image, ImageDraw
from unidecode import unidecode
img = Image.new('RGB', (100, 100), color=(255, 255, 255))
d = ImageDraw.Draw(img)
d.text((0, 0), unidecode('€'), fill=(0, 0, 0))  #  <--- over HERE
```

Please note that in doing so, some string will be synthesized with different length cf the snippet below:
```
In [1]: from unidecode import unidecode
In [2]: print(unidecode('€'))
EUR
```

Closes #495

Any feedback is welcome!