### PR TITLE
fix: Fixed computation of Mean IoU

### DIFF
--- a/doctr/utils/metrics.py
+++ b/doctr/utils/metrics.py
@@ -405,7 +405,7 @@ class LocalizationConfusion:
                 iou_mat = rbox_iou(gts, preds, self.mask_shape, self.use_broadcasting)
             else:
                 iou_mat = box_iou(gts, preds)
-            self.tot_iou += float(iou_mat.max(axis=1).sum())
+            self.tot_iou += float(iou_mat.max(axis=0).sum())
 
             # Assign pairs
             gt_indices, pred_indices = linear_sum_assignment(-iou_mat)
@@ -524,7 +524,7 @@ class OCRMetric:
             else:
                 iou_mat = box_iou(gt_boxes, pred_boxes)
 
-            self.tot_iou += float(iou_mat.max(axis=1).sum())
+            self.tot_iou += float(iou_mat.max(axis=0).sum())
 
             # Assign pairs
             gt_indices, pred_indices = linear_sum_assignment(-iou_mat)
@@ -662,7 +662,7 @@ class DetectionMetric:
             else:
                 iou_mat = box_iou(gt_boxes, pred_boxes)
 
-            self.tot_iou += float(iou_mat.max(axis=1).sum())
+            self.tot_iou += float(iou_mat.max(axis=0).sum())
 
             # Assign pairs
             gt_indices, pred_indices = linear_sum_assignment(-iou_mat)

--- a/tests/common/test_utils_metrics.py
+++ b/tests/common/test_utils_metrics.py
@@ -120,8 +120,8 @@ def test_rbox_to_mask(box, shape, mask):
     "gts, preds, iou_thresh, recall, precision, mean_iou",
     [
         [[[[0, 0, .5, .5]]], [[[0, 0, .5, .5]]], 0.5, 1, 1, 1],  # Perfect match
-        [[[[0, 0, 1, 1]]], [[[0, 0, .5, .5], [.6, .6, .7, .7]]], 0.2, 1, 0.5, 0.125],  # Bad match
-        [[[[0, 0, 1, 1]]], [[[0, 0, .5, .5], [.6, .6, .7, .7]]], 0.5, 0, 0, 0.125],  # Bad match
+        [[[[0, 0, 1, 1]]], [[[0, 0, .5, .5], [.6, .6, .7, .7]]], 0.2, 1, 0.5, 0.13],  # Bad match
+        [[[[0, 0, 1, 1]]], [[[0, 0, .5, .5], [.6, .6, .7, .7]]], 0.5, 0, 0, 0.13],  # Bad match
         [[[[0, 0, .5, .5]], [[0, 0, .5, .5]]], [[[0, 0, .5, .5]], None], 0.5, 0.5, 1, 1],  # No preds on 2nd sample
     ],
 )
@@ -179,7 +179,7 @@ def test_r_localization_confusion(gts, preds, iou_thresh, recall, precision, mea
             0.2,
             {"raw": 0, "caseless": 0, "unidecode": 1, "unicase": 1},
             {"raw": 0, "caseless": 0, "unidecode": .5, "unicase": .5},
-            0.125,
+            0.13,
         ],
         [  # No preds on 2nd sample
             [[[0, 0, .5, .5]], [[0, 0, .5, .5]]], [["Elephant"], ["elephant"]],


### PR DESCRIPTION
This PR introduces the following modifications:
- updates the expected mean IoU value in unittests
- fixes the computation of `tot_iou` in metrics which is used for Mean IoU: it was taking the max IoU across all preds for a given GT, while it's supposed to take the max IoU across all GTs for a given pred.

Any feedback is welcome!