### PR TITLE
docs: Added README specific for the API with route examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,9 @@ Your API should now be running locally on your port 8002. Access your automatica
 ```python
 
 import requests
-import io
 with open('/path/to/your/doc.jpg', 'rb') as f:
     data = f.read()
-response = requests.post("http://localhost:8002/ocr", files={'file': io.BytesIO(data)}).json()
+response = requests.post("http://localhost:8002/ocr", files={'file': data}).json()
 ```
 
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,92 @@
+# Template for your OCR API using docTR
+
+## Installation
+
+You will only need to install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [Docker](https://docs.docker.com/get-docker/). The container environment will be self-sufficient and install the remaining dependencies on its own.
+
+## Usage
+
+### Starting your web server
+
+You will need to clone the repository first:
+```shell
+git clone https://github.com/mindee/doctr.git
+```
+then from the repo root folder, you can start your container:
+
+```shell
+PORT=8050 docker-compose up -d --build
+```
+Once completed, your [FastAPI](https://fastapi.tiangolo.com/) server should be running on port 8050 (feel free to change this in the previous command).
+
+### Documentation and swagger
+
+FastAPI comes with many advantages including speed and OpenAPI features. For instance, once your server is running, you can access the automatically built documentation and swagger in your browser at: http://localhost:8050/docs
+
+
+### Using the routes
+
+You will find detailed instructions in the live documentation when your server is up, but here are some examples to use your available API routes:
+
+#### Text detection
+
+Using the following image:
+<img src="https://user-images.githubusercontent.com/76527547/117319856-fc35bf00-ae8b-11eb-9b51-ca5aba673466.jpg" width="50%" height="50%">
+
+with this snippet:
+
+```python
+import requests
+with open('/path/to/your/img.jpg', 'rb') as f:
+    data = f.read()
+print(requests.post("http://localhost:8050/detection", files={'file': data}).json())
+```
+
+should yield
+```
+[{'box': [0.826171875, 0.185546875, 0.90234375, 0.201171875]},
+ {'box': [0.75390625, 0.185546875, 0.8173828125, 0.201171875]}]
+```
+
+
+#### Text recognition
+
+Using the following image:
+![recognition-sample](https://user-images.githubusercontent.com/76527547/117133599-c073fa00-ada4-11eb-831b-412de4d28341.jpeg)
+
+with this snippet:
+
+```python
+import requests
+with open('/path/to/your/img.jpg', 'rb') as f:
+    data = f.read()
+print(requests.post("http://localhost:8050/recognition", files={'file': data}).json())
+```
+
+should yield
+```
+{'value': 'invite'}
+```
+
+
+#### End-to-end OCR
+
+Using the following image:
+<img src="https://user-images.githubusercontent.com/76527547/117319856-fc35bf00-ae8b-11eb-9b51-ca5aba673466.jpg" width="50%" height="50%">
+
+with this snippet:
+
+```python
+import requests
+with open('/path/to/your/img.jpg', 'rb') as f:
+    data = f.read()
+print(requests.post("http://localhost:8050/ocr", files={'file': data}).json())
+```
+
+should yield
+```
+[{'box': [0.75390625, 0.185546875, 0.8173828125, 0.201171875],
+  'value': 'Hello'},
+ {'box': [0.826171875, 0.185546875, 0.90234375, 0.201171875],
+  'value': 'world!'}]
+```


### PR DESCRIPTION
Following on some QA feedback, this PR adds a dedicated README for the API template. It provides curated examples of inputs and outputs on each route.

Any feedback is welcome!