### PR TITLE
fix: Fixed the bin_thresh of LinkNet

### DIFF
--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -23,14 +23,13 @@ class LinkNetPostProcessor(DetectionPostProcessor):
     """Implements a post processor for LinkNet model.
 
     Args:
-        min_size_box: minimal length (pix) to keep a box
-        box_thresh: minimal objectness score to consider a box
         bin_thresh: threshold used to binzarized p_map at inference time
-
+        box_thresh: minimal objectness score to consider a box
+        assume_straight_pages: whether the inputs were expected to have horizontal text elements
     """
     def __init__(
         self,
-        bin_thresh: float = 0.15,
+        bin_thresh: float = 0.5,
         box_thresh: float = 0.1,
         assume_straight_pages: bool = True,
     ) -> None:


### PR DESCRIPTION
This PR simply updates the binary threshold of LinkNet which was the same as in the DBNet. But with the difference in the LinkNet loss, 0.15 is way too low. This modification gives a boost on text detection evaluation.

Any feedback is welcome!