### PR TITLE
fix: Added safeguard for extreme aspect ratio in Resize

### DIFF
--- a/doctr/transforms/modules/pytorch.py
+++ b/doctr/transforms/modules/pytorch.py
@@ -34,9 +34,9 @@ class Resize(T.Resize):
         else:
             # Resize
             if actual_ratio > target_ratio:
-                tmp_size = (self.size[0], int(self.size[0] / actual_ratio))
+                tmp_size = (self.size[0], max(int(self.size[0] / actual_ratio), 1))
             else:
-                tmp_size = (int(self.size[1] * actual_ratio), self.size[1])
+                tmp_size = (max(int(self.size[1] * actual_ratio), 1), self.size[1])
 
             # Scale image
             img = F.resize(img, tmp_size, self.interpolation)


### PR DESCRIPTION
This PR fixes the second part of the unittest failures: now that we're positive no crop is 0-sized, in rare cases, preserving the aspect ratio can lead to a 0-sized intermediate image size. 

This should not be encountered for trained models but this PR adds a clipping to 1 pixel in case this happens!

Any feedback is welcome! 