### PR TITLE
docs: Restructured documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) ![Build Status](https://github.com/mindee/doctr/workflows/builds/badge.svg) [![codecov](https://codecov.io/gh/mindee/doctr/branch/main/graph/badge.svg?token=577MO567NM)](https://codecov.io/gh/mindee/doctr) [![CodeFactor](https://www.codefactor.io/repository/github/mindee/doctr/badge?s=bae07db86bb079ce9d6542315b8c6e70fa708a7e)](https://www.codefactor.io/repository/github/mindee/doctr) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/340a76749b634586a498e1c0ab998f08)](https://app.codacy.com/gh/mindee/doctr?utm_source=github.com&utm_medium=referral&utm_content=mindee/doctr&utm_campaign=Badge_Grade) [![Doc Status](https://github.com/mindee/doctr/workflows/doc-status/badge.svg)](https://mindee.github.io/doctr) [![Pypi](https://img.shields.io/badge/pypi-v0.3.1-blue.svg)](https://pypi.org/project/python-doctr/) [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/osanseviero/doctr)
 
 
-**Optical Character Recognition made seamless & accessible to anyone, powered by TensorFlow 2 (PyTorch in beta)**
+**Optical Character Recognition made seamless & accessible to anyone, powered by TensorFlow 2 & PyTorch**
 
 
 What you can expect from this repository:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,10 +57,11 @@ Supported datasets
 
 .. toctree::
    :maxdepth: 2
-   :caption: Notes
+   :caption: Using DocTR
    :hidden:
 
-   changelog
+   using_models
+   using_model_export
 
 
 .. toctree::
@@ -73,3 +74,11 @@ Supported datasets
    models
    transforms
    utils
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Notes
+   :hidden:
+
+   changelog

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -8,13 +8,27 @@ Either performed at once or separately, to each task corresponds a type of deep 
 
 For a given task, DocTR provides a Predictor, which is composed of 2 components:
 
-* PreProcessor: a module in charge of making inputs directly usable by the TensorFlow model.
-* Model: a deep learning model, implemented with TensorFlow backend along with its specific post-processor to make outputs structured and reusable.
+* PreProcessor: a module in charge of making inputs directly usable by the deep learning model.
+* Model: a deep learning model, implemented with all supported deep learning backends (TensorFlow & PyTorch) along with its specific post-processor to make outputs structured and reusable.
 
 
 Text Detection
 --------------
-Localizing text elements in images
+
+The task consists of localizing textual elements in a given image.
+While those text elements can represent many things, in DocTR, we will consider uninterrupted character sequences (words). Additionally, the localization can take several forms: from straight bounding boxes (delimited by the 2D coordinates of the top-left and bottom-right corner), to polygons, or binary segmentation (flagging which pixels belong to this element, and which don't).
+
+Available architectures
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The following architectures are currently supported:
+
+* linknet16
+* db_resnet50
+* db_mobilenet_v3_large
+
+For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
+
 
 +------------------------------------------------------------------+----------------------------+----------------------------+---------+
 |                                                                  |        FUNSD               |        CORD                |         |
@@ -23,47 +37,47 @@ Localizing text elements in images
 +---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
 | db_resnet50                     | (1024, 1024, 3) | 25.2 M       | 82.14      | 87.64         | 92.49      | 89.66         | 2.1     |
 +---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
-| db_mobilenet_v3_large           | (1024, 1024, 3) |              | 79.35      | 84.03         | 81.14      | 66.85         |         |
+| db_mobilenet_v3_large           | (1024, 1024, 3) |  4.2 M       | 79.35      | 84.03         | 81.14      | 66.85         |         |
 +---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
+
 
 All text detection models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
 Explanations about the metrics being used are available in :ref:`metrics`.
 
-*Disclaimer: both FUNSD subsets combine have 199 pages which might not be representative enough of the model capabilities*
+*Disclaimer: both FUNSD subsets combined have 199 pages which might not be representative enough of the model capabilities*
 
-FPS (Frames per second) is computed this way: we instantiate the model, we feed the model with 100 random tensors of shape [1, 1024, 1024, 3] as a warm-up. Then, we measure the average speed of the model on 1000 batches of 1 frame (random tensors of shape [1, 1024, 1024, 3]).
-We used a c5.x12large from AWS instances (CPU Xeon Platinum 8275L) to perform experiments.
+FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed tensors per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
 
-Pre-processing for detection
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In DocTR, the pre-processing scheme for detection is the following:
-
-1. resize each input image to the target size (bilinear interpolation by default) with potential deformation.
-2. batch images together
-3. normalize the batch using the training data statistics
-
-
-Detection models
-^^^^^^^^^^^^^^^^
-Models expect a TensorFlow tensor as input and produces one in return. DocTR includes implementations and pretrained versions of the following models:
-
-.. autofunction:: doctr.models.detection.db_resnet50
-.. autofunction:: doctr.models.detection.db_mobilenet_v3_large
-.. autofunction:: doctr.models.detection.linknet16
 
 Detection predictors
 ^^^^^^^^^^^^^^^^^^^^
-Combining the right components around a given architecture for easier usage, predictors lets you pass numpy images as inputs and return structured information.
+
+Wrapping your detection model to make it easily useable with your favorite deep learning framework seamlessly.
 
 .. autofunction:: doctr.models.detection.detection_predictor
 
 
 Text Recognition
 ----------------
-Identifying strings in images
+
+The task consists of transcribing the character sequence in a given image.
+
+
+Available architectures
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The following architectures are currently supported:
+
+* crnn_vgg16_bn
+* crnn_mobilenet_v3_small
+* crnn_mobilenet_v3_large
+* sar_resnet31
+* master
+
+For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
+
 
 .. list-table:: Text recognition model zoo
-   :widths: 20 20 15 10 10 10
    :header-rows: 1
 
    * - Architecture
@@ -78,59 +92,64 @@ Identifying strings in images
      - 87.15
      - 92.92
      - 12.8
-   * - master
+   * - crnn_mobilenet_v3_small
      - (32, 128, 3)
+     - 2.1M
      -
-     - 87.62
-     - 93.27
+     -
+     -
+   * - crnn_mobilenet_v3_large
+     - (32, 128, 3)
+     - 4.5M
+     -
+     -
      -
    * - sar_resnet31
      - (32, 128, 3)
-     - 53.1M
+     - 56.2M
      - **87.70**
      - **93.41**
      - 2.7
+   * - master
+     - (32, 128, 3)
+     - 67.7M
+     - 87.62
+     - 93.27
+     -
 
 All text recognition models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
-Explanations about the metrics being used are available in :ref:`metrics`.
+Explanations about the metric being used (exact match) are available in :ref:`metrics`.
 
-All these recognition models are trained with our french vocab (cf. :ref:`vocabs`).
+While most of our recognition models were trained on our french vocab (cf. :ref:`vocabs`), you can easily access the vocab of any model as follows:
+
+    >>> from doctr.models import recognition_predictor
+    >>> predictor = recognition_predictor('crnn_vgg16_bn')
+    >>> print(predictor.model.cfg['vocab'])
+
 
 *Disclaimer: both FUNSD subsets combine have 30595 word-level crops which might not be representative enough of the model capabilities*
 
-FPS (Frames per second) is computed this way: we instantiate the model, we feed the model with 100 random tensors of shape [1, 32, 128, 3] as a warm-up. Then, we measure the average speed of the model on 1000 batches of 1 frame (random tensors of shape [1, 32, 128, 3]).
-We used a c5.x12large from AWS instances (CPU Xeon Platinum 8275L) to perform experiments.
-
-Pre-processing for recognition
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In DocTR, the pre-processing scheme for recognition is the following:
-
-1. resize each input image to the target size (bilinear interpolation by default) without deformation.
-2. pad the image to the target size (with zeros by default)
-3. batch images together
-4. normalize the batch using the training data statistics
-
-Recognition models
-^^^^^^^^^^^^^^^^^^
-Models expect a TensorFlow tensor as input and produces one in return. DocTR includes implementations and pretrained versions of the following models:
-
-
-.. autofunction:: doctr.models.recognition.crnn_vgg16_bn
-.. autofunction:: doctr.models.recognition.crnn_mobilenet_v3_large
-.. autofunction:: doctr.models.recognition.sar_resnet31
-.. autofunction:: doctr.models.recognition.master
+FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed tensors per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
 
 
 Recognition predictors
 ^^^^^^^^^^^^^^^^^^^^^^
-Combining the right components around a given architecture for easier usage.
+Wrapping your recognition model to make it easily useable with your favorite deep learning framework seamlessly.
 
 .. autofunction:: doctr.models.recognition.recognition_predictor
 
 
 End-to-End OCR
 --------------
-Predictors that localize and identify text elements in images
+
+The task consists of both localizing and transcribing textual elements in a given image.
+
+Available architectures
+^^^^^^^^^^^^^^^^^^^^^^^
+
+You can use any combination of detection and recognition models supporte by DocTR.
+
+For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
 
 +----------------------------------------+--------------------------------------+--------------------------------------+
 |                                        |                  FUNSD               |                  CORD                |
@@ -150,19 +169,17 @@ Predictors that localize and identify text elements in images
 | Gvision doc. text detection            | 64.00      | 53.30         |         | 68.90      | 61.10         |         |
 +----------------------------------------+------------+---------------+---------+------------+---------------+---------+
 | AWS textract                           | **78.10**  | **83.00**     |         | **87.50**  | 66.00         |         |
-+--------------------------------- ------+------------+---------------+---------+------------+---------------+---------+
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
 
 All OCR models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
 Explanations about the metrics being used are available in :ref:`metrics`.
 
-All recognition models of predictors are trained with our french vocab (cf. :ref:`vocabs`).
-
 *Disclaimer: both FUNSD subsets combine have 199 pages which might not be representative enough of the model capabilities*
 
-FPS (Frames per second) is computed this way: we instantiate the predictor, we warm-up the model and then we measure the average speed of the end-to-end predictor on the datasets, with a batch size of 1.
-We used a c5.x12large from AWS instances (CPU Xeon Platinum 8275L) to perform experiments.
+FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed frames per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
 
-Results on private ocr datasets
+Since you may be looking for specific use cases, we also performed this benchmark on private datasets with various document types below. Unfortunately, we are not able to share those at the moment since they contain sensitive information.
+
 
 +----------------------------------------------+----------------------------+----------------------------+----------------------------+----------------------------+
 |                                              |          Receipts          |            Invoices        |            IDs             |        US Tax Forms        |
@@ -189,10 +206,11 @@ Those architectures involve one stage of text detection, and one stage of text r
 
 .. autofunction:: doctr.models.zoo.ocr_predictor
 
+
 Export model output
 ^^^^^^^^^^^^^^^^^^^^
 
-The ocr_predictor returns a `Document` object with a nested structure (with `Page`, `Block`, `Line`, `Word`, `Artefact`). 
+The ocr_predictor returns a `Document` object with a nested structure (with `Page`, `Block`, `Line`, `Word`, `Artefact`).
 To get a better understanding of our document model, check our :ref:`document_structure` section
 
 Here is a typical `Document` layout::

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1,347 +1,54 @@
 doctr.models
 ============
 
-The full Optical Character Recognition task can be seen as two consecutive tasks: text detection and text recognition.
-Either performed at once or separately, to each task corresponds a type of deep learning architecture.
-
 .. currentmodule:: doctr.models
 
-For a given task, DocTR provides a Predictor, which is composed of 2 components:
 
-* PreProcessor: a module in charge of making inputs directly usable by the deep learning model.
-* Model: a deep learning model, implemented with all supported deep learning backends (TensorFlow & PyTorch) along with its specific post-processor to make outputs structured and reusable.
+doctr.models.backbones
+----------------------
 
+.. autofunction:: doctr.models.backbones.vgg16_bn
 
-Text Detection
---------------
+.. autofunction:: doctr.models.backbones.resnet31
 
-The task consists of localizing textual elements in a given image.
-While those text elements can represent many things, in DocTR, we will consider uninterrupted character sequences (words). Additionally, the localization can take several forms: from straight bounding boxes (delimited by the 2D coordinates of the top-left and bottom-right corner), to polygons, or binary segmentation (flagging which pixels belong to this element, and which don't).
+.. autofunction:: doctr.models.backbones.mobilenet_v3_small
 
-Available architectures
-^^^^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: doctr.models.backbones.mobilenet_v3_large
 
-The following architectures are currently supported:
+.. autofunction:: doctr.models.backbones.mobilenet_v3_small_r
 
-* linknet16
-* db_resnet50
-* db_mobilenet_v3_large
-
-For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
+.. autofunction:: doctr.models.backbones.mobilenet_v3_large_r
 
 
-+------------------------------------------------------------------+----------------------------+----------------------------+---------+
-|                                                                  |        FUNSD               |        CORD                |         |
-+=================================+=================+==============+============+===============+============+===============+=========+
-| **Architecture**                | **Input shape** | **# params** | **Recall** | **Precision** | **Recall** | **Precision** | **FPS** |
-+---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
-| db_resnet50                     | (1024, 1024, 3) | 25.2 M       | 82.14      | 87.64         | 92.49      | 89.66         | 2.1     |
-+---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
-| db_mobilenet_v3_large           | (1024, 1024, 3) |  4.2 M       | 79.35      | 84.03         | 81.14      | 66.85         |         |
-+---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
+doctr.models.detection
+----------------------
 
+.. autofunction:: doctr.models.detection.linknet16
 
-All text detection models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
-Explanations about the metrics being used are available in :ref:`metrics`.
+.. autofunction:: doctr.models.detection.db_resnet50
 
-*Disclaimer: both FUNSD subsets combined have 199 pages which might not be representative enough of the model capabilities*
-
-FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed tensors per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
-
-
-Detection predictors
-^^^^^^^^^^^^^^^^^^^^
-
-Wrapping your detection model to make it easily useable with your favorite deep learning framework seamlessly.
+.. autofunction:: doctr.models.detection.db_mobilenet_v3_large
 
 .. autofunction:: doctr.models.detection.detection_predictor
 
 
-Text Recognition
-----------------
+doctr.models.recognition
+------------------------
 
-The task consists of transcribing the character sequence in a given image.
+.. autofunction:: doctr.models.recognition.crnn_vgg16_bn
 
+.. autofunction:: doctr.models.recognition.crnn_mobilenet_v3_small
 
-Available architectures
-^^^^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: doctr.models.recognition.crnn_mobilenet_v3_large
 
-The following architectures are currently supported:
+.. autofunction:: doctr.models.recognition.sar_resnet31
 
-* crnn_vgg16_bn
-* crnn_mobilenet_v3_small
-* crnn_mobilenet_v3_large
-* sar_resnet31
-* master
-
-For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
-
-
-.. list-table:: Text recognition model zoo
-   :header-rows: 1
-
-   * - Architecture
-     - Input shape
-     - # params
-     - FUNSD
-     - CORD
-     - FPS
-   * - crnn_vgg16_bn
-     - (32, 128, 3)
-     - 15.8M
-     - 87.15
-     - 92.92
-     - 12.8
-   * - crnn_mobilenet_v3_small
-     - (32, 128, 3)
-     - 2.1M
-     -
-     -
-     -
-   * - crnn_mobilenet_v3_large
-     - (32, 128, 3)
-     - 4.5M
-     -
-     -
-     -
-   * - sar_resnet31
-     - (32, 128, 3)
-     - 56.2M
-     - **87.70**
-     - **93.41**
-     - 2.7
-   * - master
-     - (32, 128, 3)
-     - 67.7M
-     - 87.62
-     - 93.27
-     -
-
-All text recognition models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
-Explanations about the metric being used (exact match) are available in :ref:`metrics`.
-
-While most of our recognition models were trained on our french vocab (cf. :ref:`vocabs`), you can easily access the vocab of any model as follows:
-
-    >>> from doctr.models import recognition_predictor
-    >>> predictor = recognition_predictor('crnn_vgg16_bn')
-    >>> print(predictor.model.cfg['vocab'])
-
-
-*Disclaimer: both FUNSD subsets combine have 30595 word-level crops which might not be representative enough of the model capabilities*
-
-FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed tensors per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
-
-
-Recognition predictors
-^^^^^^^^^^^^^^^^^^^^^^
-Wrapping your recognition model to make it easily useable with your favorite deep learning framework seamlessly.
+.. autofunction:: doctr.models.recognition.master
 
 .. autofunction:: doctr.models.recognition.recognition_predictor
 
 
-End-to-End OCR
---------------
+doctr.models.zoo
+----------------
 
-The task consists of both localizing and transcribing textual elements in a given image.
-
-Available architectures
-^^^^^^^^^^^^^^^^^^^^^^^
-
-You can use any combination of detection and recognition models supporte by DocTR.
-
-For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
-
-+----------------------------------------+--------------------------------------+--------------------------------------+
-|                                        |                  FUNSD               |                  CORD                |
-+========================================+============+===============+=========+============+===============+=========+
-| **Architecture**                       | **Recall** | **Precision** | **FPS** | **Recall** | **Precision** | **FPS** |
-+----------------------------------------+------------+---------------+---------+------------+---------------+---------+
-| db_resnet50 + crnn_vgg16_bn            | 71.00      | 76.02         | 0.85    | 83.87      |   81.34       | 1.6     |
-+----------------------------------------+------------+---------------+---------+------------+---------------+---------+
-| db_resnet50 + master                   | 71.03      | 76.06         |         | 84.49      |   81.94       |         |
-+----------------------------------------+------------+---------------+---------+------------+---------------+---------+
-| db_resnet50 + sar_resnet31             | 71.25      | 76.29         | 0.27    | 84.50      | **81.96**     | 0.83    |
-+----------------------------------------+------------+---------------+---------+------------+---------------+---------+
-| db_mobilenet_v3_large + crnn_vgg16_bn  | 67.73      | 71.73         |         | 71.65      | 59.03         |         |
-+----------------------------------------+------------+---------------+---------+------------+---------------+---------+
-| Gvision text detection                 | 59.50      | 62.50         |         | 75.30      | 70.00         |         |
-+----------------------------------------+------------+---------------+---------+------------+---------------+---------+
-| Gvision doc. text detection            | 64.00      | 53.30         |         | 68.90      | 61.10         |         |
-+----------------------------------------+------------+---------------+---------+------------+---------------+---------+
-| AWS textract                           | **78.10**  | **83.00**     |         | **87.50**  | 66.00         |         |
-+----------------------------------------+------------+---------------+---------+------------+---------------+---------+
-
-All OCR models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
-Explanations about the metrics being used are available in :ref:`metrics`.
-
-*Disclaimer: both FUNSD subsets combine have 199 pages which might not be representative enough of the model capabilities*
-
-FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed frames per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
-
-Since you may be looking for specific use cases, we also performed this benchmark on private datasets with various document types below. Unfortunately, we are not able to share those at the moment since they contain sensitive information.
-
-
-+----------------------------------------------+----------------------------+----------------------------+----------------------------+----------------------------+
-|                                              |          Receipts          |            Invoices        |            IDs             |        US Tax Forms        |
-+==============================================+============+===============+============+===============+============+===============+============+===============+
-| **Architecture**                             | **Recall** | **Precision** | **Recall** | **Precision** | **Recall** | **Precision** | **Recall** | **Precision** |
-+----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
-| db_resnet50 + crnn_vgg16_bn (ours)           |   78.70    |   81.12       | 65.80      |   70.70       |   50.25    |   51.78       |   79.08    |   92.83       |
-+----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
-| db_resnet50 + master (ours)                  | **79.00**  | **81.42**     | 65.57      |   69.86       |   51.34    |   52.90       |   78.86    |   92.57       |
-+----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
-| db_resnet50 + sar_resnet31 (ours)            |   78.94    |   81.37       | 65.89      | **70.79**     | **51.78**  | **53.35**     |   79.04    |   92.78       |
-+----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
-| db_mobilenet_v3_large + crnn_vgg16_bn (ours) |   78.36    |   74.93       | 63.04      | 68.41         | 39.36      | 41.75         |   72.14    |   89.97       |
-+----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
-| Gvision doc. text detection                  | 68.91      | 59.89         | 63.20      | 52.85         | 43.70      | 29.21         |   69.79    |   65.68       |
-+----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
-| AWS textract                                 | 75.77      | 77.70         | **70.47**  | 69.13         | 46.39      | 43.32         | **84.31**  | **98.11**     |
-+----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
-
-
-Two-stage approaches
-^^^^^^^^^^^^^^^^^^^^
-Those architectures involve one stage of text detection, and one stage of text recognition. The text detection will be used to produces cropped images that will be passed into the text recognition block.
-
-.. autofunction:: doctr.models.zoo.ocr_predictor
-
-
-Export model output
-^^^^^^^^^^^^^^^^^^^^
-
-The ocr_predictor returns a `Document` object with a nested structure (with `Page`, `Block`, `Line`, `Word`, `Artefact`).
-To get a better understanding of our document model, check our :ref:`document_structure` section
-
-Here is a typical `Document` layout::
-
-  Document(
-    (pages): [Page(
-      dimensions=(340, 600)
-      (blocks): [Block(
-        (lines): [Line(
-          (words): [
-            Word(value='No.', confidence=0.91),
-            Word(value='RECEIPT', confidence=0.99),
-            Word(value='DATE', confidence=0.96),
-          ]
-        )]
-        (artefacts): []
-      )]
-    )]
-  )
-
-You can also export them as a nested dict, more appropriate for JSON format::
-
-  json_output = result.export()
-
-For reference, here is the JSON export for the same `Document` as above::
-
-  {
-    'pages': [
-        {
-            'page_idx': 0,
-            'dimensions': (340, 600),
-            'orientation': {'value': None, 'confidence': None},
-            'language': {'value': None, 'confidence': None},
-            'blocks': [
-                {
-                    'geometry': ((0.1357421875, 0.0361328125), (0.8564453125, 0.8603515625)),
-                    'lines': [
-                        {
-                            'geometry': ((0.1357421875, 0.0361328125), (0.8564453125, 0.8603515625)),
-                            'words': [
-                                {
-                                    'value': 'No.',
-                                    'confidence': 0.914085328578949,
-                                    'geometry': ((0.5478515625, 0.06640625), (0.5810546875, 0.0966796875))
-                                },
-                                {
-                                    'value': 'RECEIPT',
-                                    'confidence': 0.9949972033500671,
-                                    'geometry': ((0.1357421875, 0.0361328125), (0.51171875, 0.1630859375))
-                                },
-                                {
-                                    'value': 'DATE',
-                                    'confidence': 0.9578408598899841,
-                                    'geometry': ((0.1396484375, 0.3232421875), (0.185546875, 0.3515625))
-                                }
-                            ]
-                        }
-                    ],
-                    'artefacts': []
-                }
-            ]
-        }
-    ]
-  }
-
-Model export
-------------
-Utility functions to make the most of document analysis models.
-
-.. currentmodule:: doctr.models.export
-
-Model compression
-^^^^^^^^^^^^^^^^^
-
-This section is meant to help you perform inference with compressed versions of your model.
-
-
-TensorFlow Lite
-"""""""""""""""
-
-TensorFlow provides utilities packaged as TensorFlow Lite to take resource constraints into account. You can easily convert any Keras model into a serialized TFLite version as follows:
-
-    >>> import tensorflow as tf
-    >>> from tensorflow.keras import Sequential
-    >>> from doctr.models import conv_sequence
-    >>> model = Sequential(conv_sequence(32, 'relu', True, kernel_size=3, input_shape=(224, 224, 3)))
-    >>> converter = tf.lite.TFLiteConverter.from_keras_model(tf_model)
-    >>> serialized_model = converter.convert()
-
-Half-precision
-""""""""""""""
-
-If you want to convert it to half-precision using your TFLite converter
-
-    >>> converter.optimizations = [tf.lite.Optimize.DEFAULT]
-    >>> converter.target_spec.supported_types = [tf.float16]
-    >>> serialized_model = converter.convert()
-
-
-Post-training quantization
-""""""""""""""""""""""""""
-
-Finally if you wish to quantize the model with your TFLite converter
-
-    >>> converter.optimizations = [tf.lite.Optimize.DEFAULT]
-    >>> # Float fallback for operators that do not have an integer implementation
-    >>> def representative_dataset():
-    >>>     for _ in range(100): yield [np.random.rand(1, *input_shape).astype(np.float32)]
-    >>> converter.representative_dataset = representative_dataset
-    >>> converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
-    >>> converter.inference_input_type = tf.int8
-    >>> converter.inference_output_type = tf.int8
-    >>> serialized_model = converter.convert()
-
-
-Using SavedModel
-^^^^^^^^^^^^^^^^
-
-Additionally, models in DocTR inherit TensorFlow 2 model properties and can be exported to
-`SavedModel <https://www.tensorflow.org/guide/saved_model>`_ format as follows:
-
-
-    >>> import tensorflow as tf
-    >>> from doctr.models import db_resnet50
-    >>> model = db_resnet50(pretrained=True)
-    >>> input_t = tf.random.uniform(shape=[1, 1024, 1024, 3], maxval=1, dtype=tf.float32)
-    >>> _ = model(input_t, training=False)
-    >>> tf.saved_model.save(model, 'path/to/your/folder/db_resnet50/')
-
-And loaded just as easily:
-
-
-    >>> import tensorflow as tf
-    >>> model = tf.saved_model.load('path/to/your/folder/db_resnet50/')
+.. autofunction:: doctr.models.ocr_predictor

--- a/docs/source/using_model_export.rst
+++ b/docs/source/using_model_export.rst
@@ -1,0 +1,71 @@
+Preparing your model for inference
+==================================
+
+A well-trained model is a good achievement but you might want to tune a few things to make it production-ready!
+
+.. currentmodule:: doctr.models.export
+
+
+Model compression
+-----------------
+
+This section is meant to help you perform inference with compressed versions of your model.
+
+
+TensorFlow Lite
+^^^^^^^^^^^^^^^
+
+TensorFlow provides utilities packaged as TensorFlow Lite to take resource constraints into account. You can easily convert any Keras model into a serialized TFLite version as follows:
+
+    >>> import tensorflow as tf
+    >>> from tensorflow.keras import Sequential
+    >>> from doctr.models import conv_sequence
+    >>> model = Sequential(conv_sequence(32, 'relu', True, kernel_size=3, input_shape=(224, 224, 3)))
+    >>> converter = tf.lite.TFLiteConverter.from_keras_model(tf_model)
+    >>> serialized_model = converter.convert()
+
+Half-precision
+^^^^^^^^^^^^^^
+
+If you want to convert it to half-precision using your TFLite converter
+
+    >>> converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    >>> converter.target_spec.supported_types = [tf.float16]
+    >>> serialized_model = converter.convert()
+
+
+Post-training quantization
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Finally if you wish to quantize the model with your TFLite converter
+
+    >>> converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    >>> # Float fallback for operators that do not have an integer implementation
+    >>> def representative_dataset():
+    >>>     for _ in range(100): yield [np.random.rand(1, *input_shape).astype(np.float32)]
+    >>> converter.representative_dataset = representative_dataset
+    >>> converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+    >>> converter.inference_input_type = tf.int8
+    >>> converter.inference_output_type = tf.int8
+    >>> serialized_model = converter.convert()
+
+
+Using SavedModel
+----------------
+
+Additionally, models in DocTR inherit TensorFlow 2 model properties and can be exported to
+`SavedModel <https://www.tensorflow.org/guide/saved_model>`_ format as follows:
+
+
+    >>> import tensorflow as tf
+    >>> from doctr.models import db_resnet50
+    >>> model = db_resnet50(pretrained=True)
+    >>> input_t = tf.random.uniform(shape=[1, 1024, 1024, 3], maxval=1, dtype=tf.float32)
+    >>> _ = model(input_t, training=False)
+    >>> tf.saved_model.save(model, 'path/to/your/folder/db_resnet50/')
+
+And loaded just as easily:
+
+
+    >>> import tensorflow as tf
+    >>> model = tf.saved_model.load('path/to/your/folder/db_resnet50/')

--- a/docs/source/using_models.rst
+++ b/docs/source/using_models.rst
@@ -1,0 +1,290 @@
+Choosing the right model
+========================
+
+The full Optical Character Recognition task can be seen as two consecutive tasks: text detection and text recognition.
+Either performed at once or separately, to each task corresponds a type of deep learning architecture.
+
+.. currentmodule:: doctr.models
+
+For a given task, DocTR provides a Predictor, which is composed of 2 components:
+
+* PreProcessor: a module in charge of making inputs directly usable by the deep learning model.
+* Model: a deep learning model, implemented with all supported deep learning backends (TensorFlow & PyTorch) along with its specific post-processor to make outputs structured and reusable.
+
+
+Text Detection
+--------------
+
+The task consists of localizing textual elements in a given image.
+While those text elements can represent many things, in DocTR, we will consider uninterrupted character sequences (words). Additionally, the localization can take several forms: from straight bounding boxes (delimited by the 2D coordinates of the top-left and bottom-right corner), to polygons, or binary segmentation (flagging which pixels belong to this element, and which don't).
+
+Available architectures
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The following architectures are currently supported:
+
+* `linknet16 <models.html#doctr.models.detection.linknet16>`_
+* `db_resnet50 <models.html#doctr.models.detection.db_resnet50>`_
+* `db_mobilenet_v3_large <models.html#doctr.models.detection.db_mobilenet_v3_large>`_
+
+For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
+
+
++------------------------------------------------------------------+----------------------------+----------------------------+---------+
+|                                                                  |        FUNSD               |        CORD                |         |
++=================================+=================+==============+============+===============+============+===============+=========+
+| **Architecture**                | **Input shape** | **# params** | **Recall** | **Precision** | **Recall** | **Precision** | **FPS** |
++---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
+| db_resnet50                     | (1024, 1024, 3) | 25.2 M       | 82.14      | 87.64         | 92.49      | 89.66         | 2.1     |
++---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
+| db_mobilenet_v3_large           | (1024, 1024, 3) |  4.2 M       | 79.35      | 84.03         | 81.14      | 66.85         |         |
++---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+---------+
+
+
+All text detection models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
+Explanations about the metrics being used are available in :ref:`metrics`.
+
+*Disclaimer: both FUNSD subsets combined have 199 pages which might not be representative enough of the model capabilities*
+
+FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed tensors per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
+
+
+Detection predictors
+^^^^^^^^^^^^^^^^^^^^
+
+Wrapping your detection model to make it easily useable with your favorite deep learning framework seamlessly.
+
+    >>> import numpy as np
+    >>> from doctr.models import detection_predictor
+    >>> predictor = detection_predictor('db_resnet50')
+    >>> dummy_img = (255 * np.random.rand(800, 600, 3)).astype(np.uint8)
+    >>> out = model([dummy_img])
+
+
+Text Recognition
+----------------
+
+The task consists of transcribing the character sequence in a given image.
+
+
+Available architectures
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The following architectures are currently supported:
+
+* `crnn_vgg16_bn <models.html#doctr.models.recognition.crnn_vgg16_bn>`_
+* `crnn_mobilenet_v3_small <models.html#doctr.models.recognition.crnn_mobilenet_v3_small>`_
+* `crnn_mobilenet_v3_large <models.html#doctr.models.recognition.crnn_mobilenet_v3_large>`_
+* `sar_resnet31 <models.html#doctr.models.recognition.sar_resnet31>`_
+* `master <models.html#doctr.models.recognition.master>`_
+
+
+For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
+
+
+.. list-table:: Text recognition model zoo
+   :header-rows: 1
+
+   * - Architecture
+     - Input shape
+     - # params
+     - FUNSD
+     - CORD
+     - FPS
+   * - crnn_vgg16_bn
+     - (32, 128, 3)
+     - 15.8M
+     - 87.15
+     - 92.92
+     - 12.8
+   * - crnn_mobilenet_v3_small
+     - (32, 128, 3)
+     - 2.1M
+     -
+     -
+     -
+   * - crnn_mobilenet_v3_large
+     - (32, 128, 3)
+     - 4.5M
+     -
+     -
+     -
+   * - sar_resnet31
+     - (32, 128, 3)
+     - 56.2M
+     - **87.70**
+     - **93.41**
+     - 2.7
+   * - master
+     - (32, 128, 3)
+     - 67.7M
+     - 87.62
+     - 93.27
+     -
+
+All text recognition models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
+Explanations about the metric being used (exact match) are available in :ref:`metrics`.
+
+While most of our recognition models were trained on our french vocab (cf. :ref:`vocabs`), you can easily access the vocab of any model as follows:
+
+    >>> from doctr.models import recognition_predictor
+    >>> predictor = recognition_predictor('crnn_vgg16_bn')
+    >>> print(predictor.model.cfg['vocab'])
+
+
+*Disclaimer: both FUNSD subsets combine have 30595 word-level crops which might not be representative enough of the model capabilities*
+
+FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed tensors per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
+
+
+Recognition predictors
+^^^^^^^^^^^^^^^^^^^^^^
+Wrapping your recognition model to make it easily useable with your favorite deep learning framework seamlessly.
+
+    >>> import numpy as np
+    >>> from doctr.models import recognition_predictor
+    >>> predictor = recognition_predictor('crnn_vgg16_bn')
+    >>> dummy_img = (255 * np.random.rand(50, 150, 3)).astype(np.uint8)
+    >>> out = model([dummy_img])
+
+
+End-to-End OCR
+--------------
+
+The task consists of both localizing and transcribing textual elements in a given image.
+
+Available architectures
+^^^^^^^^^^^^^^^^^^^^^^^
+
+You can use any combination of detection and recognition models supporte by DocTR.
+
+For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
+
++----------------------------------------+--------------------------------------+--------------------------------------+
+|                                        |                  FUNSD               |                  CORD                |
++========================================+============+===============+=========+============+===============+=========+
+| **Architecture**                       | **Recall** | **Precision** | **FPS** | **Recall** | **Precision** | **FPS** |
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
+| db_resnet50 + crnn_vgg16_bn            | 71.00      | 76.02         | 0.85    | 83.87      |   81.34       | 1.6     |
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
+| db_resnet50 + master                   | 71.03      | 76.06         |         | 84.49      |   81.94       |         |
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
+| db_resnet50 + sar_resnet31             | 71.25      | 76.29         | 0.27    | 84.50      | **81.96**     | 0.83    |
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
+| db_mobilenet_v3_large + crnn_vgg16_bn  | 67.73      | 71.73         |         | 71.65      | 59.03         |         |
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
+| Gvision text detection                 | 59.50      | 62.50         |         | 75.30      | 70.00         |         |
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
+| Gvision doc. text detection            | 64.00      | 53.30         |         | 68.90      | 61.10         |         |
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
+| AWS textract                           | **78.10**  | **83.00**     |         | **87.50**  | 66.00         |         |
++----------------------------------------+------------+---------------+---------+------------+---------------+---------+
+
+All OCR models above have been evaluated using both the training and evaluation sets of FUNSD and CORD (cf. :ref:`datasets`).
+Explanations about the metrics being used are available in :ref:`metrics`.
+
+*Disclaimer: both FUNSD subsets combine have 199 pages which might not be representative enough of the model capabilities*
+
+FPS (Frames per second) is computed after a warmup phase of 100 tensors (where the batch size is 1), by measuring the average number of processed frames per second over 1000 samples. Those results were obtained on a `c5.x12large <https://aws.amazon.com/ec2/instance-types/c5/>`_ AWS instance (CPU Xeon Platinum 8275L).
+
+Since you may be looking for specific use cases, we also performed this benchmark on private datasets with various document types below. Unfortunately, we are not able to share those at the moment since they contain sensitive information.
+
+
++----------------------------------------------+----------------------------+----------------------------+----------------------------+----------------------------+
+|                                              |          Receipts          |            Invoices        |            IDs             |        US Tax Forms        |
++==============================================+============+===============+============+===============+============+===============+============+===============+
+| **Architecture**                             | **Recall** | **Precision** | **Recall** | **Precision** | **Recall** | **Precision** | **Recall** | **Precision** |
++----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
+| db_resnet50 + crnn_vgg16_bn (ours)           |   78.70    |   81.12       | 65.80      |   70.70       |   50.25    |   51.78       |   79.08    |   92.83       |
++----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
+| db_resnet50 + master (ours)                  | **79.00**  | **81.42**     | 65.57      |   69.86       |   51.34    |   52.90       |   78.86    |   92.57       |
++----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
+| db_resnet50 + sar_resnet31 (ours)            |   78.94    |   81.37       | 65.89      | **70.79**     | **51.78**  | **53.35**     |   79.04    |   92.78       |
++----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
+| db_mobilenet_v3_large + crnn_vgg16_bn (ours) |   78.36    |   74.93       | 63.04      | 68.41         | 39.36      | 41.75         |   72.14    |   89.97       |
++----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
+| Gvision doc. text detection                  | 68.91      | 59.89         | 63.20      | 52.85         | 43.70      | 29.21         |   69.79    |   65.68       |
++----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
+| AWS textract                                 | 75.77      | 77.70         | **70.47**  | 69.13         | 46.39      | 43.32         | **84.31**  | **98.11**     |
++----------------------------------------------+------------+---------------+------------+---------------+------------+---------------+------------+---------------+
+
+
+Two-stage approaches
+^^^^^^^^^^^^^^^^^^^^
+Those architectures involve one stage of text detection, and one stage of text recognition. The text detection will be used to produces cropped images that will be passed into the text recognition block.
+
+    >>> import numpy as np
+    >>> from doctr.models import ocr_predictor
+    >>> model = ocr_predictor('db_resnet50', 'crnn_vgg16_bn', pretrained=True)
+    >>> input_page = (255 * np.random.rand(800, 600, 3)).astype(np.uint8)
+    >>> out = model([input_page])
+
+
+What should I do with the output?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ocr_predictor returns a `Document` object with a nested structure (with `Page`, `Block`, `Line`, `Word`, `Artefact`).
+To get a better understanding of our document model, check our :ref:`document_structure` section
+
+Here is a typical `Document` layout::
+
+  Document(
+    (pages): [Page(
+      dimensions=(340, 600)
+      (blocks): [Block(
+        (lines): [Line(
+          (words): [
+            Word(value='No.', confidence=0.91),
+            Word(value='RECEIPT', confidence=0.99),
+            Word(value='DATE', confidence=0.96),
+          ]
+        )]
+        (artefacts): []
+      )]
+    )]
+  )
+
+You can also export them as a nested dict, more appropriate for JSON format::
+
+  json_output = result.export()
+
+For reference, here is the JSON export for the same `Document` as above::
+
+  {
+    'pages': [
+        {
+            'page_idx': 0,
+            'dimensions': (340, 600),
+            'orientation': {'value': None, 'confidence': None},
+            'language': {'value': None, 'confidence': None},
+            'blocks': [
+                {
+                    'geometry': ((0.1357421875, 0.0361328125), (0.8564453125, 0.8603515625)),
+                    'lines': [
+                        {
+                            'geometry': ((0.1357421875, 0.0361328125), (0.8564453125, 0.8603515625)),
+                            'words': [
+                                {
+                                    'value': 'No.',
+                                    'confidence': 0.914085328578949,
+                                    'geometry': ((0.5478515625, 0.06640625), (0.5810546875, 0.0966796875))
+                                },
+                                {
+                                    'value': 'RECEIPT',
+                                    'confidence': 0.9949972033500671,
+                                    'geometry': ((0.1357421875, 0.0361328125), (0.51171875, 0.1630859375))
+                                },
+                                {
+                                    'value': 'DATE',
+                                    'confidence': 0.9578408598899841,
+                                    'geometry': ((0.1396484375, 0.3232421875), (0.185546875, 0.3515625))
+                                }
+                            ]
+                        }
+                    ],
+                    'artefacts': []
+                }
+            ]
+        }
+    ]
+  }

--- a/docs/source/using_models.rst
+++ b/docs/source/using_models.rst
@@ -52,7 +52,7 @@ FPS (Frames per second) is computed after a warmup phase of 100 tensors (where t
 Detection predictors
 ^^^^^^^^^^^^^^^^^^^^
 
-Wrapping your detection model to make it easily useable with your favorite deep learning framework seamlessly.
+`detection_predictor <models.html#doctr.models.detection.detection_predictor>`_ wraps your detection model to make it easily useable with your favorite deep learning framework seamlessly.
 
     >>> import numpy as np
     >>> from doctr.models import detection_predictor
@@ -139,7 +139,7 @@ FPS (Frames per second) is computed after a warmup phase of 100 tensors (where t
 
 Recognition predictors
 ^^^^^^^^^^^^^^^^^^^^^^
-Wrapping your recognition model to make it easily useable with your favorite deep learning framework seamlessly.
+`recognition_predictor <models.html#doctr.models.recognition.recognition_predictor>`_ wraps your recognition model to make it easily useable with your favorite deep learning framework seamlessly.
 
     >>> import numpy as np
     >>> from doctr.models import recognition_predictor
@@ -211,7 +211,7 @@ Since you may be looking for specific use cases, we also performed this benchmar
 
 Two-stage approaches
 ^^^^^^^^^^^^^^^^^^^^
-Those architectures involve one stage of text detection, and one stage of text recognition. The text detection will be used to produces cropped images that will be passed into the text recognition block.
+Those architectures involve one stage of text detection, and one stage of text recognition. The text detection will be used to produces cropped images that will be passed into the text recognition block. Everything is wrapped up with `ocr_predictor <models.html#doctr.models.ocr_predictor>`_.
 
     >>> import numpy as np
     >>> from doctr.models import ocr_predictor

--- a/doctr/models/detection/zoo.py
+++ b/doctr/models/detection/zoo.py
@@ -43,12 +43,12 @@ def detection_predictor(arch: str = 'db_resnet50', pretrained: bool = False, **k
     Example::
         >>> import numpy as np
         >>> from doctr.models import detection_predictor
-        >>> model = detection_predictor(pretrained=True)
+        >>> model = detection_predictor(arch='db_resnet50', pretrained=True)
         >>> input_page = (255 * np.random.rand(600, 800, 3)).astype(np.uint8)
         >>> out = model([input_page])
 
     Args:
-        arch: name of the architecture to use ('db_resnet50')
+        arch: name of the architecture to use (e.g. 'db_resnet50')
         pretrained: If True, returns a model pre-trained on our text detection dataset
 
     Returns:

--- a/doctr/models/recognition/master/tensorflow.py
+++ b/doctr/models/recognition/master/tensorflow.py
@@ -357,6 +357,7 @@ class MASTER(_MASTER, Model):
 
 class MASTERPostProcessor(_MASTERPostProcessor):
     """Post processor for MASTER architectures
+
     Args:
         vocab: string containing the ordered sequence of supported characters
         ignore_case: if True, ignore case of letters
@@ -405,14 +406,17 @@ def _master(arch: str, pretrained: bool, input_shape: Tuple[int, int, int] = Non
 
 def master(pretrained: bool = False, **kwargs: Any) -> MASTER:
     """MASTER as described in paper: <https://arxiv.org/pdf/1910.02562.pdf>`_.
+
     Example::
         >>> import tensorflow as tf
         >>> from doctr.models import master
         >>> model = master(pretrained=False)
         >>> input_tensor = tf.random.uniform(shape=[1, 48, 160, 3], maxval=1, dtype=tf.float32)
         >>> out = model(input_tensor)
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
+
     Returns:
         text recognition architecture
     """

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -46,7 +46,7 @@ def recognition_predictor(arch: str = 'crnn_vgg16_bn', pretrained: bool = False,
         >>> out = model([input_page])
 
     Args:
-        arch: name of the architecture to use ('crnn_vgg16_bn', 'crnn_resnet31', 'sar_vgg16_bn', 'sar_resnet31')
+        arch: name of the architecture to use (e.g. 'crnn_vgg16_bn')
         pretrained: If True, returns a model pre-trained on our text recognition dataset
 
     Returns:

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -34,7 +34,7 @@ def ocr_predictor(
     Example::
         >>> import numpy as np
         >>> from doctr.models import ocr_predictor
-        >>> model = ocr_predictor(pretrained=True)
+        >>> model = ocr_predictor('db_resnet50', 'crnn_vgg16_bn', pretrained=True)
         >>> input_page = (255 * np.random.rand(600, 800, 3)).astype(np.uint8)
         >>> out = model([input_page])
 


### PR DESCRIPTION
This PR introduces the following modifications:
- removes the mention that PyTorch is in beta in the README
- in the documentation, split benchmark & export model from actual docstrings: "Using DocTR" section doesn't include any function/class documentation but explains how some features work and provides benchmarks. Hyperlinks were added so that users can easily access the signature.

Here is the new navigation menu:
![image](https://user-images.githubusercontent.com/76527547/135616160-f9a9ec69-c47d-4a6b-9292-b141bb532558.png)

Please note that this doesn't include the PyTorch benchmark for now!

Any feedback is welcome!