### PR TITLE
test: Fixed TF loss unittest

### DIFF
--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -65,7 +65,7 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
         np.array([[.75, .75, .5, .5, 0], [.65, .7, .3, .4, 0]], dtype=np.float32),
     ]
     loss = model(input_tensor, target, training=True)['loss']
-    assert isinstance(loss, tf.Tensor) and ((loss - out['loss']) / loss).numpy() < 1e-1
+    assert isinstance(loss, tf.Tensor) and ((loss - out['loss']) / loss).numpy() < 2e-1
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This PR fixes the tolerance threshold for the loss difference between straight & rotated bboxes

Any feedback is welcome!