### PR TITLE
test: Switch to a fully mocked PDF for unittests

### DIFF
--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -221,9 +221,9 @@ def rectify_loc_preds(
     so that the points are in this order: top L, top R, bot R, bot L if the crop is readable
     """
     return np.stack(
-        [page_loc_pred if orientation == 0 else np.roll(
-            page_loc_pred,
-            orientation,
-            axis=0) for orientation, page_loc_pred in zip(orientations, page_loc_preds)],
+        [
+            page_loc_pred if orientation == 0 else np.roll(page_loc_pred, orientation, axis=0)
+            for orientation, page_loc_pred in zip(orientations, page_loc_preds)
+        ],
         axis=0
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 from io import BytesIO
 
+import fitz
 import hdf5storage
 import numpy as np
 import pytest
@@ -17,17 +18,20 @@ def mock_vocab():
 
 
 @pytest.fixture(scope="session")
-def mock_pdf_stream():
-    url = 'https://arxiv.org/pdf/1911.08947.pdf'
-    return requests.get(url).content
+def mock_pdf(tmpdir_factory):
 
+    doc = fitz.open()
 
-@pytest.fixture(scope="session")
-def mock_pdf(mock_pdf_stream, tmpdir_factory):
-    file = BytesIO(mock_pdf_stream)
+    page = doc.newPage()
+    page.insertText(fitz.Point(50, 100), "I am a jedi!", fontsize=50)
+    page = doc.newPage()
+    page.insertText(fitz.Point(50, 100), "No, I am your father.", fontsize=50)
+
+    # Save the PDF
     fn = tmpdir_factory.mktemp("data").join("mock_pdf_file.pdf")
     with open(fn, 'wb') as f:
-        f.write(file.getbuffer())
+        doc.save(f)
+
     return str(fn)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,9 @@ def mock_pdf(tmpdir_factory):
     doc = fitz.open()
 
     page = doc.newPage()
-    page.insertText(fitz.Point(50, 100), "I am a jedi!", fontsize=50)
+    page.insertText(fitz.Point(50, 100), "I am a jedi!", fontsize=20)
     page = doc.newPage()
-    page.insertText(fitz.Point(50, 100), "No, I am your father.", fontsize=50)
+    page.insertText(fitz.Point(50, 100), "No, I am your father.", fontsize=20)
 
     # Save the PDF
     fn = tmpdir_factory.mktemp("data").join("mock_pdf_file.pdf")

--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -79,8 +79,8 @@ def test_detectionpredictor(mock_pdf):  # noqa: F811
 
     pages = DocumentFile.from_pdf(mock_pdf).as_images()
     out = predictor(pages)
-    # The input PDF has 8 pages
-    assert len(out) == 8
+    # The input PDF has 2 pages
+    assert len(out) == 2
 
     # Dimension check
     with pytest.raises(ValueError):
@@ -102,8 +102,8 @@ def test_rotated_detectionpredictor(mock_pdf):  # noqa: F811
     pages = DocumentFile.from_pdf(mock_pdf).as_images()
     out = predictor(pages)
 
-    # The input PDF has 8 pages
-    assert len(out) == 8
+    # The input PDF has 2 pages
+    assert len(out) == 2
 
     # Dimension check
     with pytest.raises(ValueError):

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -22,10 +22,15 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
     det_bsize = 4
     det_predictor = DetectionPredictor(
         PreProcessor(output_size=(512, 512), batch_size=det_bsize),
-        detection.db_mobilenet_v3_large(pretrained=False, pretrained_backbone=False, input_shape=(512, 512, 3))
+        detection.db_mobilenet_v3_large(
+            pretrained=False,
+            pretrained_backbone=False,
+            input_shape=(512, 512, 3),
+            assume_straight_pages=assume_straight_pages,
+        )
     )
 
-    reco_bsize = 32
+    reco_bsize = 16
     reco_predictor = RecognitionPredictor(
         PreProcessor(output_size=(32, 128), batch_size=reco_bsize, preserve_aspect_ratio=True),
         recognition.crnn_vgg16_bn(pretrained=False, pretrained_backbone=False, vocab=mock_vocab)


### PR DESCRIPTION
This PR introduces the following modifications:
- seeing that CI takes sometimes a long time to download the initial PDF, this PR mocks it completely to avoid data transfer
- updates impacted unittests

This speeds up the unittests of models and avoids CI failure when the URL is unreachable.

Any feedback is welcome!