### PR TITLE
docs: :memo: update readme and help in analyse.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,10 @@ For Windows users, those dependencies are included in GTK. You can find the late
 
 You can then install the latest release of the package using [pypi](https://pypi.org/project/python-doctr/) as follows:
 
-> :warning: Notice that the basic installation is not standalone, as it does not provide a deep learning framework, which is required for the package to run.
-
 ```shell
 pip install python-doctr
 ```
+> :warning: Please note that the basic installation is not standalone, as it does not provide a deep learning framework, which is required for the package to run.
 
 We try to keep framework-specific dependencies to a minimum. You can install framework-specific builds as follows:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For examples & further details about the export format, please refer to [this se
 
 ### Prerequisites
 
-Python 3.6 (or higher) and [pip](https://pip.pypa.io/en/stable/) are required to install docTR. Additionally, you will need to install at least one of [TensorFlow](https://www.tensorflow.org/install/) or [PyTorch](https://pytorch.org/get-started/locally/#start-locally). If you use tensorflow, you will need to install the additional package `tensorflow-addons`
+Python 3.6 (or higher) and [pip](https://pip.pypa.io/en/stable/) are required to install docTR. 
 
 Since we use [weasyprint](https://weasyprint.readthedocs.io/), you will need extra dependencies if you are not running Linux.
 
@@ -105,11 +105,13 @@ For Windows users, those dependencies are included in GTK. You can find the late
 
 You can then install the latest release of the package using [pypi](https://pypi.org/project/python-doctr/) as follows:
 
+> :warning: Notice that the basic installation is not standalone, as it does not provide a deep learning framework, which is required for the package to run.
+
 ```shell
 pip install python-doctr
 ```
 
-We try to keep framework-specific dependencies to a minimum. But if you encounter missing ones, you can install framework-specific builds as follows:
+We try to keep framework-specific dependencies to a minimum. You can install framework-specific builds as follows:
 
 ```shell
 # for TensorFlow

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For examples & further details about the export format, please refer to [this se
 
 ### Prerequisites
 
-Python 3.6 (or higher) and [pip](https://pip.pypa.io/en/stable/) are required to install docTR. Additionally, you will need to install at least one of [TensorFlow](https://www.tensorflow.org/install/) or [PyTorch](https://pytorch.org/get-started/locally/#start-locally).
+Python 3.6 (or higher) and [pip](https://pip.pypa.io/en/stable/) are required to install docTR. Additionally, you will need to install at least one of [TensorFlow](https://www.tensorflow.org/install/) or [PyTorch](https://pytorch.org/get-started/locally/#start-locally). If you use tensorflow, you will need to install the additional package `tensorflow-addons`
 
 Since we use [weasyprint](https://weasyprint.readthedocs.io/), you will need extra dependencies if you are not running Linux.
 
@@ -140,13 +140,13 @@ pip install -e doctr/.[torch]
 Credits where it's due: this repository is implementing, among others, architectures from published research papers.
 
 ### Text Detection
-- [Real-time Scene Text Detection with Differentiable Binarization](https://arxiv.org/pdf/1911.08947.pdf).
-- [LinkNet: Exploiting Encoder Representations for Efficient Semantic Segmentation](https://arxiv.org/pdf/1707.03718.pdf)
+- DBNet: [Real-time Scene Text Detection with Differentiable Binarization](https://arxiv.org/pdf/1911.08947.pdf).
+- LinkNet: [LinkNet: Exploiting Encoder Representations for Efficient Semantic Segmentation](https://arxiv.org/pdf/1707.03718.pdf)
 
 ### Text Recognition
-- [An End-to-End Trainable Neural Network for Image-based Sequence Recognition and Its Application to Scene Text Recognition](https://arxiv.org/pdf/1507.05717.pdf).
-- [Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition](https://arxiv.org/pdf/1811.00751.pdf).
-- [MASTER: Multi-Aspect Non-local Network for Scene Text Recognition](https://arxiv.org/pdf/1910.02562.pdf).
+- CRNN: [An End-to-End Trainable Neural Network for Image-based Sequence Recognition and Its Application to Scene Text Recognition](https://arxiv.org/pdf/1507.05717.pdf).
+- SAR: [Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition](https://arxiv.org/pdf/1811.00751.pdf).
+- MASTER: [MASTER: Multi-Aspect Non-local Network for Scene Text Recognition](https://arxiv.org/pdf/1910.02562.pdf).
 
 
 ## More goodies

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -45,7 +45,8 @@ def parse_args():
                         help='Text detection model to use for analysis')
     parser.add_argument('--recognition', type=str, default='crnn_vgg16_bn',
                         help='Text recognition model to use for analysis')
-    parser.add_argument("--noblock", dest="noblock", help="Disables blocking visualization. Used only for CI.", action="store_true")
+    parser.add_argument("--noblock", dest="noblock", help="Disables blocking visualization. Used only for CI.",
+                        action="store_true")
     parser.add_argument("--static", dest="static", help="Switches to static visualization", action="store_true")
     args = parser.parse_args()
 

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -45,7 +45,7 @@ def parse_args():
                         help='Text detection model to use for analysis')
     parser.add_argument('--recognition', type=str, default='crnn_vgg16_bn',
                         help='Text recognition model to use for analysis')
-    parser.add_argument("--noblock", dest="noblock", help="Disables blocking visualization", action="store_true")
+    parser.add_argument("--noblock", dest="noblock", help="Disables blocking visualization. Used only for CI.", action="store_true")
     parser.add_argument("--static", dest="static", help="Switches to static visualization", action="store_true")
     args = parser.parse_args()
 


### PR DESCRIPTION
Slight fixes and modification of the doc:

- fixed typo in readme suggested code using demonstrating synthesize
- Added the mention to tensorflow-addons
- Added model names in front of papers
- Mentionned in help of the noblock option of analyze.py that it's only used for CI.