### PR TITLE
Updated readme

### DIFF
--- a/references/detection/README.md
+++ b/references/detection/README.md
@@ -47,10 +47,13 @@ Each JSON file must be a dictionary, where the keys are the image file names and
 The order of the points does not matter inside a polygon. Points are (x, y) absolutes coordinates.
 
 ```shell
-image.json = {
-    'img_dimensions': (900, 600),
-    'img_hash': "theimagedumpmyhash",
-    'polygons': [[[x1, y1], [x2, y2], [x3, y3], [x4, y4]], ...]
+labels.json 
+{
+    "sample_img_01.png" = {
+        'img_dimensions': (900, 600),
+        'img_hash': "theimagedumpmyhash",
+        'polygons': [[[x1, y1], [x2, y2], [x3, y3], [x4, y4]], ...]
+     }
 }
 ```
 


### PR DESCRIPTION
Line no. 46 says `Each JSON file must be a dictionary, where the keys are the image file names and the value is a dictionary with 3 entries: `img_dimensions` (spatial shape of the image), `img_hash` (SHA256 of the image file), `polygons` (the set of 2D points forming the localization polygon).`
But shown format is
```shell 
image.json = {
    'img_dimensions': (900, 600),
    'img_hash': "theimagedumpmyhash",
    'polygons': [[[x1, y1], [x2, y2], [x3, y3], [x4, y4]], ...]
}
```
Which does not seem correct.
Have updated it to 
```shell
labels.json 
{
    "sample_img_01.png" = {
        'img_dimensions': (900, 600),
        'img_hash': "theimagedumpmyhash",
        'polygons': [[[x1, y1], [x2, y2], [x3, y3], [x4, y4]], ...]
     }
}
```