### PR TITLE
refactor: :zap: Speeded up CTC decoding in PyTorch by x10

### DIFF
--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -5,7 +5,7 @@
 
 import string
 import unicodedata
-from collections import Sequence
+from collections.abc import Sequence
 from functools import partial
 from typing import Any, List, Optional
 from typing import Sequence as SequenceType

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -7,7 +7,9 @@ import string
 import unicodedata
 from collections import Sequence
 from functools import partial
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, List, Optional
+from typing import Sequence as SequenceType
+from typing import Union
 
 import numpy as np
 
@@ -67,7 +69,7 @@ def encode_string(
 
 
 def decode_sequence(
-    input_seq: Union[np.array, Sequence[int]],
+    input_seq: Union[np.array, SequenceType[int]],
     mapping: str,
 ) -> str:
     """Given a predefined mapping, decode the sequence of numbers to a string
@@ -80,7 +82,9 @@ def decode_sequence(
         A string, decoded from input_seq
     """
 
-    if not isinstance(input_seq, Sequence) or input_seq.dtype != np.int_ or input_seq.max() >= len(mapping):
+    if not isinstance(input_seq, (Sequence, np.ndarray)):
+        raise TypeError("Invalid sequence type")
+    if isinstance(input_seq, np.ndarray) and (input_seq.dtype != np.int_ or input_seq.max() >= len(mapping)):
         raise AssertionError("Input must be an array of int, with max less than mapping size")
 
     return ''.join(map(mapping.__getitem__, input_seq))

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -5,8 +5,9 @@
 
 import string
 import unicodedata
+from collections import Sequence
 from functools import partial
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence, Union
 
 import numpy as np
 
@@ -66,23 +67,23 @@ def encode_string(
 
 
 def decode_sequence(
-    input_array: np.array,
+    input_seq: Union[np.array, Sequence[int]],
     mapping: str,
 ) -> str:
     """Given a predefined mapping, decode the sequence of numbers to a string
 
     Args:
-        input_array: array to decode
+        input_seq: array to decode
         mapping: vocabulary (string), the encoding is given by the indexing of the character sequence
 
     Returns:
-        A string, decoded from input_array
+        A string, decoded from input_seq
     """
 
-    if not input_array.dtype == np.int_ or input_array.max() >= len(mapping):
+    if not isinstance(input_seq, Sequence) or input_seq.dtype != np.int_ or input_seq.max() >= len(mapping):
         raise AssertionError("Input must be an array of int, with max less than mapping size")
 
-    return ''.join(map(mapping.__getitem__, input_array))
+    return ''.join(map(mapping.__getitem__, input_seq))
 
 
 def encode_sequences(

--- a/tests/common/test_datasets_utils.py
+++ b/tests/common/test_datasets_utils.py
@@ -47,6 +47,8 @@ def test_decode_sequence():
     with pytest.raises(AssertionError):
         utils.decode_sequence(np.array([2, 4.5]), mapping)
 
+    assert utils.decode_sequence([3, 4, 3, 4], mapping) == "dede"
+
 
 @pytest.mark.parametrize(
     "sequences, vocab, target_size, sos, eos, pad, dynamic_len, error, out_shape, gts",

--- a/tests/common/test_datasets_utils.py
+++ b/tests/common/test_datasets_utils.py
@@ -34,7 +34,7 @@ def test_encode_decode(input_str):
     mapping = """3K}7eé;5àÎYho]QwV6qU~W"XnbBvcADfËmy.9ÔpÛ*{CôïE%M4#ÈR:g@T$x?0î£|
         za1ù8,OG€P-kçHëÀÂ2É/ûIJ\'j(LNÙFut[)èZs+&°Sd=Ï!<â_Ç>rêi`l"""
     encoded = utils.encode_string(input_str, mapping)
-    decoded = utils.decode_sequence(np.array(encoded), mapping)
+    decoded = utils.decode_sequence(encoded, mapping)
     assert decoded == input_str
 
 

--- a/tests/common/test_datasets_utils.py
+++ b/tests/common/test_datasets_utils.py
@@ -38,6 +38,16 @@ def test_encode_decode(input_str):
     assert decoded == input_str
 
 
+def test_decode_sequence():
+    mapping = "abcdef"
+    with pytest.raises(TypeError):
+        utils.decode_sequence(123, mapping)
+    with pytest.raises(AssertionError):
+        utils.decode_sequence(np.array([2, 10]), mapping)
+    with pytest.raises(AssertionError):
+        utils.decode_sequence(np.array([2, 4.5]), mapping)
+
+
 @pytest.mark.parametrize(
     "sequences, vocab, target_size, sos, eos, pad, dynamic_len, error, out_shape, gts",
     [


### PR DESCRIPTION
This PR introduces the following modifications:
- extends arg type support of `decode_sequence`
- refactored CTC decoding in PyTorch bringing a 10x speedup
- updated unittests

Any feedback is welcome!