### PR TITLE
docs: Fixed docstring and export as xml dim bug

### DIFF
--- a/doctr/io/elements.py
+++ b/doctr/io/elements.py
@@ -211,7 +211,7 @@ class Page(Element):
     Args:
         blocks: list of block elements
         page_idx: the index of the page in the input raw document
-        dimensions: the page size in pixels in format (width, height)
+        dimensions: the page size in pixels in format (height, width)
         orientation: a dictionary with the value of the rotation angle in degress and confidence of the prediction
         language: a dictionary with the language value and confidence of the prediction
     """
@@ -276,7 +276,7 @@ class Page(Element):
         block_count: int = 1
         line_count: int = 1
         word_count: int = 1
-        width, height = self.dimensions
+        height, width = self.dimensions
         language = self.language if 'language' in self.language.keys() else 'en'
         # Create the XML root element
         page_hocr = ETElement('html', attrib={'xmlns': 'http://www.w3.org/1999/xhtml', 'xml:lang': str(language)})

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -34,7 +34,7 @@ def rect_patch(
 
     Args:
         geometry: bounding box of the element
-        page_dimensions: dimensions of the Page
+        page_dimensions: dimensions of the Page in format (height, width)
         label: label to display when hovered
         color: color to draw box
         alpha: opacity parameter to fill the boxes, 0 = transparent
@@ -80,7 +80,7 @@ def polygon_patch(
 
     Args:
         geometry: bounding box of the element
-        page_dimensions: dimensions of the Page
+        page_dimensions: dimensions of the Page in format (height, width)
         label: label to display when hovered
         color: color to draw box
         alpha: opacity parameter to fill the boxes, 0 = transparent
@@ -121,7 +121,7 @@ def create_obj_patch(
 
     Args:
         geometry: bounding box (straight or rotated) of the element
-        page_dimensions: dimensions of the page
+        page_dimensions: dimensions of the page in format (height, width)
 
     Returns:
         a matplotlib Patch
@@ -273,8 +273,8 @@ def synthesize_page(
             for word in line["words"]:
                 # Get aboslute word geometry
                 (xmin, ymin), (xmax, ymax) = word["geometry"]
-                xmin, xmax = int(w * xmin), int(w * xmax)
-                ymin, ymax = int(h * ymin), int(h * ymax)
+                xmin, xmax = int(round(w * xmin)), int(round(w * xmax))
+                ymin, ymax = int(round(h * ymin)), int(round(h * ymax))
 
                 # White drawing context adapted to font size, 0.75 factor to convert pts --> pix
                 font = get_font(font_family, int(0.75 * (ymax - ymin)))


### PR DESCRIPTION
There was a wrong description in the docstring which results also in the wrong dim order in export_as_xml 
now the parser example runs also correct