### PR TITLE
fix: Fixed param override of backbone

### DIFF
--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -151,7 +151,10 @@ class DBNet(_DBNet, nn.Module):
 
         self.postprocessor = DBPostProcessor(assume_straight_pages=assume_straight_pages)
 
-        for m in self.modules():
+        for n, m in self.named_modules():
+            # Don't override the initialization of the backbone
+            if n.startswith('feat_extractor.'):
+                continue
             if isinstance(m, (nn.Conv2d, DeformConv2d)):
                 nn.init.kaiming_normal_(m.weight.data, mode='fan_out', nonlinearity='relu')
                 if m.bias is not None:

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -151,7 +151,10 @@ class LinkNet(nn.Module, _LinkNet):
 
         self.postprocessor = LinkNetPostProcessor(assume_straight_pages=assume_straight_pages)
 
-        for m in self.modules():
+        for n, m in self.named_modules():
+            # Don't override the initialization of the backbone
+            if n.startswith('feat_extractor.'):
+                continue
             if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):
                 nn.init.kaiming_normal_(m.weight.data, mode='fan_out', nonlinearity='relu')
                 if m.bias is not None:

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -136,7 +136,10 @@ class CRNN(RecognitionModel, nn.Module):
 
         self.postprocessor = CTCPostProcessor(vocab=vocab)
 
-        for m in self.modules():
+        for n, m in self.named_modules():
+            # Don't override the initialization of the backbone
+            if n.startswith('feat_extractor.'):
+                continue
             if isinstance(m, nn.Conv2d):
                 nn.init.kaiming_normal_(m.weight.data, mode='fan_out', nonlinearity='relu')
                 if m.bias is not None:

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -205,7 +205,10 @@ class MASTER(_MASTER, nn.Module):
 
         self.postprocessor = MASTERPostProcessor(vocab=self.vocab)
 
-        for m in self.modules():
+        for n, m in self.named_modules():
+            # Don't override the initialization of the backbone
+            if n.startswith('feat_extractor.'):
+                continue
             if isinstance(m, nn.Conv2d):
                 nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
             elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):


### PR DESCRIPTION
This PR fixes the initialization when the feature extractor already has defined param values. Before this PR, those values were overridden with a param initialization, and this PR prevents this (for `pretrained_backbone=True` to work correctly).

cf. #591 

Any feedback is welcome!