### PR TITLE
fix: Fixed build_target for detection models with rotated targets

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -319,11 +319,12 @@ class _DBNet:
             abs_boxes[:, [1, 3]] *= output_shape[-2]
             abs_boxes = abs_boxes.round().astype(np.int32)
 
+            # Convert to polygons --> (N, 4, 2)
             if abs_boxes.shape[1] == 5:
                 boxes_size = np.minimum(abs_boxes[:, 2], abs_boxes[:, 3])
                 polys = np.stack([
                     rbbox_to_polygon(tuple(rbbox)) for rbbox in abs_boxes  # type: ignore[arg-type]
-                ], axis=1)
+                ], axis=0)
             else:
                 boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
                 polys = np.stack([

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -176,11 +176,12 @@ class _LinkNet(BaseModel):
             abs_boxes[:, [1, 3]] *= h
             abs_boxes = abs_boxes.round().astype(np.int32)
 
+            # Convert to polygons --> (N, 4, 2)
             if abs_boxes.shape[1] == 5:
                 boxes_size = np.minimum(abs_boxes[:, 2], abs_boxes[:, 3])
                 polys = np.stack([
                     rbbox_to_polygon(tuple(rbbox)) for rbbox in abs_boxes  # type: ignore[arg-type]
-                ], axis=1)
+                ], axis=0)
             else:
                 boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
                 polys = [None] * abs_boxes.shape[0]  # Unused

--- a/tests/pytorch/test_models_detection_pt.py
+++ b/tests/pytorch/test_models_detection_pt.py
@@ -10,10 +10,10 @@ from doctr.models.detection.predictor import DetectionPredictor
 @pytest.mark.parametrize(
     "arch_name, input_shape, output_size, out_prob",
     [
-        ["db_resnet34", (3, 1024, 1024), (1, 1024, 1024), True],
-        ["db_resnet50", (3, 1024, 1024), (1, 1024, 1024), True],
-        ["db_mobilenet_v3_large", (3, 1024, 1024), (1, 1024, 1024), True],
-        ["linknet16", (3, 1024, 1024), (1, 1024, 1024), False],
+        ["db_resnet34", (3, 512, 512), (1, 512, 512), True],
+        ["db_resnet50", (3, 512, 512), (1, 512, 512), True],
+        ["db_mobilenet_v3_large", (3, 512, 512), (1, 512, 512), True],
+        ["linknet16", (3, 512, 512), (1, 512, 512), False],
     ],
 )
 def test_detection_models(arch_name, input_shape, output_size, out_prob):
@@ -22,8 +22,8 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     assert isinstance(model, torch.nn.Module)
     input_tensor = torch.rand((batch_size, *input_shape))
     target = [
-        np.array([[.5, .5, 1, 1], [0.5, 0.5, .8, .8]], dtype=np.float32),
-        np.array([[.5, .5, 1, 1], [0.5, 0.5, .8, .9]], dtype=np.float32),
+        np.array([[.5, .5, 1, 1], [.5, .5, .8, .8]], dtype=np.float32),
+        np.array([[.5, .5, 1, 1], [.5, .5, .8, .9]], dtype=np.float32),
     ]
     if torch.cuda.is_available():
         model.cuda()

--- a/tests/pytorch/test_models_detection_pt.py
+++ b/tests/pytorch/test_models_detection_pt.py
@@ -43,12 +43,13 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
         assert np.all(boxes[:, :4] >= 0) and np.all(boxes[:, :4] <= 1)
     # Check loss
     assert isinstance(out['loss'], torch.Tensor)
-    # Check the rotated case
+    # Check the rotated case (same targets)
     target = [
         np.array([[.75, .75, .5, .5, 0], [.65, .65, .3, .3, 0]], dtype=np.float32),
         np.array([[.75, .75, .5, .5, 0], [.65, .7, .3, .4, 0]], dtype=np.float32),
     ]
-    assert isinstance(model(input_tensor, target)['loss'], torch.Tensor)
+    loss = model(input_tensor, target)['loss']
+    assert isinstance(loss, torch.Tensor) and ((loss - out['loss']).abs() / loss).item() < 5e-2
 
 
 @pytest.mark.parametrize(

--- a/tests/pytorch/test_models_detection_pt.py
+++ b/tests/pytorch/test_models_detection_pt.py
@@ -43,6 +43,12 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
         assert np.all(boxes[:, :4] >= 0) and np.all(boxes[:, :4] <= 1)
     # Check loss
     assert isinstance(out['loss'], torch.Tensor)
+    # Check the rotated case
+    target = [
+        np.array([[.75, .75, .5, .5, 0], [.65, .65, .3, .3, 0]], dtype=np.float32),
+        np.array([[.75, .75, .5, .5, 0], [.65, .7, .3, .4, 0]], dtype=np.float32),
+    ]
+    assert isinstance(model(input_tensor, target)['loss'], torch.Tensor)
 
 
 @pytest.mark.parametrize(

--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -59,6 +59,13 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     with pytest.raises(ValueError):
         out = model(input_tensor, target, training=True)
 
+    # Check the rotated case
+    target = [
+        np.array([[.75, .75, .5, .5, 0], [.65, .65, .3, .3, 0]], dtype=np.float32),
+        np.array([[.75, .75, .5, .5, 0], [.65, .7, .3, .4, 0]], dtype=np.float32),
+    ]
+    assert isinstance(model(input_tensor, target, training=True)['loss'], tf.Tensor)
+
 
 @pytest.fixture(scope="session")
 def test_detectionpredictor(mock_pdf):  # noqa: F811

--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -19,7 +19,7 @@ from doctr.models.preprocessor import PreProcessor
 )
 def test_detection_models(arch_name, input_shape, output_size, out_prob):
     batch_size = 2
-    model = detection.__dict__[arch_name](pretrained=True)
+    model = detection.__dict__[arch_name](pretrained=True, input_shape=input_shape)
     assert isinstance(model, tf.keras.Model)
     input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
     target = [
@@ -64,7 +64,8 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
         np.array([[.75, .75, .5, .5, 0], [.65, .65, .3, .3, 0]], dtype=np.float32),
         np.array([[.75, .75, .5, .5, 0], [.65, .7, .3, .4, 0]], dtype=np.float32),
     ]
-    assert isinstance(model(input_tensor, target, training=True)['loss'], tf.Tensor)
+    loss = model(input_tensor, target, training=True)['loss']
+    assert isinstance(loss, tf.Tensor) and ((loss - out['loss']) / loss).numpy() < 1e-1
 
 
 @pytest.fixture(scope="session")

--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -12,9 +12,9 @@ from doctr.models.preprocessor import PreProcessor
 @pytest.mark.parametrize(
     "arch_name, input_shape, output_size, out_prob",
     [
-        ["db_resnet50", (1024, 1024, 3), (1024, 1024, 1), True],
-        ["db_mobilenet_v3_large", (1024, 1024, 3), (1024, 1024, 1), True],
-        ["linknet16", (1024, 1024, 3), (1024, 1024, 1), False],
+        ["db_resnet50", (512, 512, 3), (512, 512, 1), True],
+        ["db_mobilenet_v3_large", (512, 512, 3), (512, 512, 1), True],
+        ["linknet16", (512, 512, 3), (512, 512, 1), False],
     ],
 )
 def test_detection_models(arch_name, input_shape, output_size, out_prob):


### PR DESCRIPTION
This PR introduces the following modifications:
- fixes the `build_target` polygon conversion for LinkNet & DBNet when rotated targets are used
- adds a test case for rotated targets
- reduces the input size in unittest from 1024 to 512 to speed up the test & ease the RAM

Any feedback is welcome!