### PR TITLE
feat: add 2 new rotation flags in the ocr_predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ doc = DocumentFile.from_pdf("path/to/your/doc.pdf").as_images()
 result = model(doc)
 ```
 
+### Deal with the rotation issues
+You can provide rotated documents, and/or documents with different boxes orientations.
+We provide different options to deal with such cases:
+
+- If you will only use straight document pages with straight words (horizontal, same reading direction),
+pass `assume_straigth_pages=True` in the `ocr_predictor`, it will directly fit straight boxes to your pages
+and return straight boxes, it is the faster pipeline.
+
+- If you want the predictor to output straight boxes (no matter the orientation of your pages, it will approximate
+rotated boxes to straight ones), you need to pass `export_as_straight_boxes=True` in the predictor. Otherwise, it
+will always return rotated boxes (with an angle which can be 0) except if you passed `assume_straigth_pages=True`,
+in that case you end up with straight bounding boxes.
+
+If you deactivate those 2 options, the predictor will always fit and return rotated boxes.
+
+
 To interpret your model's predictions, you can visualize them interactively as follows:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -56,20 +56,18 @@ doc = DocumentFile.from_pdf("path/to/your/doc.pdf").as_images()
 result = model(doc)
 ```
 
-### Deal with the rotation issues
-You can provide rotated documents, and/or documents with different boxes orientations.
-We provide different options to deal with such cases:
+### Dealing with rotated documents
+Should you use docTR on documents that include rotated pages, or pages with multiple box orientations,
+you have multiple options to handle it:
 
-- If you will only use straight document pages with straight words (horizontal, same reading direction),
-pass `assume_straigth_pages=True` in the `ocr_predictor`, it will directly fit straight boxes to your pages
-and return straight boxes, it is the faster pipeline.
+- If you only use straight document pages with straight words (horizontal, same reading direction),
+consider passing `assume_straight_boxes=True` to the ocr_predictor. It will directly fit straight boxes
+on your page and return straight boxes, which makes it the fastest option.
 
-- If you want the predictor to output straight boxes (no matter the orientation of your pages, it will approximate
-rotated boxes to straight ones), you need to pass `export_as_straight_boxes=True` in the predictor. Otherwise, it
-will always return rotated boxes (with an angle which can be 0) except if you passed `assume_straigth_pages=True`,
-in that case you end up with straight bounding boxes.
+- If you want the predictor to output straight boxes (no matter the orientation of your pages, the final localizations
+will be converted to straight boxes), you need to pass `export_as_straight_boxes=True` in the predictor. Otherwise, if `assume_straight_pages=False`, it will return rotated bounding boxes (potentially with an angle of 0°).
 
-If you deactivate those 2 options, the predictor will always fit and return rotated boxes.
+If both options are set to False, the predictor will always fit and return rotated boxes.
 
 
 To interpret your model's predictions, you can visualize them interactively as follows:

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -25,6 +25,11 @@ class OCRPredictor(nn.Module, _OCRPredictor):
     Args:
         det_predictor: detection module
         reco_predictor: recognition module
+        assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
+            without rotated textual elements.
+        export_as_straight_boxes: when assume_straight_pages is set to False, export final predictions
+            (potentially rotated) as straight bounding boxes.
+
     """
 
     def __init__(

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -25,6 +25,10 @@ class OCRPredictor(NestedObject, _OCRPredictor):
     Args:
         det_predictor: detection module
         reco_predictor: recognition module
+        assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
+            without rotated textual elements.
+        export_as_straight_boxes: when assume_straight_pages is set to False, export final predictions
+            (potentially rotated) as straight bounding boxes.
     """
     _children_names = ['det_predictor', 'reco_predictor']
 

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -61,5 +61,10 @@ def ocr_predictor(
     """
 
     return _predictor(
-        det_arch, reco_arch, pretrained, assume_straight_pages, export_as_straight_boxes, **kwargs
+        det_arch,
+        reco_arch,
+        pretrained,
+        assume_straight_pages=assume_straight_pages,
+        export_as_straight_boxes=export_as_straight_boxes,
+        **kwargs,
     )

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -16,10 +16,9 @@ def _predictor(
     det_arch: str,
     reco_arch: str,
     pretrained: bool,
-    assume_straight_pages: bool = True,
-    export_as_straight_boxes: bool = False,
     det_bs: int = 2,
     reco_bs: int = 128,
+    **kwargs,
 ) -> OCRPredictor:
 
     # Detection
@@ -28,7 +27,7 @@ def _predictor(
     # Recognition
     reco_predictor = recognition_predictor(reco_arch, pretrained=pretrained, batch_size=reco_bs)
 
-    return OCRPredictor(det_predictor, reco_predictor, assume_straight_pages, export_as_straight_boxes)
+    return OCRPredictor(det_predictor, reco_predictor, **kwargs)
 
 
 def ocr_predictor(
@@ -49,13 +48,13 @@ def ocr_predictor(
         >>> out = model([input_page])
 
     Args:
-        det_arch: name of the detection architecture to use ('db_resnet50', 'db_mobilenet_v3_large')
-        reco_arch: name of the recognition architecture to use ('crnn_vgg16_bn', 'sar_resnet31')
+        det_arch: name of the detection architecture to use (e.g. 'db_resnet50', 'db_mobilenet_v3_large')
+        reco_arch: name of the recognition architecture to use (e.g. 'crnn_vgg16_bn', 'sar_resnet31')
         pretrained: If True, returns a model pre-trained on our OCR dataset
-        assume_straight_pages: if you only pass straight pages with straight boxes, activate this arg.
-            to speed up the pipeline!
-        export_as_straight_boxes: output format of boxes: if True, boxes are always straight rectangles,
-            otherwise predicted boxes are rotated rectangles (except if you pass assume_straight_pages=True)
+        assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
+            without rotated textual elements.
+        export_as_straight_boxes: when assume_straight_pages is set to False, export final predictions
+            (potentially rotated) as straight bounding boxes.
 
     Returns:
         OCR predictor

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -12,7 +12,15 @@ from .recognition.zoo import recognition_predictor
 __all__ = ["ocr_predictor"]
 
 
-def _predictor(det_arch: str, reco_arch: str, pretrained: bool, det_bs=2, reco_bs=128) -> OCRPredictor:
+def _predictor(
+    det_arch: str,
+    reco_arch: str,
+    pretrained: bool,
+    assume_straight_pages: bool = True,
+    export_as_straight_boxes: bool = False,
+    det_bs: int = 2,
+    reco_bs: int = 128,
+) -> OCRPredictor:
 
     # Detection
     det_predictor = detection_predictor(det_arch, pretrained=pretrained, batch_size=det_bs)
@@ -20,13 +28,15 @@ def _predictor(det_arch: str, reco_arch: str, pretrained: bool, det_bs=2, reco_b
     # Recognition
     reco_predictor = recognition_predictor(reco_arch, pretrained=pretrained, batch_size=reco_bs)
 
-    return OCRPredictor(det_predictor, reco_predictor)
+    return OCRPredictor(det_predictor, reco_predictor, assume_straight_pages, export_as_straight_boxes)
 
 
 def ocr_predictor(
     det_arch: str = 'db_resnet50',
     reco_arch: str = 'crnn_vgg16_bn',
     pretrained: bool = False,
+    assume_straight_pages: bool = True,
+    export_as_straight_boxes: bool = False,
     **kwargs: Any
 ) -> OCRPredictor:
     """End-to-end OCR architecture using one model for localization, and another for text recognition.
@@ -39,11 +49,18 @@ def ocr_predictor(
         >>> out = model([input_page])
 
     Args:
-        arch: name of the architecture to use ('db_sar_vgg', 'db_sar_resnet', 'db_crnn_vgg', 'db_crnn_resnet')
+        det_arch: name of the detection architecture to use ('db_resnet50', 'db_mobilenet_v3_large')
+        reco_arch: name of the recognition architecture to use ('crnn_vgg16_bn', 'sar_resnet31')
         pretrained: If True, returns a model pre-trained on our OCR dataset
+        assume_straight_pages: if you only pass straight pages with straight boxes, activate this arg.
+            to speed up the pipeline!
+        export_as_straight_boxes: output format of boxes: if True, boxes are always straight rectangles,
+            otherwise predicted boxes are rotated rectangles (except if you pass assume_straight_pages=True) 
 
     Returns:
         OCR predictor
     """
 
-    return _predictor(det_arch, reco_arch, pretrained, **kwargs)
+    return _predictor(
+        det_arch, reco_arch, pretrained, assume_straight_pages, export_as_straight_boxes, **kwargs
+    )

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -55,7 +55,7 @@ def ocr_predictor(
         assume_straight_pages: if you only pass straight pages with straight boxes, activate this arg.
             to speed up the pipeline!
         export_as_straight_boxes: output format of boxes: if True, boxes are always straight rectangles,
-            otherwise predicted boxes are rotated rectangles (except if you pass assume_straight_pages=True) 
+            otherwise predicted boxes are rotated rectangles (except if you pass assume_straight_pages=True)
 
     Returns:
         OCR predictor


### PR DESCRIPTION
This PR adds the 2 flags introduced in #551 in the highest level predictor so the user can easily choose the parameters of the rotation.

Any feedback is welcome!