### PR TITLE
fix: rotation arg in training scripts

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -132,6 +132,37 @@ class DBPostProcessor(DetectionPostProcessor):
                 x, y, w, h = x / width, y / height, w / width, h / height
                 boxes.append([x, y, w, h, alpha, score])
 
+        # Compute median angle and mean aspect ratio to resolve quadrants
+        median_angle = np.median(np.float32(boxes)[:, -2])
+        mean_w = np.mean(np.float32(boxes)[:, 2])
+        mean_h = np.mean(np.float32(boxes)[:, 3])
+
+        # Rectify angles
+        new_boxes = []
+        for box in boxes:
+            [x, y, w, h, alpha, score] = box
+            if mean_h >= mean_w:
+                # We are in the upper quadrant
+                if  .5 < h / w < 2:
+                    # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
+                    new_boxes.append([x, y, h, w, 90 + median_angle, score])
+                elif abs(90 - abs(alpha) - abs(median_angle)) <= 5:
+                    # We jumped to the next quadrant, rectify
+                    new_boxes.append([x, y, w, h, alpha, score])
+                else:
+                    new_boxes.append([x, y, h, w, 90 + alpha, score])
+            else:
+                # We are in the lower quadrant.
+                if  .5 < h / w < 2:
+                    # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
+                    new_boxes.append([x, y, w, h, median_angle, score])
+                elif abs(90 - abs(alpha) - abs(median_angle)) <= 5:
+                    # We jumped to the next quadrant, rectify
+                    new_boxes.append([x, y, h, w, 90 + alpha, score])
+                else: 
+                    new_boxes.append([x, y, w, h, alpha, score])
+        boxes = new_boxes
+
         if not self.assume_straight_pages:
             if len(boxes) == 0:
                 return np.zeros((0, 6), dtype=pred.dtype)

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -132,37 +132,6 @@ class DBPostProcessor(DetectionPostProcessor):
                 x, y, w, h = x / width, y / height, w / width, h / height
                 boxes.append([x, y, w, h, alpha, score])
 
-        # Compute median angle and mean aspect ratio to resolve quadrants
-        median_angle = np.median(np.float32(boxes)[:, -2])
-        mean_w = np.mean(np.float32(boxes)[:, 2])
-        mean_h = np.mean(np.float32(boxes)[:, 3])
-
-        # Rectify angles
-        new_boxes = []
-        for box in boxes:
-            [x, y, w, h, alpha, score] = box
-            if mean_h >= mean_w:
-                # We are in the upper quadrant
-                if  .5 < h / w < 2:
-                    # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
-                    new_boxes.append([x, y, h, w, 90 + median_angle, score])
-                elif abs(90 - abs(alpha) - abs(median_angle)) <= 5:
-                    # We jumped to the next quadrant, rectify
-                    new_boxes.append([x, y, w, h, alpha, score])
-                else:
-                    new_boxes.append([x, y, h, w, 90 + alpha, score])
-            else:
-                # We are in the lower quadrant.
-                if  .5 < h / w < 2:
-                    # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
-                    new_boxes.append([x, y, w, h, median_angle, score])
-                elif abs(90 - abs(alpha) - abs(median_angle)) <= 5:
-                    # We jumped to the next quadrant, rectify
-                    new_boxes.append([x, y, h, w, 90 + alpha, score])
-                else: 
-                    new_boxes.append([x, y, w, h, alpha, score])
-        boxes = new_boxes
-
         if not self.assume_straight_pages:
             if len(boxes) == 0:
                 return np.zeros((0, 6), dtype=pred.dtype)

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -112,7 +112,6 @@ def main(args):
         img_folder=os.path.join(args.val_path, 'images'),
         label_path=os.path.join(args.val_path, 'labels.json'),
         sample_transforms=T.Resize((args.input_size, args.input_size)),
-        rotated_bbox=args.rotation
     )
     val_loader = DataLoader(
         val_set,
@@ -131,7 +130,7 @@ def main(args):
     batch_transforms = Normalize(mean=(0.798, 0.785, 0.772), std=(0.264, 0.2749, 0.287))
 
     # Load doctr model
-    model = detection.__dict__[args.arch](pretrained=args.pretrained)
+    model = detection.__dict__[args.arch](pretrained=args.pretrained, assume_straight_pages=not args.rotation)
 
     # Resume weights
     if isinstance(args.resume, str):
@@ -175,7 +174,6 @@ def main(args):
             T.RandomApply(T.ColorInversion(), .1),
             ColorJitter(brightness=0.3, contrast=0.3, saturation=0.3, hue=0.02),
         ]),
-        rotated_bbox=args.rotation
     )
 
     train_loader = DataLoader(

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -82,7 +82,6 @@ def main(args):
         img_folder=os.path.join(args.val_path, 'images'),
         label_path=os.path.join(args.val_path, 'labels.json'),
         sample_transforms=T.Resize((args.input_size, args.input_size)),
-        rotated_bbox=args.rotation
     )
     val_loader = DataLoader(val_set, batch_size=args.batch_size, shuffle=False, drop_last=False, workers=args.workers)
     print(f"Validation set loaded in {time.time() - st:.4}s ({len(val_set)} samples in "
@@ -97,7 +96,8 @@ def main(args):
     # Load doctr model
     model = detection.__dict__[args.arch](
         pretrained=args.pretrained,
-        input_shape=(args.input_size, args.input_size, 3)
+        input_shape=(args.input_size, args.input_size, 3),
+        assume_straight_pages=not args.rotation,
     )
 
     # Resume weights
@@ -128,7 +128,6 @@ def main(args):
             T.RandomContrast(.3),
             T.RandomBrightness(.3),
         ]),
-        rotated_bbox=args.rotation
     )
     train_loader = DataLoader(train_set, batch_size=args.batch_size, shuffle=True, drop_last=True, workers=args.workers)
     print(f"Train set loaded in {time.time() - st:.4}s ({len(train_set)} samples in "


### PR DESCRIPTION
This PR fixes the rotation arg in training scripts:
- it is now passed in the model to instantiate the postprocessor correctly
- it is not passed in the dataset constructor, otherwise it will load our annotations as rotated boxes, but we have straight boxes and we rotate the images afterwards as a transformation in the get_itm fn.
Any feedback is welcome!