### PR TITLE
docs: Specified that the API template only supports images for now

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -46,4 +46,4 @@ jobs:
           streamlit --version
           screen -dm streamlit run demo/app.py
           sleep 10
-          curl http://localhost:8501
+          curl http://localhost:8501/docs

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -7,16 +7,16 @@ from typing import List
 
 from app.schemas import DetectionOut
 from app.vision import det_predictor
-from fastapi import APIRouter, File, UploadFile
+from fastapi import APIRouter, File, UploadFile, status
 
 from doctr.io import decode_img_as_tensor
 
 router = APIRouter()
 
 
-@router.post("/", response_model=List[DetectionOut], status_code=200, summary="Perform text detection")
+@router.post("/", response_model=List[DetectionOut], status_code=status.HTTP_200_OK, summary="Perform text detection")
 async def text_detection(file: UploadFile = File(...)):
-    """Runs docTR text detection model to analyze the input"""
+    """Runs docTR text detection model to analyze the input image"""
     img = decode_img_as_tensor(file.file.read())
     boxes, _ = det_predictor([img])[0]
     return [DetectionOut(box=box.tolist()) for box in boxes[:, :-1]]

--- a/api/app/routes/ocr.py
+++ b/api/app/routes/ocr.py
@@ -7,16 +7,16 @@ from typing import List
 
 from app.schemas import OCROut
 from app.vision import predictor
-from fastapi import APIRouter, File, UploadFile
+from fastapi import APIRouter, File, UploadFile, status
 
 from doctr.io import decode_img_as_tensor
 
 router = APIRouter()
 
 
-@router.post("/", response_model=List[OCROut], status_code=200, summary="Perform OCR")
+@router.post("/", response_model=List[OCROut], status_code=status.HTTP_200_OK, summary="Perform OCR")
 async def perform_ocr(file: UploadFile = File(...)):
-    """Runs docTR OCR model to analyze the input"""
+    """Runs docTR OCR model to analyze the input image"""
     img = decode_img_as_tensor(file.file.read())
     out = predictor([img])
 

--- a/api/app/routes/recognition.py
+++ b/api/app/routes/recognition.py
@@ -5,16 +5,16 @@
 
 from app.schemas import RecognitionOut
 from app.vision import reco_predictor
-from fastapi import APIRouter, File, UploadFile
+from fastapi import APIRouter, File, UploadFile, status
 
 from doctr.io import decode_img_as_tensor
 
 router = APIRouter()
 
 
-@router.post("/", response_model=RecognitionOut, status_code=200, summary="Perform text recognition")
+@router.post("/", response_model=RecognitionOut, status_code=status.HTTP_200_OK, summary="Perform text recognition")
 async def text_recognition(file: UploadFile = File(...)):
-    """Runs docTR text recognition model to analyze the input"""
+    """Runs docTR text recognition model to analyze the input image"""
     img = decode_img_as_tensor(file.file.read())
     out = reco_predictor([img])
     return RecognitionOut(value=out[0][0])


### PR DESCRIPTION
Following up on some QA feedback, this PR introduces the following modifications:
- specifies that all routes support only images and not PDF for now
- cleaned the expected route status
- improved the CI check: it used to check that the base URL is accessible, and now it will check whether it can access the swagger/docs

Any feedback is welcome!

cc @RBMindee