### PR TITLE
fix: Fixed deprecation warnings from numpy & PyMuPDF

### DIFF
--- a/doctr/datasets/doc_artefacts.py
+++ b/doctr/datasets/doc_artefacts.py
@@ -63,7 +63,7 @@ class DocArtefacts(VisionDataset):
                 raise FileNotFoundError(f"unable to locate {os.path.join(tmp_root, img_name)}")
 
             boxes = np.asarray([obj['geometry'] for obj in label], dtype=np_dtype)
-            classes = np.asarray([self.CLASSES.index(obj['label']) for obj in label], dtype=np.long)
+            classes = np.asarray([self.CLASSES.index(obj['label']) for obj in label], dtype=np.int64)
             if rotated_bbox:
                 # box_targets: xmin, ymin, xmax, ymax -> x, y, w, h, alpha = 0
                 boxes = np.stack((

--- a/doctr/io/pdf.py
+++ b/doctr/io/pdf.py
@@ -74,7 +74,7 @@ def convert_page_to_numpy(
     transform_matrix = fitz.Matrix(*scales)
 
     # Generate the pixel map using the transformation matrix
-    pixmap = page.getPixmap(matrix=transform_matrix)
+    pixmap = page.get_pixmap(matrix=transform_matrix)
     # Decode it into a numpy
     img = np.frombuffer(pixmap.samples, dtype=np.uint8).reshape(pixmap.height, pixmap.width, 3)
 

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -33,7 +33,7 @@ def extract_crops(img: np.ndarray, boxes: np.ndarray, channels_last: bool = True
     # Project relative coordinates
     _boxes = boxes.copy()
     h, w = img.shape[:2] if channels_last else img.shape[-2:]
-    if _boxes.dtype != np.int:
+    if _boxes.dtype != int:
         _boxes[:, [0, 2]] *= w
         _boxes[:, [1, 3]] *= h
         _boxes = _boxes.round().astype(int)

--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -253,11 +253,11 @@ def _rbox_to_mask(box: np.ndarray, shape: Tuple[int, int]) -> np.ndarray:
 
     mask = np.zeros(shape, dtype=np.uint8)
     # Get absolute coords
-    if box.dtype != np.int:
+    if box.dtype != int:
         abs_box = box.copy()
         abs_box[[0, 2]] = abs_box[[0, 2]] * shape[1]
         abs_box[[1, 3]] = abs_box[[1, 3]] * shape[0]
-        abs_box = abs_box.round().astype(np.int)
+        abs_box = abs_box.round().astype(int)
     else:
         abs_box = box
         abs_box[2:] = abs_box[2:] + 1

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -53,7 +53,7 @@ def test_extract_rcrops(mock_pdf):  # noqa: F811
                            int((idx / num_crops + .1) * doc_img.shape[0]),
                            int(.1 * doc_img.shape[1]),
                            int(.1 * doc_img.shape[0]), 0]
-                          for idx in range(num_crops)], dtype=np.int)
+                          for idx in range(num_crops)], dtype=int)
 
     with pytest.raises(AssertionError):
         extract_rcrops(doc_img, np.zeros((1, 8)))


### PR DESCRIPTION
This PR fixes the multiple deprecation warnings from PyMuPDF & numpy by using the recommended replacement.

Any feedback is welcome!