### PR TITLE
docs: Added links to tutorial notebooks in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://github.com/mindee/doctr/releases/download/v0.3.1/Logo_doctr.gif" width="40%">
 </p>
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) ![Build Status](https://github.com/mindee/doctr/workflows/builds/badge.svg) [![codecov](https://codecov.io/gh/mindee/doctr/branch/main/graph/badge.svg?token=577MO567NM)](https://codecov.io/gh/mindee/doctr) [![CodeFactor](https://www.codefactor.io/repository/github/mindee/doctr/badge?s=bae07db86bb079ce9d6542315b8c6e70fa708a7e)](https://www.codefactor.io/repository/github/mindee/doctr) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/340a76749b634586a498e1c0ab998f08)](https://app.codacy.com/gh/mindee/doctr?utm_source=github.com&utm_medium=referral&utm_content=mindee/doctr&utm_campaign=Badge_Grade) [![Doc Status](https://github.com/mindee/doctr/workflows/doc-status/badge.svg)](https://mindee.github.io/doctr) [![Pypi](https://img.shields.io/badge/pypi-v0.4.0-blue.svg)](https://pypi.org/project/python-doctr/) [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/mindee/doctr)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) ![Build Status](https://github.com/mindee/doctr/workflows/builds/badge.svg) [![codecov](https://codecov.io/gh/mindee/doctr/branch/main/graph/badge.svg?token=577MO567NM)](https://codecov.io/gh/mindee/doctr) [![CodeFactor](https://www.codefactor.io/repository/github/mindee/doctr/badge?s=bae07db86bb079ce9d6542315b8c6e70fa708a7e)](https://www.codefactor.io/repository/github/mindee/doctr) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/340a76749b634586a498e1c0ab998f08)](https://app.codacy.com/gh/mindee/doctr?utm_source=github.com&utm_medium=referral&utm_content=mindee/doctr&utm_campaign=Badge_Grade) [![Doc Status](https://github.com/mindee/doctr/workflows/doc-status/badge.svg)](https://mindee.github.io/doctr) [![Pypi](https://img.shields.io/badge/pypi-v0.4.0-blue.svg)](https://pypi.org/project/python-doctr/) [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/mindee/doctr) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mindee/notebooks/blob/main/doctr/quicktour.ipynb)
 
 
 **Optical Character Recognition made seamless & accessible to anyone, powered by TensorFlow 2 & PyTorch**
@@ -230,6 +230,9 @@ with open('/path/to/your/doc.jpg', 'rb') as f:
     data = f.read()
 response = requests.post("http://localhost:8002/ocr", files={'file': io.BytesIO(data)}).json()
 ```
+
+### Example notebooks
+Looking for more illustrations of docTR features? You might want to check the [Jupyter notebooks](https://github.com/mindee/doctr/tree/main/notebooks) designed to give you a broader overview.
 
 
 ## Citation

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,5 @@ sphinx-rtd-theme==0.4.3
 sphinxemoji>=0.1.8
 sphinx-copybutton>=0.3.1
 docutils<0.18
+recommonmark>=0.7.1
+sphinx-markdown-tables>=0.0.15

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store', 'notebooks/*.rst']
 
 
 # The name of the Pygments (syntax highlighting) style to use.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,8 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'sphinxemoji.sphinxemoji',  # cf. https://sphinxemojicodes.readthedocs.io/en/stable/
     'sphinx_copybutton',
+    'recommonmark',
+    'sphinx_markdown_tables',
 ]
 
 napoleon_use_ivar = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,7 @@ Main Features
    :hidden:
 
    installing
+   notebooks
 
 
 Model zoo

--- a/docs/source/notebooks.md
+++ b/docs/source/notebooks.md
@@ -1,0 +1,1 @@
+../../notebooks/README.md

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,8 @@
+# docTR Notebooks
+
+Here are some notebooks compiled for users to better leverage the library capabilities:
+
+| Notebook     |      Description      |   |
+|:----------|:-------------|------:|
+| [Quicktour](https://github.com/mindee/notebooks/blob/main/doctr/quicktour.ipynb) | A presentation of the main features of docTR | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mindee/notebooks/blob/main/doctr/quicktour.ipynb) |
+

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,8 @@ _deps = [
     "sphinxemoji>=0.1.8",
     "sphinx-copybutton>=0.3.1",
     "docutils<0.18",
+    "recommonmark>=0.7.1",
+    "sphinx-markdown-tables>=0.0.15",
 ]
 
 deps = {b: a for a, b in (re.findall(r"^(([^!=<>]+)(?:[!=<>].*)?$)", x)[0] for x in _deps)}
@@ -142,6 +144,8 @@ extras["docs_specific"] = deps_list(
     "sphinxemoji",
     "sphinx-copybutton",
     "docutils",
+    "recommonmark",
+    "sphinx-markdown-tables",
 )
 
 extras["docs"] = extras["all"] + extras["docs_specific"]


### PR DESCRIPTION
This PR introduces the following modifications:
- adds a `notebooks` folder that will reference all notebooks to be displayed in the documentation
- added a symlink in sphinx documentation to use this README to generate an identical page in the documentation
- added corresponding sphinx deps to handle tables


Here is how the corresponding documentation page renders:
![image](https://user-images.githubusercontent.com/76527547/141516841-adffa562-f235-46c1-93e8-bb6702898481.png)

Closes #558

Any feedback is welcome!