### PR TITLE
fix: tgt_mask computation in master model (PyTorch backend)

### DIFF
--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -325,7 +325,7 @@ class MASTER(_MASTER, nn.Module):
             output = self.decoder(ys, encoded, ys_mask, None)
             logits = self.linear(output)
             prob = F.softmax(logits, dim=-1)
-            _, next_word = torch.max(prob, dim=-1)
+            next_word = torch.max(prob, dim=-1).indices
             ys[:, i + 1] = next_word[:, i + 1]
 
         # Shape (N, max_length, vocab_size + 1)


### PR DESCRIPTION
This PR simply fixes the mask computation for the master model in torch, which was computed the wrong way, so that logits were never decoded properly.
Any feedback is welcome!