### PR TITLE
fix: Fixed Makefile by converting spaces to tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,32 @@
 # this target runs checks on all files
 quality:
-    isort **/*.py -c -v
-    flake8 ./
-    mypy doctr/
+	isort **/*.py -c -v
+	flake8 ./
+	mypy doctr/
 
 # this target runs checks on all files and potentially modifies some of them
 style:
-    isort **/*.py
+	isort **/*.py
 
 # Run tests for the library
 test:
-    coverage run -m pytest tests/common/
-    USE_TF='1' coverage run -m pytest tests/tensorflow/
-    USE_TORCH='1' coverage run -m pytest tests/pytorch/
+	coverage run -m pytest tests/common/
+	USE_TF='1' coverage run -m pytest tests/tensorflow/
+	USE_TORCH='1' coverage run -m pytest tests/pytorch/
 
 test-common:
-    coverage run -m pytest tests/common/
+	coverage run -m pytest tests/common/
 
 test-tf:
-    USE_TF='1' coverage run -m pytest tests/tensorflow/
+	USE_TF='1' coverage run -m pytest tests/tensorflow/
 
 test-torch:
-    USE_TORCH='1' coverage run -m pytest tests/pytorch/
+	USE_TORCH='1' coverage run -m pytest tests/pytorch/
 
 # Check that docs can build
 docs-single-version:
-    sphinx-build docs/source docs/_build -a
+	sphinx-build docs/source docs/_build -a
 
 # Check that docs can build
 docs:
-    cd docs && bash build.sh
+	cd docs && bash build.sh


### PR DESCRIPTION
This PR fixes the Makefile as it doesn't work when tabs are converted into spaces.
