### PR TITLE
fix: Fixed LinkNet target & loss computation

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -110,7 +110,7 @@ class DBPostProcessor(DetectionPostProcessor):
             else:
                 score = self.box_score(pred, contour, assume_straight_pages=False)
 
-            if self.box_thresh > score:   # remove polygons with a weak objectness
+            if score < self.box_thresh:   # remove polygons with a weak objectness
                 continue
 
             if self.assume_straight_pages:

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -108,7 +108,7 @@ class _LinkNet(BaseModel):
     def compute_target(
         self,
         target: List[np.ndarray],
-        output_shape: Tuple[int, int, int],
+        output_shape: Tuple[int, int],
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
 
         if any(t.dtype != np.float32 for t in target):
@@ -116,13 +116,16 @@ class _LinkNet(BaseModel):
         if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for t in target):
             raise ValueError("the 'boxes' entry of the target is expected to take values between 0 & 1.")
 
-        if self.assume_straight_pages:
-            seg_target = np.zeros(output_shape, dtype=bool)
-            edge_mask = np.zeros(output_shape, dtype=bool)
-        else:
-            seg_target = np.zeros(output_shape, dtype=np.uint8)
+        h, w = output_shape
+        target_shape = (len(target), h, w, 1)
 
-        seg_mask = np.ones(output_shape, dtype=bool)
+        if self.assume_straight_pages:
+            seg_target = np.zeros(target_shape, dtype=bool)
+            edge_mask = np.zeros(target_shape, dtype=bool)
+        else:
+            seg_target = np.zeros(target_shape, dtype=np.uint8)
+
+        seg_mask = np.ones(target_shape, dtype=bool)
 
         for idx, _target in enumerate(target):
             # Draw each polygon on gt
@@ -132,8 +135,8 @@ class _LinkNet(BaseModel):
 
             # Absolute bounding boxes
             abs_boxes = _target.copy()
-            abs_boxes[:, [0, 2]] *= output_shape[-1]
-            abs_boxes[:, [1, 3]] *= output_shape[-2]
+            abs_boxes[:, [0, 2]] *= w
+            abs_boxes[:, [1, 3]] *= h
             abs_boxes = abs_boxes.round().astype(np.int32)
 
             if abs_boxes.shape[1] == 5:
@@ -155,11 +158,13 @@ class _LinkNet(BaseModel):
                     cv2.fillPoly(seg_target[idx], [poly.astype(np.int32)], 1)
                 else:
                     seg_target[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = True
-                    # fill the 2 vertical edges
-                    edge_mask[idx, max(0, box[1] - 1): min(box[1] + 1, box[3]), box[0]: box[2] + 1] = True
-                    edge_mask[idx, max(box[1] + 1, box[3]): min(output_shape[1], box[3] + 2), box[0]: box[2] + 1] = True
-                    # fill the 2 horizontal edges
-                    edge_mask[idx, box[1]: box[3] + 1, max(0, box[0] - 1): min(box[0] + 1, box[2])] = True
-                    edge_mask[idx, box[1]: box[3] + 1, max(box[0] + 1, box[2]): min(output_shape[2], box[2] + 2)] = True
+                    # top edge
+                    edge_mask[idx, box[1], box[0]: min(box[2] + 1, w)] = True
+                    # bot edge
+                    edge_mask[idx, min(box[3], h - 1), box[0]: min(box[2] + 1, w)] = True
+                    # left edge
+                    edge_mask[idx, box[1]: min(box[3] + 1, h), box[0]] = True
+                    # right edge
+                    edge_mask[idx, box[1]: min(box[3] + 1, h), min(box[2], w - 1)] = True
 
         return seg_target, seg_mask, edge_mask

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -71,7 +71,7 @@ class LinkNetPostProcessor(DetectionPostProcessor):
             else:
                 score = self.box_score(pred, contour, assume_straight_pages=False)
 
-            if self.box_thresh > score:   # remove polygons with a weak objectness
+            if score < self.box_thresh:   # remove polygons with a weak objectness
                 continue
 
             if self.assume_straight_pages:

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -10,6 +10,7 @@ from typing import List, Tuple
 import cv2
 import numpy as np
 
+from doctr.file_utils import is_tf_available
 from doctr.models.core import BaseModel
 from doctr.utils.geometry import fit_rbbox, rbbox_to_polygon
 
@@ -166,5 +167,11 @@ class _LinkNet(BaseModel):
                     edge_mask[idx, box[1]: min(box[3] + 1, h), box[0]] = True
                     # right edge
                     edge_mask[idx, box[1]: min(box[3] + 1, h), min(box[2], w - 1)] = True
+
+        # Don't forget to switch back to channel first if PyTorch is used
+        if not is_tf_available():
+            seg_target = seg_target.transpose(0, 3, 1, 2)
+            seg_mask = seg_mask.transpose(0, 3, 1, 2)
+            edge_mask = edge_mask.transpose(0, 3, 1, 2)
 
         return seg_target, seg_mask, edge_mask

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -166,7 +166,6 @@ class LinkNet(nn.Module, _LinkNet):
         target: Optional[List[np.ndarray]] = None,
         return_model_output: bool = False,
         return_boxes: bool = False,
-        focal_loss: bool = True,
         **kwargs: Any,
     ) -> Dict[str, Any]:
 
@@ -185,7 +184,7 @@ class LinkNet(nn.Module, _LinkNet):
             out["preds"] = self.postprocessor(prob_map.squeeze(1).detach().cpu().numpy())
 
         if target is not None:
-            loss = self.compute_loss(logits, target, focal_loss)
+            loss = self.compute_loss(logits, target)
             out['loss'] = loss
 
         return out
@@ -194,53 +193,34 @@ class LinkNet(nn.Module, _LinkNet):
         self,
         out_map: torch.Tensor,
         target: List[np.ndarray],
-        focal_loss: bool = False,
-        alpha: float = .5,
-        gamma: float = 2.,
         edge_factor: float = 2.,
     ) -> torch.Tensor:
         """Compute linknet loss, BCE with boosted box edges or focal loss. Focal loss implementation based on
         <https://github.com/tensorflow/addons/>`_.
 
         Args:
-            out_map: output feature map of the model of shape N x H x W x 1
+            out_map: output feature map of the model of shape (N, 1, H, W)
             target: list of dictionary where each dict has a `boxes` and a `flags` entry
-            focal_loss: if True, use focal loss instead of BCE
             edge_factor: boost factor for box edges (in case of BCE)
-            alpha: balancing factor in the focal loss formula
-            gamma: modulating factor in the focal loss formula
 
         Returns:
             A loss tensor
         """
-        targets = self.compute_target(target, out_map.shape)  # type: ignore[arg-type]
+        targets = self.compute_target(target, out_map.shape[-2:])  # type: ignore[arg-type]
 
         seg_target, seg_mask = torch.from_numpy(targets[0]).to(dtype=out_map.dtype), torch.from_numpy(targets[1])
         seg_target, seg_mask = seg_target.to(out_map.device), seg_mask.to(out_map.device)
-        edge_mask = torch.from_numpy(targets[2]).to(out_map.device)
+        if edge_factor > 0:
+            edge_mask = torch.from_numpy(targets[2]).to(dtype=out_map.dtype, device=out_map.device)
 
         # Get the cross_entropy for each entry
-        bce = F.binary_cross_entropy_with_logits(out_map, seg_target, reduction='none')[seg_mask]
+        loss = F.binary_cross_entropy_with_logits(out_map, seg_target, reduction='none')
 
-        if focal_loss:
-            if gamma and gamma < 0:
-                raise ValueError("Value of gamma should be greater than or equal to zero.")
-
-            # Convert logits to prob, compute gamma factor
-            pred_prob = torch.sigmoid(out_map)[seg_mask]
-            p_t = (seg_target[seg_mask] * pred_prob) + ((1 - seg_target[seg_mask]) * (1 - pred_prob))
-
-            # Compute alpha factor
-            alpha_factor = seg_target[seg_mask] * alpha + (1 - seg_target[seg_mask]) * (1 - alpha)
-
-            # compute the final loss
-            loss = (alpha_factor * (1. - p_t) ** gamma * bce).mean()
-
-        else:
-            # Compute BCE loss with highlighted edges
-            loss = ((1 + (edge_factor - 1) * edge_mask) * bce).mean()
-
-        return loss
+        # Compute BCE loss with highlighted edges
+        if edge_factor > 0:
+            loss = ((1 + (edge_factor - 1) * edge_mask) * loss)
+        # Only consider contributions overlaping the mask
+        return loss[seg_mask].mean()
 
 
 def _linknet(arch: str, pretrained: bool, pretrained_backbone: bool = False, **kwargs: Any) -> LinkNet:

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -139,9 +139,6 @@ class LinkNet(_LinkNet, keras.Model):
         self,
         out_map: tf.Tensor,
         target: List[np.ndarray],
-        focal_loss: bool = False,
-        alpha: float = .5,
-        gamma: float = 2.,
         edge_factor: float = 2.,
     ) -> tf.Tensor:
         """Compute linknet loss, BCE with boosted box edges or focal loss. Focal loss implementation based on
@@ -150,49 +147,28 @@ class LinkNet(_LinkNet, keras.Model):
         Args:
             out_map: output feature map of the model of shape N x H x W x 1
             target: list of dictionary where each dict has a `boxes` and a `flags` entry
-            focal_loss: if True, use focal loss instead of BCE
             edge_factor: boost factor for box edges (in case of BCE)
-            alpha: balancing factor in the focal loss formula
-            gammma: modulating factor in the focal loss formula
 
         Returns:
             A loss tensor
         """
-        seg_target, seg_mask, edge_mask = self.compute_target(target, out_map.shape[:3])
+        seg_target, seg_mask, edge_mask = self.compute_target(target, out_map.shape[1:3])
         seg_target = tf.convert_to_tensor(seg_target, dtype=out_map.dtype)
-        edge_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
         seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
+        if edge_factor > 0:
+            edge_mask = tf.convert_to_tensor(edge_mask, dtype=tf.bool)
 
         # Get the cross_entropy for each entry
-        bce = tf.keras.losses.binary_crossentropy(
-            seg_target[seg_mask],
-            tf.squeeze(out_map, axis=[-1])[seg_mask],
-            from_logits=True)
+        loss = tf.keras.losses.binary_crossentropy(seg_target, out_map, from_logits=True)[..., None]
 
-        if focal_loss:
-            if gamma and gamma < 0:
-                raise ValueError("Value of gamma should be greater than or equal to zero.")
-
-            # Convert logits to prob, compute gamma factor
-            pred_prob = tf.sigmoid(tf.squeeze(out_map, axis=[-1])[seg_mask])
-            p_t = (seg_target[seg_mask] * pred_prob) + ((1 - seg_target[seg_mask]) * (1 - pred_prob))
-            modulating_factor = tf.pow((1.0 - p_t), gamma)
-
-            # Compute alpha factor
-            alpha_factor = seg_target[seg_mask] * alpha + (1 - seg_target[seg_mask]) * (1 - alpha)
-
-            # compute the final loss
-            loss = tf.reduce_mean(alpha_factor * modulating_factor * bce)
-
-        else:
-            # Compute BCE loss with highlighted edges
+        # Compute BCE loss with highlighted edges
+        if edge_factor > 0:
             loss = tf.math.multiply(
                 1 + (edge_factor - 1) * tf.cast(edge_mask, out_map.dtype),
-                bce
+                loss
             )
-            loss = tf.reduce_mean(loss)
 
-        return loss
+        return tf.reduce_mean(loss[seg_mask])
 
     def call(
         self,
@@ -200,7 +176,6 @@ class LinkNet(_LinkNet, keras.Model):
         target: Optional[List[np.ndarray]] = None,
         return_model_output: bool = False,
         return_boxes: bool = False,
-        focal_loss: bool = True,
         **kwargs: Any,
     ) -> Dict[str, Any]:
 
@@ -219,7 +194,7 @@ class LinkNet(_LinkNet, keras.Model):
             out["preds"] = self.postprocessor(tf.squeeze(prob_map, axis=-1).numpy())
 
         if target is not None:
-            loss = self.compute_loss(logits, target, focal_loss)
+            loss = self.compute_loss(logits, target)
             out['loss'] = loss
 
         return out


### PR DESCRIPTION
This PR introduces the following modifications:
- fixed `edge_mask` building
- fixed `seg_target` for PyTorch (was built as channels last)
- removes focal_loss option in LinkNet loss computation

Any feedback is welcome!