### PR TITLE
feat: Added rbox_iou function with a memory-savy option

### DIFF
--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -313,6 +313,8 @@ class LocalizationConfusion:
 
     Args:
         iou_thresh: minimum IoU to consider a pair of prediction and ground truth as a match
+        rotated_bbox: if set to True, predictions and targets will be expected to have rotated format
+        mask_shape: if rotated_bbox is True, describes the spatial shape of the image used
     """
 
     def __init__(
@@ -410,6 +412,8 @@ class OCRMetric:
 
     Args:
         iou_thresh: minimum IoU to consider a pair of prediction and ground truth as a match
+        rotated_bbox: if set to True, predictions and targets will be expected to have rotated format
+        mask_shape: if rotated_bbox is True, describes the spatial shape of the image used
     """
 
     def __init__(
@@ -537,6 +541,8 @@ class DetectionMetric:
 
     Args:
         iou_thresh: minimum IoU to consider a pair of prediction and ground truth as a match
+        rotated_bbox: if set to True, predictions and targets will be expected to have rotated format
+        mask_shape: if rotated_bbox is True, describes the spatial shape of the image used
     """
 
     def __init__(

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -17,7 +17,7 @@ __all__ = ['TextMatch', 'box_iou', 'box_ioa', 'mask_iou', 'rbox_iou',
 
 
 def string_match(word1: str, word2: str) -> Tuple[bool, bool, bool, bool]:
-    """Perform string comparison with multiple levels of tolerance
+    """Performs string comparison with multiple levels of tolerance
 
     Args:
         word1: a string
@@ -119,7 +119,7 @@ class TextMatch:
 
 
 def box_iou(boxes_1: np.ndarray, boxes_2: np.ndarray) -> np.ndarray:
-    """Compute the IoU between two sets of bounding boxes
+    """Computes the IoU between two sets of bounding boxes
 
     Args:
         boxes_1: bounding boxes of shape (N, 4) in format (xmin, ymin, xmax, ymax)
@@ -147,7 +147,7 @@ def box_iou(boxes_1: np.ndarray, boxes_2: np.ndarray) -> np.ndarray:
 
 
 def box_ioa(boxes_1: np.ndarray, boxes_2: np.ndarray) -> np.ndarray:
-    """Compute the IoA (intersection over area) between two sets of bounding boxes:
+    """Computes the IoA (intersection over area) between two sets of bounding boxes:
     ioa(i, j) = inter(i, j) / area(i)
 
     Args:
@@ -176,7 +176,7 @@ def box_ioa(boxes_1: np.ndarray, boxes_2: np.ndarray) -> np.ndarray:
 
 
 def mask_iou(masks_1: np.ndarray, masks_2: np.ndarray) -> np.ndarray:
-    """Compute the IoU between two sets of boolean masks
+    """Computes the IoU between two sets of boolean masks
 
     Args:
         masks_1: boolean masks of shape (N, H, W)
@@ -206,7 +206,7 @@ def rbox_iou(
     mask_shape: Tuple[int, int],
     use_broadcasting: bool = True
 ) -> np.ndarray:
-    """Compute the IoU between two sets of rotated bounding boxes
+    """Computes the IoU between two sets of rotated bounding boxes
 
     Args:
         boxes_1: rotated bounding boxes of shape (N, 5) in format (x, y, w, h, alpha)
@@ -240,7 +240,7 @@ def rbox_iou(
 
 
 def _rbox_to_mask(box: np.ndarray, shape: Tuple[int, int]) -> np.ndarray:
-    """Convert boxes to masks
+    """Converts a rotated bounding box to a boolean mask
 
     Args:
         box: rotated bounding box of shape (5,) in format (x, y, w, h, alpha)
@@ -268,7 +268,7 @@ def _rbox_to_mask(box: np.ndarray, shape: Tuple[int, int]) -> np.ndarray:
 
 
 def rbox_to_mask(boxes: np.ndarray, shape: Tuple[int, int]) -> np.ndarray:
-    """Convert boxes to masks
+    """Converts rotated bounding boxes to boolean masks
 
     Args:
         boxes: rotated bounding boxes of shape (N, 5) in format (x, y, w, h, alpha)
@@ -505,7 +505,7 @@ class OCRMetric:
         # Compute IoU
         if pred_boxes.shape[0] > 0:
             if self.rotated_bbox:
-                iou_mat = rbox_iou(gts, preds, self.mask_shape, self.use_broadcasting)
+                iou_mat = rbox_iou(gt_boxes, pred_boxes, self.mask_shape, self.use_broadcasting)
             else:
                 iou_mat = box_iou(gt_boxes, pred_boxes)
 
@@ -635,7 +635,7 @@ class DetectionMetric:
         # Compute IoU
         if pred_boxes.shape[0] > 0:
             if self.rotated_bbox:
-                iou_mat = rbox_iou(gts, preds, self.mask_shape, self.use_broadcasting)
+                iou_mat = rbox_iou(gt_boxes, pred_boxes, self.mask_shape, self.use_broadcasting)
             else:
                 iou_mat = box_iou(gt_boxes, pred_boxes)
 

--- a/tests/common/test_utils_metrics.py
+++ b/tests/common/test_utils_metrics.py
@@ -68,6 +68,10 @@ def test_mask_iou(mask1, mask2, iou, abs_tol):
     if iou_mat.size > 0:
         assert abs(iou_mat - iou) <= abs_tol
 
+    # No broadcasting
+    iou_matbis = metrics.mask_iou(np.asarray(mask1), np.asarray(mask2), use_broadcasting=False)
+    assert np.all(iou_mat == iou_matbis)
+
     with pytest.raises(AssertionError):
         metrics.mask_iou(np.zeros((2, 3, 5), dtype=bool), np.ones((3, 2, 5), dtype=bool))
 

--- a/tests/common/test_utils_metrics.py
+++ b/tests/common/test_utils_metrics.py
@@ -68,12 +68,37 @@ def test_mask_iou(mask1, mask2, iou, abs_tol):
     if iou_mat.size > 0:
         assert abs(iou_mat - iou) <= abs_tol
 
-    # No broadcasting
-    iou_matbis = metrics.mask_iou(np.asarray(mask1), np.asarray(mask2), use_broadcasting=False)
-    assert np.all(iou_mat == iou_matbis)
-
+    # Incompatible spatial shapes
     with pytest.raises(AssertionError):
         metrics.mask_iou(np.zeros((2, 3, 5), dtype=bool), np.ones((3, 2, 5), dtype=bool))
+
+
+@pytest.mark.parametrize(
+    "rbox1, rbox2, iou, abs_tol",
+    [
+        [[[.25, .25, .5, .5, 0.]], [[.25, .25, .5, .5, 0.]], 1, 0],  # Perfect match
+        [[[.25, .25, .5, .5, 0.]], [[.75, .75, .5, .5, 0.]], 0, 1e-4],  # No match
+        [[[.5, .5, 1, 1, 0.]], [[.75, .75, .5, .5, 0.]], 0.25, 0],  # Partial match
+        [[[.4, .4, .4, .4, 0.]], [[.6, .6, .4, .4, 0.]], 4 / 28, 5e-3],  # Partial match
+        [[[.05, .05, .1, .1, 0.]], [[.95, .95, .1, .1, 0.]], 0, 0],  # Boxes far from each other
+        [np.zeros((0, 5)), [[.25, .25, .5, .5, 0.]], 0, 0],  # Zero-sized inputs
+        [[[.25, .25, .5, .5, 0.]], np.zeros((0, 5)), 0, 0],  # Zero-sized inputs
+    ],
+)
+def test_rbox_iou(rbox1, rbox2, iou, abs_tol):
+    mask_shape = (256, 256)
+    iou_mat = metrics.rbox_iou(np.asarray(rbox1), np.asarray(rbox2), mask_shape)
+    assert iou_mat.shape == (len(rbox1), len(rbox2))
+    if iou_mat.size > 0:
+        assert abs(iou_mat - iou) <= abs_tol
+
+    # Ensure broadcasting doesn't change the result
+    iou_matbis = metrics.rbox_iou(np.asarray(rbox1), np.asarray(rbox2), mask_shape, use_broadcasting=False)
+    assert np.all((iou_mat - iou_matbis) <= 1e-7)
+
+    # Incorrect boxes
+    with pytest.raises(AssertionError):
+        metrics.rbox_iou(np.zeros((2, 5), dtype=float), np.ones((3, 4), dtype=float), mask_shape)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces the following modifications:
- adds `rbox_iou` function to compute IoU between sets of rotated bounding boxes
- replace iou computation in task metrics with `rbox_iou` while adding a `use_broadcasting` boolean flag
- adds missing constructor arg description in docstrings
- fixes typos in multiple docstrings

Any feedback is welcome!