### PR TITLE
chore: Fixed coverage upload of TF unittests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Run unittests
         run: |
           coverage run -m pytest test/tensorflow/
-          coverage xml
+          coverage xml -o coverage-tf.xml
       - uses: actions/upload-artifact@v2
         with:
           name: coverage-tf


### PR DESCRIPTION
This PR fixes the pytest CI job for TensorFlow. The coverage file was wrongly named in #498 and thus this coverage report was not uploaded to codecov.

Any feedback is welcome!