### PR TITLE
chore: Fixed keras version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ Pillow>=8.3.2
 tqdm>=4.30.0
 tensorflow-addons>=0.13.0
 rapidfuzz>=1.6.0
+keras<2.7.0

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ _deps = [
     "tqdm>=4.30.0",
     "tensorflow-addons>=0.13.0",
     "rapidfuzz>=1.6.0",
+    "keras<2.7.0",
 ]
 
 deps = {b: a for a, b in (re.findall(r"^(([^!=<>]+)(?:[!=<>].*)?$)", x)[0] for x in _deps)}
@@ -86,8 +87,8 @@ install_requires = [
 ]
 
 extras = {}
-extras["tf"] = deps_list("tensorflow", "tensorflow-addons")
-extras["tf-cpu"] = deps_list("tensorflow-cpu", "tensorflow-addons")
+extras["tf"] = deps_list("tensorflow", "tensorflow-addons", "keras")
+extras["tf-cpu"] = deps_list("tensorflow-cpu", "tensorflow-addons", "keras")
 extras["torch"] = deps_list("torch", "torchvision")
 extras["all"] = (
     extras["tf"]


### PR DESCRIPTION
This PR tries to fix the CI issue that happens since the release of keras 2.7 https://github.com/keras-team/keras/releases/tag/v2.7.0 by constraining the version to a lower index.

cf. https://github.com/tensorflow/tensorflow/issues/52937 & https://github.com/keras-team/keras/issues/15585

Any feedback is welcome!