### PR TITLE
fix: box computing when assume straight pages is false

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -44,7 +44,7 @@ class DBPostProcessor(DetectionPostProcessor):
             bin_thresh,
             assume_straight_pages
         )
-        self.unclip_ratio = 1.5 if assume_straight_pages else 2.2
+        self.unclip_ratio = 1.5
 
     def polygon_to_box(
         self,
@@ -58,8 +58,18 @@ class DBPostProcessor(DetectionPostProcessor):
         Returns:
             a box in absolute coordinates (xmin, ymin, xmax, ymax) or (x, y, w, h, alpha)
         """
-        poly = Polygon(points)
-        distance = poly.area * self.unclip_ratio / poly.length  # compute distance to expand polygon
+        if not self.assume_straight_pages:
+            # Compute the rectangle polygon enclosing the raw polygon
+            rect = cv2.minAreaRect(points)
+            points = cv2.boxPoints(rect)
+            # Add 1 pixel to correct cv2 approx
+            area = (rect[1][0] + 1) * (1 + rect[1][1])
+            length = 2 * (rect[1][0] + rect[1][1]) + 2
+        else:
+            poly = Polygon(points)
+            area = poly.area
+            length = poly.length
+        distance = area * self.unclip_ratio / length  # compute distance to expand polygon
         offset = pyclipper.PyclipperOffset()
         offset.AddPath(points, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
         _points = offset.Execute(distance)

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -27,7 +27,7 @@ def rbbox_to_polygon(rbbox: RotatedBbox) -> Polygon4P:
 
 def fit_rbbox(pts: np.ndarray) -> RotatedBbox:
     ((x, y), (w, h), alpha) = cv2.minAreaRect(pts)
-    return x, y, h, w, 90 - alpha
+    return x, y, h, w, 90 + alpha
 
 
 def polygon_to_bbox(polygon: Polygon4P) -> BoundingBox:

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -100,7 +100,7 @@ def polygon_patch(
     # Switch to absolute coords
     x, w = x * width, w * width
     y, h = y * height, h * height
-    points = cv2.boxPoints(((x, y), (w, h), -a))
+    points = cv2.boxPoints(((x, y), (w, h), a))
 
     return patches.Polygon(
         points,

--- a/tests/common/test_utils_geometry.py
+++ b/tests/common/test_utils_geometry.py
@@ -34,7 +34,7 @@ def test_rbbox_to_polygon():
 def test_polygon_to_rbbox():
     pred = geometry.polygon_to_rbbox([[105, 120], [95, 120], [95, 80], [105, 80]])
     # Accept both possibilities
-    assert (pred == (100, 100, 10, 40, 0)) or (pred == (100, 100, 40, 10, 90))
+    assert (pred == (100, 100, 10, 40, 180)) or (pred == (100, 100, 40, 10, 90))
 
 
 def test_resolve_enclosing_rbbox():


### PR DESCRIPTION
This PR fixes the following:

- angle computation in visualization.py
- angle computation in fit_rbbox
- Polygon expansion for rbbox: before this PR, we computed the area & perimeter of the polygon for the Vatti clipping algorithm from the raw polygon, now we compute it from the rotated rectangle which is more accurate and allow us to match the boxes when we have assume_straight_pages = False and assume_straight_pages = True.

before:
![ex5](https://user-images.githubusercontent.com/70526046/146210347-949e02ee-3e70-4f16-833f-19194f66e7b5.png)

now:
 
![ex3](https://user-images.githubusercontent.com/70526046/146212207-2cf23cfb-f671-42dc-a146-90cc8bbfa16c.png)

