### PR TITLE
chore: Split common, torch & tensorflow unittests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,44 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[torch] --upgrade
 
+  pytest-common:
+    needs: install-tf
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: [3.7]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: x64
+      - name: Cache python modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-
+            ${{ runner.os }}-pkg-deps-${{ matrix.python }}-
+            ${{ runner.os }}-pkg-deps-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[tf] --upgrade
+          pip install -r test/requirements.txt
+      - name: Run unittests
+        run: |
+          coverage run -m pytest test/common/
+          coverage xml
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage-common
+          path: ./coverage-common.xml
+
   pytest-tf:
     needs: install-tf
     runs-on: ${{ matrix.os }}
@@ -94,12 +132,12 @@ jobs:
           pip install -r test/requirements.txt
       - name: Run unittests
         run: |
-          coverage run -m pytest test/ --ignore test/pytorch
+          coverage run -m pytest test/tensorflow/
           coverage xml
       - uses: actions/upload-artifact@v2
         with:
-          name: coverage-main
-          path: ./coverage.xml
+          name: coverage-tf
+          path: ./coverage-tf.xml
 
   pytest-torch:
     needs: install-pytorch
@@ -143,7 +181,7 @@ jobs:
 
   codecov-upload:
     runs-on: ubuntu-latest
-    needs: [ pytest-tf, pytest-torch ]
+    needs: [ pytest-common, pytest-tf, pytest-torch ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
For clarity and CI speedups, this PR splits the unittests of `common`, `pytorch`, and `tensorflow`.
This brings several advantages:
- many unittests will now be done in parallel instead of making `pytest-tf` slower
- when an error occurs, it's easier to spot right now if it involves any of the framework

Any feedback is welcome!