### PR TITLE
refactor: Unified return_preds flags across all tasks

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -79,7 +79,7 @@ def main():
 
                 # Forward the image to the model
                 processed_batches = predictor.det_predictor.pre_processor([doc[page_idx]])
-                out = predictor.det_predictor.model(processed_batches[0], return_model_output=True)
+                out = predictor.det_predictor.model(processed_batches[0], return_preds=True)
                 seg_map = out["out_map"]
                 seg_map = tf.squeeze(seg_map[0, ...], axis=[2])
                 seg_map = cv2.resize(seg_map.numpy(), (doc[page_idx].shape[1], doc[page_idx].shape[0]),

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -168,7 +168,7 @@ class DBNet(_DBNet, nn.Module):
         x: torch.Tensor,
         target: Optional[List[np.ndarray]] = None,
         return_model_output: bool = False,
-        return_boxes: bool = False,
+        return_preds: bool = False,
     ) -> Dict[str, torch.Tensor]:
         # Extract feature maps at different stages
         feats = self.feat_extractor(x)
@@ -178,13 +178,13 @@ class DBNet(_DBNet, nn.Module):
         logits = self.prob_head(feat_concat)
 
         out: Dict[str, Any] = {}
-        if return_model_output or target is None or return_boxes:
+        if return_model_output or target is None or return_preds:
             prob_map = torch.sigmoid(logits)
 
         if return_model_output:
             out["out_map"] = prob_map
 
-        if target is None or return_boxes:
+        if target is None or return_preds:
             # Post-process boxes (keep only text predictions)
             out["preds"] = [
                 preds[0] for preds in self.postprocessor(prob_map.detach().cpu().permute((0, 2, 3, 1)).numpy())

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -223,7 +223,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         x: tf.Tensor,
         target: Optional[List[np.ndarray]] = None,
         return_model_output: bool = False,
-        return_boxes: bool = False,
+        return_preds: bool = False,
         **kwargs: Any,
     ) -> Dict[str, Any]:
 
@@ -232,13 +232,13 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         logits = self.probability_head(feat_concat, **kwargs)
 
         out: Dict[str, tf.Tensor] = {}
-        if return_model_output or target is None or return_boxes:
+        if return_model_output or target is None or return_preds:
             prob_map = tf.math.sigmoid(logits)
 
         if return_model_output:
             out["out_map"] = prob_map
 
-        if target is None or return_boxes:
+        if target is None or return_preds:
             # Post-process boxes (keep only text predictions)
             out["preds"] = [preds[0] for preds in self.postprocessor(prob_map.numpy())]
 

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -133,7 +133,7 @@ class LinkNet(nn.Module, _LinkNet):
         x: torch.Tensor,
         target: Optional[List[np.ndarray]] = None,
         return_model_output: bool = False,
-        return_boxes: bool = False,
+        return_preds: bool = False,
         **kwargs: Any,
     ) -> Dict[str, Any]:
 
@@ -142,12 +142,12 @@ class LinkNet(nn.Module, _LinkNet):
         logits = self.classifier(logits)
 
         out: Dict[str, Any] = {}
-        if return_model_output or target is None or return_boxes:
+        if return_model_output or target is None or return_preds:
             prob_map = torch.sigmoid(logits)
         if return_model_output:
             out["out_map"] = prob_map
 
-        if target is None or return_boxes:
+        if target is None or return_preds:
             # Post-process boxes
             out["preds"] = [
                 preds[0] for preds in self.postprocessor(prob_map.detach().cpu().permute((0, 2, 3, 1)).numpy())

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -176,7 +176,7 @@ class LinkNet(_LinkNet, keras.Model):
         x: tf.Tensor,
         target: Optional[List[np.ndarray]] = None,
         return_model_output: bool = False,
-        return_boxes: bool = False,
+        return_preds: bool = False,
     ) -> Dict[str, Any]:
 
         logits = self.stem(x)
@@ -184,12 +184,12 @@ class LinkNet(_LinkNet, keras.Model):
         logits = self.classifier(logits)
 
         out: Dict[str, tf.Tensor] = {}
-        if return_model_output or target is None or return_boxes:
+        if return_model_output or target is None or return_preds:
             prob_map = tf.math.sigmoid(logits)
         if return_model_output:
             out["out_map"] = prob_map
 
-        if target is None or return_boxes:
+        if target is None or return_preds:
             # Post-process boxes
             out["preds"] = [preds[0] for preds in self.postprocessor(prob_map.numpy())]
 

--- a/doctr/models/detection/predictor/pytorch.py
+++ b/doctr/models/detection/predictor/pytorch.py
@@ -45,7 +45,7 @@ class DetectionPredictor(nn.Module):
 
         processed_batches = self.pre_processor(pages)
         predicted_batches = [
-            self.model(batch, return_boxes=True, **kwargs)['preds']  # type:ignore[operator]
+            self.model(batch, return_preds=True, **kwargs)['preds']  # type:ignore[operator]
             for batch in processed_batches
         ]
         return [pred for batch in predicted_batches for pred in batch]

--- a/doctr/models/detection/predictor/tensorflow.py
+++ b/doctr/models/detection/predictor/tensorflow.py
@@ -46,7 +46,7 @@ class DetectionPredictor(NestedObject):
 
         processed_batches = self.pre_processor(pages)
         predicted_batches = [
-            self.model(batch, return_boxes=True, training=False, **kwargs)['preds']  # type:ignore[operator]
+            self.model(batch, return_preds=True, training=False, **kwargs)['preds']  # type:ignore[operator]
             for batch in processed_batches
         ]
         return [pred for batch in predicted_batches for pred in batch]

--- a/tests/pytorch/test_models_detection_pt.py
+++ b/tests/pytorch/test_models_detection_pt.py
@@ -28,7 +28,7 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     if torch.cuda.is_available():
         model.cuda()
         input_tensor = input_tensor.cuda()
-    out = model(input_tensor, target, return_model_output=True, return_boxes=True)
+    out = model(input_tensor, target, return_model_output=True, return_preds=True)
     assert isinstance(out, dict)
     assert len(out) == 3
     # Check proba map

--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -27,7 +27,7 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
         np.array([[.5, .5, 1, 1], [0.5, 0.5, .8, .9]], dtype=np.float32),
     ]
     # test training model
-    out = model(input_tensor, target, return_model_output=True, return_boxes=True, training=True)
+    out = model(input_tensor, target, return_model_output=True, return_preds=True, training=True)
     assert isinstance(out, dict)
     assert len(out) == 3
     # Check proba map


### PR DESCRIPTION
This PR introduces the following modifications:
- ensures all prediction call flags are named the same way ("return_boxes" --> "return_preds")
- reflected changes on unittests, and demo

Any feedback is welcome!