### PR TITLE
fix: Fixed inconsistency of export when nothing is detected

### DIFF
--- a/doctr/models/builder.py
+++ b/doctr/models/builder.py
@@ -250,36 +250,34 @@ class DocumentBuilder(NestedObject):
     def __call__(
         self,
         boxes: List[np.ndarray],
-        word_preds: List[Tuple[str, float]],
+        text_preds: List[List[Tuple[str, float]]],
         page_shapes: List[Tuple[int, int]]
     ) -> Document:
         """Re-arrange detected words into structured blocks
 
         Args:
-            boxes: list of localization predictions for all words, of shape (N, 5) or (N, 6)
-            word_preds: list of all word values, of size N
-            page_shape: shape of each page
+            boxes: list of N elements, where each element represents the localization predictions, of shape (*, 5)
+                or (*, 6) for all words for a given page
+            text_preds: list of N elements, where each element is the list of all word prediction (text + confidence)
+            page_shape: shape of each page, of size N
 
         Returns:
-            list of documents
+            document object
         """
 
-        # Check the number of crops for each page
-        page_idx, crop_idx = 0, 0
-        _pages = []
-        for page_boxes in boxes:
-            # Assemble all detected words into structured blocks
-            _pages.append(
-                Page(
-                    self._build_blocks(
-                        page_boxes,
-                        word_preds[crop_idx: crop_idx + page_boxes.shape[0]]
-                    ),
-                    page_idx,
-                    page_shapes[page_idx],
-                )
+        if len(boxes) != len(text_preds) or len(boxes) != len(page_shapes):
+            raise ValueError("All arguments are expected to be lists of the same size")
+
+        _pages = [
+            Page(
+                self._build_blocks(
+                    page_boxes,
+                    word_preds,
+                ),
+                _idx,
+                shape,
             )
-            crop_idx += page_boxes.shape[0]
-            page_idx += 1
+            for _idx, shape, page_boxes, word_preds in zip(range(len(boxes)), page_shapes, boxes, text_preds)
+        ]
 
         return Document(_pages)

--- a/doctr/models/predictor/base.py
+++ b/doctr/models/predictor/base.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import numpy as np
+from typing import List, Tuple
+
+from doctr.models.builder import DocumentBuilder
+from doctr.utils.geometry import rotate_image
+from .._utils import extract_crops, extract_rcrops
+
+
+__all__ = ['_OCRPredictor']
+
+
+class _OCRPredictor:
+    """Implements an object able to localize and identify text elements in a set of documents
+
+    Args:
+        det_predictor: detection module
+        reco_predictor: recognition module
+    """
+
+    doc_builder: DocumentBuilder
+
+    @staticmethod
+    def _generate_crops(
+        pages: List[np.ndarray],
+        loc_preds: List[Tuple[np.ndarray, float]],
+        channels_last: bool,
+        allow_rotated_boxes: bool = False
+    ) -> List[List[np.ndarray]]:
+
+        if allow_rotated_boxes:
+            crops = [
+                extract_rcrops(rotate_image(page, -angle, False), _boxes[:, :-1], channels_last=channels_last)
+                for page, (_boxes, angle) in zip(pages, loc_preds)
+            ]
+        else:
+            crops = [
+                extract_crops(page, _boxes[:, :-1], channels_last=channels_last)
+                for page, (_boxes, _) in zip(pages, loc_preds)
+            ]
+
+        return crops
+
+    def _prepare_crops(
+        self,
+        pages: List[np.ndarray],
+        loc_preds: List[Tuple[np.ndarray, float]],
+        channels_last: bool,
+    ) -> Tuple[List[List[np.ndarray]], List[Tuple[np.ndarray, float]]]:
+
+        crops = self._generate_crops(pages, loc_preds, channels_last, self.doc_builder.rotated_bbox)
+
+        # Avoid sending zero-sized crops
+        is_kept = [[all(s > 0 for s in crop.shape) for crop in page_crops] for page_crops in crops]
+        crops = [
+            [crop for crop, _kept in zip(page_crops, page_kept) if _kept]
+            for page_crops, page_kept in zip(crops, is_kept)
+        ]
+        loc_preds = [(_boxes[_kept], angle) for (_boxes, angle), _kept in zip(loc_preds, is_kept)]
+
+        return crops, loc_preds
+
+    @staticmethod
+    def _process_predictions(
+        loc_preds: List[Tuple[np.ndarray, float]],
+        word_preds: List[Tuple[str, float]],
+        allow_rotated_boxes: bool = False
+    ) -> Tuple[List[np.ndarray], List[List[Tuple[str, float]]]]:
+        # Localization
+        boxes, angles = zip(*loc_preds)
+        # Rotate back boxes if necessary
+        if allow_rotated_boxes:
+            boxes = [rotate_boxes(page_boxes, angle) for page_boxes, angle in zip(boxes, angles)]
+        # Text
+        text_preds, _idx = [], 0
+        for page_boxes in boxes:
+            text_preds.append(word_preds[_idx: _idx + page_boxes.shape[0]])
+            _idx += page_boxes.shape[0]
+
+        return boxes, text_preds

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -60,9 +60,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
         # Identify character sequences
         word_preds = self.reco_predictor([crop for page_crops in crops for crop in page_crops], **kwargs)
 
-        boxes, text_preds = [], []
-        if len(loc_preds) > 0:
-            boxes, text_preds = self._process_predictions(loc_preds, word_preds, self.doc_builder.rotated_bbox)
+        boxes, text_preds = self._process_predictions(loc_preds, word_preds, self.doc_builder.rotated_bbox)
         out = self.doc_builder(
             boxes,
             text_preds,

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -12,8 +12,6 @@ from doctr.io.elements import Document
 from doctr.models.builder import DocumentBuilder
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
-from doctr.utils.geometry import rotate_image, rotate_boxes
-from .._utils import extract_crops, extract_rcrops
 from .base import _OCRPredictor
 
 

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -14,12 +14,13 @@ from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.utils.geometry import rotate_image, rotate_boxes
 from .._utils import extract_crops, extract_rcrops
+from .base import _OCRPredictor
 
 
 __all__ = ['OCRPredictor']
 
 
-class OCRPredictor(nn.Module):
+class OCRPredictor(nn.Module, _OCRPredictor):
     """Implements an object able to localize and identify text elements in a set of documents
 
     Args:
@@ -38,7 +39,6 @@ class OCRPredictor(nn.Module):
         self.det_predictor = det_predictor.eval()  # type: ignore[attr-defined]
         self.reco_predictor = reco_predictor.eval()  # type: ignore[attr-defined]
         self.doc_builder = DocumentBuilder(rotated_bbox=rotated_bbox)
-        self.extract_crops_fn = extract_rcrops if rotated_bbox else extract_crops
 
     @torch.no_grad()
     def forward(
@@ -52,41 +52,22 @@ class OCRPredictor(nn.Module):
             raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")
 
         # Localize text elements
-        boxes = self.det_predictor(pages, **kwargs)
+        loc_preds = self.det_predictor(pages, **kwargs)
         # Check whether crop mode should be switched to channels first
-        crop_kwargs = {}
-        if len(pages) > 0 and not isinstance(pages[0], np.ndarray):
-            crop_kwargs['channels_last'] = False
+        channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
         # Crop images, rotate page if necessary
-        if self.doc_builder.rotated_bbox:
-            crops = [
-                crop for page, (_boxes, angle) in zip(pages, boxes) for crop in
-                self.extract_crops_fn(  # type: ignore[operator]
-                    rotate_image(page, -angle, False),
-                    _boxes[:, :-1],
-                    **crop_kwargs
-                )
-            ]
-        else:
-            crops = [crop for page, (_boxes, _) in zip(pages, boxes) for crop in
-                     self.extract_crops_fn(page, _boxes[:, :-1], **crop_kwargs)]  # type: ignore[operator]
-        # Avoid sending zero-sized crops
-        is_kept = [all(s > 0 for s in crop.shape) for crop in crops]
-        crops = [crop for crop, _kept in zip(crops, is_kept) if _kept]
-        boxes = [box for box, _kept in zip(boxes, is_kept) if _kept]
+        crops, loc_preds = self._prepare_crops(pages, loc_preds, channels_last=channels_last)
         # Identify character sequences
-        word_preds = self.reco_predictor(crops, **kwargs)
+        word_preds = self.reco_predictor([crop for page_crops in crops for crop in page_crops], **kwargs)
 
-        # Rotate back boxes if necessary
-        if len(boxes) > 0:
-            boxes, angles = zip(*boxes)
-            if self.doc_builder.rotated_bbox:
-                boxes = [rotate_boxes(boxes_page, angle) for boxes_page, angle in zip(boxes, angles)]
+        boxes, text_preds = [], []
+        if len(loc_preds) > 0:
+            boxes, text_preds = self._process_predictions(loc_preds, word_preds, self.doc_builder.rotated_bbox)
         out = self.doc_builder(
             boxes,
-            word_preds,
+            text_preds,
             [
-                page.shape[:2] if crop_kwargs.get('channels_last', True) else page.shape[-2:]  # type: ignore[misc]
+                page.shape[:2] if channels_last else page.shape[-2:]  # type: ignore[misc]
                 for page in pages
             ]
         )

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -57,8 +57,6 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         # Identify character sequences
         word_preds = self.reco_predictor([crop for page_crops in crops for crop in page_crops], **kwargs)
 
-        boxes, text_preds = [], []
-        if len(loc_preds) > 0:
-            boxes, text_preds = self._process_predictions(loc_preds, word_preds, self.doc_builder.rotated_bbox)
+        boxes, text_preds = self._process_predictions(loc_preds, word_preds, self.doc_builder.rotated_bbox)
         out = self.doc_builder(boxes, text_preds, [page.shape[:2] for page in pages])  # type: ignore[misc]
         return out

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -12,8 +12,6 @@ from doctr.utils.repr import NestedObject
 from doctr.models.builder import DocumentBuilder
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
-from doctr.utils.geometry import rotate_image, rotate_boxes
-from .._utils import extract_crops, extract_rcrops
 from .base import _OCRPredictor
 
 

--- a/test/common/test_models_builder.py
+++ b/test/common/test_models_builder.py
@@ -15,7 +15,10 @@ def test_documentbuilder():
     boxes = np.random.rand(words_per_page, 6)
     boxes[:2] *= boxes[2:4]
 
-    out = doc_builder([boxes, boxes], [('hello', 1.0)] * (num_pages * words_per_page), [(100, 200), (100, 200)])
+    # Arg consistency check
+    with pytest.raises(ValueError):
+        doc_builder([boxes, boxes], [('hello', 1.0)] * 3, [(100, 200), (100, 200)])
+    out = doc_builder([boxes, boxes], [[('hello', 1.0)] * words_per_page] * num_pages, [(100, 200), (100, 200)])
     assert isinstance(out, Document)
     assert len(out.pages) == num_pages
     # 1 Block & 1 line per page
@@ -24,11 +27,11 @@ def test_documentbuilder():
 
     # Resolve lines
     doc_builder = builder.DocumentBuilder(resolve_lines=True, resolve_blocks=True)
-    out = doc_builder([boxes, boxes], [('hello', 1.0)] * (num_pages * words_per_page), [(100, 200), (100, 200)])
+    out = doc_builder([boxes, boxes], [[('hello', 1.0)] * words_per_page] * num_pages, [(100, 200), (100, 200)])
 
     # No detection
     boxes = np.zeros((0, 5))
-    out = doc_builder([boxes, boxes], [], [(100, 200), (100, 200)])
+    out = doc_builder([boxes, boxes], [[], []], [(100, 200), (100, 200)])
     assert len(out.pages[0].blocks) == 0
 
     # Repr


### PR DESCRIPTION
So I noticed that when the predictor wasn't detecting anything, the number of pages in the export wasn't matching the input. Even if it doesn't manage to detect anything, the export should reflect the correct number of pages.
This PR introduces the following modifications:
- refactors the `DocumentBuilder` to ensure that localization predictions are the same length as the text predictions, as well as the number of pages
- fixed zero-sized crop filtering (on multi-pages cases)
- refactored crop preparation & prediction processing for all framework-specific predictors

Using this image
![euro](https://user-images.githubusercontent.com/76527547/135123143-d764be2c-4407-42b3-b8af-45a791586546.png)

with the following snippet:
```python
from doctr.models import ocr_predictor
from doctr.io import DocumentFile
predictor = ocr_predictor(pretrained=True)

doc = DocumentFile.from_images('/home/fg/Downloads/euro.png')
out = predictor(doc)
print(out.export())
```

used to yield:
```
{'pages': []}
```

and now yields:
```
{'pages': [{'page_idx': 0,
   'dimensions': (960, 640),
   'orientation': {'value': None, 'confidence': None},
   'language': {'value': None, 'confidence': None},
   'blocks': []}]}
```

I checked with a sample PDF, both TF & PyTorch are yielding almost identical results.

Any feedback is welcome!
