### PR TITLE
feat: :sparkles: add det/reco_predictor arch in OCRPredictor.__repr__

### DIFF
--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -26,6 +26,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         det_predictor: detection module
         reco_predictor: recognition module
     """
+    _children_names = ['det_predictor', 'reco_predictor']
 
     def __init__(
         self,


### PR DESCRIPTION
Previously, if model is a TF version of OCRPredictor, `print(model) `shows only `OCRPredictor() ` which is not too informative. It now prints the architecture of the underlying det_predictor and reco_predictor.