### PR TITLE
fix: box angle rectification according to the quadrant

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -132,6 +132,37 @@ class DBPostProcessor(DetectionPostProcessor):
                 x, y, w, h = x / width, y / height, w / width, h / height
                 boxes.append([x, y, w, h, alpha, score])
 
+        # Compute median angle and mean aspect ratio to resolve quadrants
+        median_angle = np.median(np.float32(boxes)[:, -2])
+        mean_w = np.mean(np.float32(boxes)[:, 2])
+        mean_h = np.mean(np.float32(boxes)[:, 3])
+
+        # Rectify angles
+        new_boxes = []
+        for box in boxes:
+            [x, y, w, h, alpha, score] = box
+            if mean_h >= mean_w:
+                # We are in the upper quadrant
+                if  .5 < h / w < 2:
+                    # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
+                    new_boxes.append([x, y, h, w, 90 + median_angle, score])
+                elif abs(90 - abs(alpha) - abs(median_angle)) <= 5:
+                    # We jumped to the next quadrant, rectify
+                    new_boxes.append([x, y, w, h, alpha, score])
+                else:
+                    new_boxes.append([x, y, h, w, 90 + alpha, score])
+            else:
+                # We are in the lower quadrant.
+                if  .5 < h / w < 2:
+                    # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
+                    new_boxes.append([x, y, w, h, median_angle, score])
+                elif abs(90 - abs(alpha) - abs(median_angle)) <= 5:
+                    # We jumped to the next quadrant, rectify
+                    new_boxes.append([x, y, h, w, 90 + alpha, score])
+                else: 
+                    new_boxes.append([x, y, w, h, alpha, score])
+        boxes = new_boxes
+
         if not self.assume_straight_pages:
             if len(boxes) == 0:
                 return np.zeros((0, 6), dtype=pred.dtype)

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -82,6 +82,8 @@ class DBPostProcessor(DetectionPostProcessor):
         self,
         pred: np.ndarray,
         bitmap: np.ndarray,
+        angle_tol: float = 5.,
+        ratio_tol: float = 2.,
     ) -> np.ndarray:
         """Compute boxes from a bitmap/pred_map
 
@@ -143,23 +145,23 @@ class DBPostProcessor(DetectionPostProcessor):
             [x, y, w, h, alpha, score] = box
             if mean_h >= mean_w:
                 # We are in the upper quadrant
-                if  .5 < h / w < 2:
+                if 1 / ratio_tol < h / w < ratio_tol:
                     # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
                     new_boxes.append([x, y, h, w, 90 + median_angle, score])
-                elif abs(90 - abs(alpha) - abs(median_angle)) <= 5:
+                elif abs(90 - abs(alpha) - abs(median_angle)) <= angle_tol:
                     # We jumped to the next quadrant, rectify
                     new_boxes.append([x, y, w, h, alpha, score])
                 else:
                     new_boxes.append([x, y, h, w, 90 + alpha, score])
             else:
                 # We are in the lower quadrant.
-                if  .5 < h / w < 2:
+                if 1 / ratio_tol < h / w < ratio_tol:
                     # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
                     new_boxes.append([x, y, w, h, median_angle, score])
-                elif abs(90 - abs(alpha) - abs(median_angle)) <= 5:
+                elif abs(90 - abs(alpha) - abs(median_angle)) <= angle_tol:
                     # We jumped to the next quadrant, rectify
                     new_boxes.append([x, y, h, w, 90 + alpha, score])
-                else: 
+                else:
                     new_boxes.append([x, y, w, h, alpha, score])
         boxes = new_boxes
 

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -147,23 +147,23 @@ class DBPostProcessor(DetectionPostProcessor):
                     # We are in the upper quadrant
                     if 1 / ratio_tol < h / w < ratio_tol:
                         # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
-                        _box = [x, y, h, w, 90 + median_angle, score]
+                        _rbox = [x, y, h, w, 90 + median_angle, score]
                     elif abs(90 - abs(alpha) - abs(median_angle)) <= angle_tol:
                         # We jumped to the next quadrant, rectify
-                        _box = [x, y, w, h, alpha, score]
+                        _rbox = [x, y, w, h, alpha, score]
                     else:
-                        _box = [x, y, h, w, 90 + alpha, score]
+                        _rbox = [x, y, h, w, 90 + alpha, score]
                 else:
                     # We are in the lower quadrant.
                     if 1 / ratio_tol < h / w < ratio_tol:
                         # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
-                        _box = [x, y, w, h, median_angle, score]
+                        _rbox = [x, y, w, h, median_angle, score]
                     elif abs(90 - abs(alpha) - abs(median_angle)) <= angle_tol:
                         # We jumped to the next quadrant, rectify
-                        _box = [x, y, h, w, 90 + alpha, score]
+                        _rbox = [x, y, h, w, 90 + alpha, score]
                     else:
-                        _box = [x, y, w, h, alpha, score]
-                new_boxes.append(_box)
+                        _rbox = [x, y, w, h, alpha, score]
+                new_boxes.append(_rbox)
             boxes = new_boxes
 
         if not self.assume_straight_pages:

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -138,12 +138,12 @@ class DBPostProcessor(DetectionPostProcessor):
             # Compute median angle and mean aspect ratio to resolve quadrants
             np_boxes = np.asarray(boxes, dtype=np.float32)
             median_angle = np.median(np_boxes[:, -2])
-            mean_w, mean_h = np_boxes[:, 2].mean(), np_boxes[:, 3].mean()
+            median_w, median_h = np.median(np_boxes[:, 2]), np.median(np_boxes[:, 3])
 
             # Rectify angles
             new_boxes = []
             for x, y, w, h, alpha, score in boxes:
-                if mean_h >= mean_w:
+                if median_h >= median_w:
                     # We are in the upper quadrant
                     if 1 / ratio_tol < h / w < ratio_tol:
                         # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -136,34 +136,34 @@ class DBPostProcessor(DetectionPostProcessor):
 
         if not self.assume_straight_pages:
             # Compute median angle and mean aspect ratio to resolve quadrants
-            median_angle = np.median(np.float32(boxes)[:, -2])
-            mean_w = np.mean(np.float32(boxes)[:, 2])
-            mean_h = np.mean(np.float32(boxes)[:, 3])
+            np_boxes = np.asarray(boxes, dtype=np.float32)
+            median_angle = np.median(np_boxes[:, -2])
+            mean_w, mean_h = np_boxes[:, 2].mean(), np_boxes[:, 3].mean()
 
             # Rectify angles
             new_boxes = []
-            for box in boxes:
-                [x, y, w, h, alpha, score] = box
+            for x, y, w, h, alpha, score in boxes:
                 if mean_h >= mean_w:
                     # We are in the upper quadrant
                     if 1 / ratio_tol < h / w < ratio_tol:
                         # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
-                        new_boxes.append([x, y, h, w, 90 + median_angle, score])
+                        _box = [x, y, h, w, 90 + median_angle, score]
                     elif abs(90 - abs(alpha) - abs(median_angle)) <= angle_tol:
                         # We jumped to the next quadrant, rectify
-                        new_boxes.append([x, y, w, h, alpha, score])
+                        _box = [x, y, w, h, alpha, score]
                     else:
-                        new_boxes.append([x, y, h, w, 90 + alpha, score])
+                        _box = [x, y, h, w, 90 + alpha, score]
                 else:
                     # We are in the lower quadrant.
                     if 1 / ratio_tol < h / w < ratio_tol:
                         # If a box has an aspect ratio close to 1 (cubic), we set the angle to the median angle
-                        new_boxes.append([x, y, w, h, median_angle, score])
+                        _box = [x, y, w, h, median_angle, score]
                     elif abs(90 - abs(alpha) - abs(median_angle)) <= angle_tol:
                         # We jumped to the next quadrant, rectify
-                        new_boxes.append([x, y, h, w, 90 + alpha, score])
+                        _box = [x, y, h, w, 90 + alpha, score]
                     else:
-                        new_boxes.append([x, y, w, h, alpha, score])
+                        _box = [x, y, w, h, alpha, score]
+                new_boxes.append(_box)
             boxes = new_boxes
 
         if not self.assume_straight_pages:


### PR DESCRIPTION
This PR provides an heuristic to determine the quadrant of the document (only 2 quadrants are allowed, +90 and -90 with respect to the horizontal). The quadrant is determined with the median aspect ratio of cv2 min area rect, and then we can rectify boxes knowing the quadrant.
This is not a long-term fix, we should add a classifier to resolve the angle of each box perfectly, but for the moment I couldn't find anything else to fix this issue.

Any feedback is welcome!