### PR TITLE
fix: pymupdf version

### DIFF
--- a/requirements-pt.txt
+++ b/requirements-pt.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.0
 scipy>=1.4.0
 opencv-python>=3.4.5.20
-PyMuPDF>=1.16.0,<=1.18.15
+PyMuPDF>=1.18.13,<=1.18.15
 pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0,<3.4.3

--- a/requirements-pt.txt
+++ b/requirements-pt.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.0
 scipy>=1.4.0
 opencv-python>=3.4.5.20
-PyMuPDF>=1.18.13,<=1.18.15
+PyMuPDF>=1.16.0,!=1.18.11,!=1.18.12
 pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0,<3.4.3

--- a/requirements-pt.txt
+++ b/requirements-pt.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.0
 scipy>=1.4.0
 opencv-python>=3.4.5.20
-PyMuPDF>=1.16.0,<1.18.11
+PyMuPDF>=1.16.0,<=1.18.15
 pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0,<3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.0
 scipy>=1.4.0
 opencv-python>=3.4.5.20
-PyMuPDF>=1.16.0,<=1.18.15
+PyMuPDF>=1.18.13,<=1.18.15
 pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0,<3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.0
 scipy>=1.4.0
 opencv-python>=3.4.5.20
-PyMuPDF>=1.18.13,<=1.18.15
+PyMuPDF>=1.16.0,!=1.18.11,!=1.18.12
 pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0,<3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.0
 scipy>=1.4.0
 opencv-python>=3.4.5.20
-PyMuPDF>=1.16.0,<1.18.11
+PyMuPDF>=1.16.0,<=1.18.15
 pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0,<3.4.3

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _deps = [
     "scipy>=1.4.0",
     "opencv-python>=3.4.5.20",
     "tensorflow>=2.4.0",
-    "PyMuPDF>=1.18.13,<=1.18.15",
+    "PyMuPDF>=1.18.13,<=1.18.15",  # under 1.18.13 #222 fails, and we need 1.18.15 for in-house lib
     "pyclipper>=1.2.0",
     "shapely>=1.6.0",
     "matplotlib>=3.1.0,<3.4.3",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _deps = [
     "scipy>=1.4.0",
     "opencv-python>=3.4.5.20",
     "tensorflow>=2.4.0",
-    "PyMuPDF>=1.16.0,<=1.18.15",
+    "PyMuPDF>=1.18.13,<=1.18.15",
     "pyclipper>=1.2.0",
     "shapely>=1.6.0",
     "matplotlib>=3.1.0,<3.4.3",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _deps = [
     "scipy>=1.4.0",
     "opencv-python>=3.4.5.20",
     "tensorflow>=2.4.0",
-    "PyMuPDF>=1.16.0,<1.18.11",
+    "PyMuPDF>=1.16.0,<=1.18.15",
     "pyclipper>=1.2.0",
     "shapely>=1.6.0",
     "matplotlib>=3.1.0,<3.4.3",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _deps = [
     "scipy>=1.4.0",
     "opencv-python>=3.4.5.20",
     "tensorflow>=2.4.0",
-    "PyMuPDF>=1.18.13,<=1.18.15",  # under 1.18.13 #222 fails, and we need 1.18.15 for in-house lib
+    "PyMuPDF>=1.16.0,!=1.18.11,!=1.18.12",  # 18.11 and 18.12 fail (issue #222)
     "pyclipper>=1.2.0",
     "shapely>=1.6.0",
     "matplotlib>=3.1.0,<3.4.3",


### PR DESCRIPTION
This PR allows the PyMuPDF version to be 1.18.15 for in-house compatibility issues.

Any feedback is welcome! 