### PR TITLE
docs: Specified comment in SAR about symbol encoding

### DIFF
--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -98,7 +98,7 @@ class SARDecoder(nn.Module):
 
         # initialize states (each of shape (N, rnn_units))
         hx = [None, None]
-        # Initialize with the index of virtual START symbol (placed after <eos>)
+        # Initialize with the index of virtual START symbol (placed after <eos> so that the one-hot is only zeros)
         symbol = torch.zeros((features.shape[0], self.vocab_size + 1), device=features.device, dtype=features.dtype)
         logits_list = []
         for t in range(self.max_length + 1):  # keep 1 step for <eos>

--- a/doctr/models/recognition/sar/tensorflow.py
+++ b/doctr/models/recognition/sar/tensorflow.py
@@ -132,7 +132,7 @@ class SARDecoder(layers.Layer, NestedObject):
         # run first step of lstm
         # holistic: shape (N, rnn_units)
         _, states = self.lstm_decoder(holistic, states, **kwargs)
-        # Initialize with the index of virtual START symbol (placed after <eos>)
+        # Initialize with the index of virtual START symbol (placed after <eos> so that the one-hot is only zeros)
         symbol = tf.fill(features.shape[0], self.vocab_size + 1)
         logits_list = []
         if kwargs.get('training') and gt is None:


### PR DESCRIPTION
This PR specifies the reason of the one hot symbol encoding in the SAR decoder following up on #578.

cc @khalidMindee 