### PR TITLE
fix: :bug: bug canvas dtype for threshold target

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -268,7 +268,7 @@ class _DBNet:
 
         seg_target = np.zeros(output_shape, dtype=np.uint8)
         seg_mask = np.ones(output_shape, dtype=bool)
-        thresh_target = np.zeros(output_shape, dtype=np.uint8)
+        thresh_target = np.zeros(output_shape, dtype=np.float32)
         thresh_mask = np.ones(output_shape, dtype=np.uint8)
 
         for idx, _target in enumerate(target):


### PR DESCRIPTION
The threshold target map (of the DB) was set to be an uint8 tensor, but it should contains values between 0 and 1 (which were cast to 0).
This is now fixed.