### PR TITLE
fix: Fixed geometry utils for polygon <--> rbox conversions

### DIFF
--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -22,12 +22,15 @@ def bbox_to_polygon(bbox: BoundingBox) -> Polygon4P:
 
 def rbbox_to_polygon(rbbox: RotatedBbox) -> Polygon4P:
     (x, y, w, h, alpha) = rbbox
-    return cv2.boxPoints(((float(x), float(y)), (float(w), float(h)), float(alpha)))
+    return cv2.boxPoints(((float(x), float(y)), (float(w), float(h)), -float(alpha)))
 
 
 def fit_rbbox(pts: np.ndarray) -> RotatedBbox:
     ((x, y), (w, h), alpha) = cv2.minAreaRect(pts)
-    return x, y, w, h, alpha
+    if abs(alpha) > 45:
+        alpha = (90 - alpha) if alpha > 0 else alpha - 90
+        w, h = h, w
+    return x, y, w, h, -alpha
 
 
 def polygon_to_bbox(polygon: Polygon4P) -> BoundingBox:

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -27,10 +27,7 @@ def rbbox_to_polygon(rbbox: RotatedBbox) -> Polygon4P:
 
 def fit_rbbox(pts: np.ndarray) -> RotatedBbox:
     ((x, y), (w, h), alpha) = cv2.minAreaRect(pts)
-    if abs(alpha) > 45:
-        alpha = (90 - alpha) if alpha > 0 else alpha - 90
-        w, h = h, w
-    return x, y, w, h, -alpha
+    return x, y, h, w, 90 - alpha
 
 
 def polygon_to_bbox(polygon: Polygon4P) -> BoundingBox:

--- a/tests/common/test_utils_geometry.py
+++ b/tests/common/test_utils_geometry.py
@@ -22,15 +22,19 @@ def test_resolve_enclosing_bbox():
 
 
 def test_rbbox_to_polygon():
+    # Non-rotated
     assert (
         geometry.rbbox_to_polygon((.1, .1, .2, .2, 0)) == np.array([[0, .2], [0, 0], [.2, 0], [.2, .2]], np.float32)
     ).all()
+    # Rotate by 90° a non-squared rectangle
+    poly = geometry.rbbox_to_polygon((100, 100, 40, 10, 90))
+    assert (poly == np.array([[105, 120], [95, 120], [95, 80], [105, 80]])).all()
 
 
 def test_polygon_to_rbbox():
-    pred = geometry.polygon_to_rbbox([[.2, 0], [0, 0], [0, .2], [.2, .2]])[:4]
-    target = (.1, .1, .2, .2)
-    assert all(abs(i - j) <= 1e-7 for (i, j) in zip(pred, target))
+    pred = geometry.polygon_to_rbbox([[105, 120], [95, 120], [95, 80], [105, 80]])
+    # Accept both possibilities
+    assert (pred == (100, 100, 10, 40, 0)) or (pred == (100, 100, 40, 10, 90))
 
 
 def test_resolve_enclosing_rbbox():


### PR DESCRIPTION
This PR introduces the following modifications:
- fixes the cv2 conventions of angle orientation for polygon <--> rbox conversions
- updates unittests

The following snippet:
```python
import numpy as np
import matplotlib.pyplot as plt
from doctr.utils.geometry import rbbox_to_polygon

def plot_points(points):
    img = np.zeros((200, 150))
    for point in points.round().astype(int):
        img[point[1], point[0]] = 1
    plt.imshow(img); plt.show()


# Horizontal word rotated counter-clockwise by 45°
plot_points(rbbox_to_polygon((100, 100, 40, 10, 45.)))
```
was producing
![before_rot](https://user-images.githubusercontent.com/76527547/145620226-a4e3731a-b568-4cae-95e5-4ee2d956b678.png)


and now produces
![now_rot](https://user-images.githubusercontent.com/76527547/145620075-1cd39065-7952-4d66-9966-31047e2c512c.png)

Additionally this snippet:
```python
import numpy as np
import matplotlib.pyplot as plt
from doctr.utils.geometry import rbbox_to_polygon, fit_rbbox

angles = np.arange(-90, 91)
rboxes = [fit_rbbox(rbbox_to_polygon((100, 100, 40, 10, angle)))for angle in angles]
estimated_angles = [rbox[-1] for rbox in rboxes]
estimated_width = [rbox[2] for rbox in rboxes]

plt.plot(angles, estimated_angles, label="angles")
plt.plot(angles, estimated_width, label="width")
plt.xlabel("Anti-clockwise rotation")
plt.legend(loc="upper left")
plt.show()
```
used to yield:

![before](https://user-images.githubusercontent.com/76527547/145623514-adb23398-2683-4b5b-9dc7-0a23d18c48d0.png)


and now yields (similar to before, we can't do more because of cv2):
![now](https://user-images.githubusercontent.com/76527547/145624483-8ba987f3-7d7f-4c7a-8482-429f2e78b5b0.png)

Any feedback is welcome!