### PR TITLE
ci: Fixed silent isort failure

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -39,25 +39,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('**/*.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-
-            ${{ runner.os }}-pkg-deps-${{ matrix.python }}-
-            ${{ runner.os }}-pkg-deps-
-            ${{ runner.os }}-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[tf] --upgrade
-          pip install isort
       - name: Run isort
         run: |
+          pip install isort
           isort --version
-          isort **/*.py --skip "**/__init_.py" --filter-files
+          isort **/*.py --skip "**/__init_.py" --filter-files --project doctr
           if [ -n "$(git status --porcelain --untracked-files=no)" ]; then exit 1; else echo "All clear"; fi
 
   mypy-py3:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -39,9 +39,23 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
+      - name: Cache python modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-
+            ${{ runner.os }}-pkg-deps-${{ matrix.python }}-
+            ${{ runner.os }}-pkg-deps-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[tf] --upgrade
+          pip install isort
       - name: Run isort
         run: |
-          pip install isort
           isort --version
           isort **/*.py --skip "**/__init_.py" --filter-files
           if [ -n "$(git status --porcelain --untracked-files=no)" ]; then exit 1; else echo "All clear"; fi

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Run isort
         run: |
           pip install isort
+          isort --version
           isort **/*.py --skip "**/__init_.py" --filter-files
           if [ -n "$(git status --porcelain --untracked-files=no)" ]; then exit 1; fi
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           pip install isort
           isort --version
-          isort **/*.py --skip "**/__init_.py" --filter-files --project doctr
+          isort **/*.py --skip "**/__init_.py" --filter-files --project doctr --show-files
           if [ -n "$(git status --porcelain --untracked-files=no)" ]; then exit 1; else echo "All clear"; fi
 
   mypy-py3:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           pip install isort
           isort --version
-          isort **/*.py --skip "**/__init_.py" --filter-files --project doctr --show-files
+          isort .
           if [ -n "$(git status --porcelain --untracked-files=no)" ]; then exit 1; else echo "All clear"; fi
 
   mypy-py3:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: [3.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.7]
+        python: [3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -43,7 +43,7 @@ jobs:
         run: |
           pip install isort
           isort --version
-          isort **/*.py --skip "**/__init_.py" --filter-files --verbose
+          isort **/*.py --skip "**/__init_.py" --filter-files
           if [ -n "$(git status --porcelain --untracked-files=no)" ]; then exit 1; else echo "All clear"; fi
 
   mypy-py3:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           pip install isort
           isort --version
-          isort **/*.py --skip "**/__init_.py" --filter-files
-          if [ -n "$(git status --porcelain --untracked-files=no)" ]; then exit 1; fi
+          isort **/*.py --skip "**/__init_.py" --filter-files --verbose
+          if [ -n "$(git status --porcelain --untracked-files=no)" ]; then exit 1; else echo "All clear"; fi
 
   mypy-py3:
     runs-on: ${{ matrix.os }}

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 src_paths = doctr,tests
 skip_glob=**/__init__.py
-known_third_party=tensorflow,torch,torchvision
+known_third_party=tensorflow,torch,torchvision,wandb,fastprogress

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+line_length = 120
+src_paths = doctr,tests
+skip_glob=**/__init__.py
+known_third_party=tensorflow,torch,torchvision

--- a/doctr/models/predictor/base.py
+++ b/doctr/models/predictor/base.py
@@ -3,10 +3,12 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-import numpy as np
 from typing import List, Tuple
 
+import numpy as np
+
 from doctr.models.builder import DocumentBuilder
+
 from .._utils import extract_crops, extract_rcrops
 
 __all__ = ['_OCRPredictor']

--- a/references/classification/train_pytorch.py
+++ b/references/classification/train_pytorch.py
@@ -14,6 +14,7 @@ import time
 
 import numpy as np
 import torch
+import wandb
 from contiguous_params import ContiguousParams
 from fastprogress.fastprogress import master_bar, progress_bar
 from torch.nn.functional import cross_entropy
@@ -21,11 +22,10 @@ from torch.optim.lr_scheduler import CosineAnnealingLR, OneCycleLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torchvision import models
 from torchvision.transforms import ColorJitter, Compose, Normalize, RandomPerspective
-from utils import plot_samples
 
-import wandb
 from doctr import transforms as T
 from doctr.datasets import VOCABS, CharacterGenerator
+from utils import plot_samples
 
 
 def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, mb, amp=False):

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -14,19 +14,17 @@ import time
 
 import numpy as np
 import tensorflow as tf
-from fastprogress.fastprogress import master_bar, progress_bar
-
 import wandb
+from fastprogress.fastprogress import master_bar, progress_bar
 
 gpu_devices = tf.config.experimental.list_physical_devices('GPU')
 if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
-from utils import plot_samples
-
 from doctr import transforms as T
 from doctr.datasets import VOCABS, CharacterGenerator, DataLoader
 from doctr.models import backbones
+from utils import plot_samples
 
 
 def fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb):

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -15,18 +15,18 @@ import time
 
 import numpy as np
 import torch
+import wandb
 from contiguous_params import ContiguousParams
 from fastprogress.fastprogress import master_bar, progress_bar
 from torch.optim.lr_scheduler import CosineAnnealingLR, OneCycleLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torchvision.transforms import ColorJitter, Compose, Normalize
-from utils import plot_samples
 
-import wandb
 from doctr import transforms as T
 from doctr.datasets import DetectionDataset
 from doctr.models import detection
 from doctr.utils.metrics import LocalizationConfusion
+from utils import plot_samples
 
 
 def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, mb, amp=False):

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -15,20 +15,18 @@ import time
 
 import numpy as np
 import tensorflow as tf
-from fastprogress.fastprogress import master_bar, progress_bar
-
 import wandb
+from fastprogress.fastprogress import master_bar, progress_bar
 
 gpu_devices = tf.config.experimental.list_physical_devices('GPU')
 if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
-from utils import plot_samples
-
 from doctr import transforms as T
 from doctr.datasets import DataLoader, DetectionDataset
 from doctr.models import detection
 from doctr.utils.metrics import LocalizationConfusion
+from utils import plot_samples
 
 
 def fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb):

--- a/references/obj_detection/train_pytorch.py
+++ b/references/obj_detection/train_pytorch.py
@@ -15,11 +15,11 @@ import numpy as np
 import torch
 import torch.optim as optim
 import torchvision
+import wandb
 from fastprogress.fastprogress import master_bar, progress_bar
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torchvision.ops import MultiScaleRoIAlign
 
-import wandb
 from doctr.datasets import DocArtefacts
 from doctr.utils import DetectionMetric
 

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -16,18 +16,18 @@ from pathlib import Path
 
 import numpy as np
 import torch
+import wandb
 from contiguous_params import ContiguousParams
 from fastprogress.fastprogress import master_bar, progress_bar
 from torch.optim.lr_scheduler import CosineAnnealingLR, OneCycleLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torchvision.transforms import ColorJitter, Compose, Normalize
-from utils import plot_samples
 
-import wandb
 from doctr import transforms as T
 from doctr.datasets import VOCABS, RecognitionDataset
 from doctr.models import recognition
 from doctr.utils.metrics import TextMatch
+from utils import plot_samples
 
 
 def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, mb, amp=False):

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -16,20 +16,18 @@ from pathlib import Path
 
 import numpy as np
 import tensorflow as tf
-from fastprogress.fastprogress import master_bar, progress_bar
-
 import wandb
+from fastprogress.fastprogress import master_bar, progress_bar
 
 gpu_devices = tf.config.experimental.list_physical_devices('GPU')
 if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
-from utils import plot_samples
-
 from doctr import transforms as T
 from doctr.datasets import VOCABS, DataLoader, RecognitionDataset
 from doctr.models import recognition
 from doctr.utils.metrics import TextMatch
+from utils import plot_samples
 
 
 def fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
 [metadata]
 description-file = README.md
 license_file = LICENSE
-
-[isort]
-line_length = 120


### PR DESCRIPTION
This PR tries to solve why isort doesn't throw an error while there is a file on `main` with the wrong import order. This finally manages to get some isort errors when needed (cf. https://github.com/mindee/doctr/runs/4356017960?check_suite_focus=true)

Any feedback is welcome!