### PR TITLE
chore: Fixed coverage upload of common

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,7 @@ jobs:
         with:
           name: coverage-common
           path: ./coverage-common.xml
+          if-no-files-found: error
 
   pytest-tf:
     needs: install-tf
@@ -138,6 +139,7 @@ jobs:
         with:
           name: coverage-tf
           path: ./coverage-tf.xml
+          if-no-files-found: error
 
   pytest-torch:
     needs: install-pytorch
@@ -178,6 +180,7 @@ jobs:
         with:
           name: coverage-pytorch
           path: ./coverage-pt.xml
+          if-no-files-found: error
 
   codecov-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Run unittests
         run: |
           coverage run -m pytest test/common/
-          coverage xml
+          coverage xml -o coverage-common.xml
       - uses: actions/upload-artifact@v2
         with:
           name: coverage-common


### PR DESCRIPTION
Similarly to #503, this PR fixes the pytest CI job for common. The coverage file was wrongly named in #498 and thus this coverage report was not uploaded to codecov.

Any feedback is welcome!