### PR TITLE
refactor: Introduces img + target transforms in Datasets

### DIFF
--- a/doctr/datasets/classification/base.py
+++ b/doctr/datasets/classification/base.py
@@ -45,10 +45,10 @@ class _CharacterGenerator(AbstractDataset):
         vocab: str,
         num_samples: int,
         cache_samples: bool = False,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         font_family: Optional[str] = None,
     ) -> None:
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
         self.vocab = vocab
         self._num_samples = num_samples
         self.font_family = font_family

--- a/doctr/datasets/classification/base.py
+++ b/doctr/datasets/classification/base.py
@@ -46,9 +46,11 @@ class _CharacterGenerator(AbstractDataset):
         num_samples: int,
         cache_samples: bool = False,
         img_transforms: Optional[Callable[[Any], Any]] = None,
+        sample_transforms: Optional[Callable[[Any, Any], Tuple[Any, Any]]] = None,
         font_family: Optional[str] = None,
     ) -> None:
         self.img_transforms = img_transforms
+        self.sample_transforms = sample_transforms
         self.vocab = vocab
         self._num_samples = num_samples
         self.font_family = font_family

--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -6,7 +6,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 

--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -28,7 +28,6 @@ class CORD(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -41,7 +40,6 @@ class CORD(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -53,7 +51,6 @@ class CORD(VisionDataset):
         tmp_root = os.path.join(self.root, 'image')
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         self.train = train
-        self.img_transforms = img_transforms
         for img_path in os.listdir(tmp_root):
             # File existence check
             if not os.path.exists(os.path.join(tmp_root, img_path)):

--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -28,7 +28,7 @@ class CORD(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -41,7 +41,7 @@ class CORD(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -53,7 +53,7 @@ class CORD(VisionDataset):
         tmp_root = os.path.join(self.root, 'image')
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         self.train = train
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
         for img_path in os.listdir(tmp_root):
             # File existence check
             if not os.path.exists(os.path.join(tmp_root, img_path)):

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -44,10 +44,10 @@ class _AbstractDataset:
 
         # Read image
         img, target = self._read_sample(index)
-        self.sample_transforms: Optional[Callable[[Any], Any]]
-        if self.sample_transforms is not None:
+        self.img_transforms: Optional[Callable[[Any], Any]]
+        if self.img_transforms is not None:
             # typing issue cf. https://github.com/python/mypy/issues/5485
-            img = self.sample_transforms(img)  # type: ignore[call-arg]
+            img = self.img_transforms(img)  # type: ignore[call-arg]
 
         return img, target
 

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -53,7 +53,7 @@ class _AbstractDataset:
             img = self.img_transforms(img)  # type: ignore[call-arg]
 
         if self.sample_transforms is not None:
-            img, target = self.sample_transforms(img)
+            img, target = self.sample_transforms(img, target)
 
         return img, target
 

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -27,7 +27,7 @@ class DetectionDataset(AbstractDataset):
     Args:
         img_folder: folder with all the images of the dataset
         label_path: path to the annotations of each image
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
     """
 
@@ -35,11 +35,11 @@ class DetectionDataset(AbstractDataset):
         self,
         img_folder: str,
         label_path: str,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
     ) -> None:
         super().__init__(img_folder)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
 
         # File existence check
         if not os.path.exists(label_path):
@@ -70,8 +70,8 @@ class DetectionDataset(AbstractDataset):
 
         img, boxes = self._read_sample(index)
         h, w = self._get_img_shape(img)
-        if self.sample_transforms is not None:
-            img = self.sample_transforms(img)
+        if self.img_transforms is not None:
+            img = self.img_transforms(img)
 
         # Boxes
         boxes = boxes.copy()

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -27,7 +27,6 @@ class DetectionDataset(AbstractDataset):
     Args:
         img_folder: folder with all the images of the dataset
         label_path: path to the annotations of each image
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
     """
 
@@ -35,11 +34,10 @@ class DetectionDataset(AbstractDataset):
         self,
         img_folder: str,
         label_path: str,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(img_folder)
-        self.img_transforms = img_transforms
+        super().__init__(img_folder, **kwargs)
 
         # File existence check
         if not os.path.exists(label_path):
@@ -68,15 +66,18 @@ class DetectionDataset(AbstractDataset):
         index: int
     ) -> Tuple[Any, np.ndarray]:
 
-        img, boxes = self._read_sample(index)
+        img, target = self._read_sample(index)
         h, w = self._get_img_shape(img)
         if self.img_transforms is not None:
             img = self.img_transforms(img)
 
-        # Boxes
-        boxes = boxes.copy()
-        boxes[..., [0, 2]] /= w
-        boxes[..., [1, 3]] /= h
-        boxes = boxes.clip(0, 1)
+        if self.sample_transforms is not None:
+            img, target = self.sample_transforms(img, target)
 
-        return img, boxes
+        # Boxes
+        target = target.copy()
+        target[..., [0, 2]] /= w
+        target[..., [1, 3]] /= h
+        target = target.clip(0, 1)
+
+        return img, target

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -5,7 +5,7 @@
 
 import json
 import os
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 import numpy as np
 

--- a/doctr/datasets/doc_artefacts.py
+++ b/doctr/datasets/doc_artefacts.py
@@ -25,7 +25,7 @@ class DocArtefacts(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -37,14 +37,14 @@ class DocArtefacts(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, None, self.SHA256, True, **kwargs)
         self.train = train
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
 
         # Update root
         self.root = os.path.join(self.root, "train" if train else "val")

--- a/doctr/datasets/doc_artefacts.py
+++ b/doctr/datasets/doc_artefacts.py
@@ -5,7 +5,7 @@
 
 import json
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 

--- a/doctr/datasets/doc_artefacts.py
+++ b/doctr/datasets/doc_artefacts.py
@@ -25,7 +25,6 @@ class DocArtefacts(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -37,14 +36,12 @@ class DocArtefacts(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, None, self.SHA256, True, **kwargs)
         self.train = train
-        self.img_transforms = img_transforms
 
         # Update root
         self.root = os.path.join(self.root, "train" if train else "val")

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -6,7 +6,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -26,7 +26,6 @@ class FUNSD(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -38,14 +37,12 @@ class FUNSD(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, self.FILE_NAME, self.SHA256, True, **kwargs)
         self.train = train
-        self.img_transforms = img_transforms
 
         # Use the subset
         subfolder = os.path.join('dataset', 'training_data' if train else 'testing_data')

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -26,7 +26,7 @@ class FUNSD(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -38,14 +38,14 @@ class FUNSD(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, self.FILE_NAME, self.SHA256, True, **kwargs)
         self.train = train
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
 
         # Use the subset
         subfolder = os.path.join('dataset', 'training_data' if train else 'testing_data')

--- a/doctr/datasets/ic03.py
+++ b/doctr/datasets/ic03.py
@@ -25,7 +25,7 @@ class IC03(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -40,14 +40,14 @@ class IC03(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         url, sha256, file_name = self.TRAIN if train else self.TEST
         super().__init__(url, file_name, sha256, True, **kwargs)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
         self.train = train
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         np_dtype = np.float32

--- a/doctr/datasets/ic03.py
+++ b/doctr/datasets/ic03.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import defusedxml.ElementTree as ET
 import numpy as np

--- a/doctr/datasets/ic03.py
+++ b/doctr/datasets/ic03.py
@@ -25,7 +25,6 @@ class IC03(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -40,14 +39,12 @@ class IC03(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         url, sha256, file_name = self.TRAIN if train else self.TEST
         super().__init__(url, file_name, sha256, True, **kwargs)
-        self.img_transforms = img_transforms
         self.train = train
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         np_dtype = np.float32

--- a/doctr/datasets/ic13.py
+++ b/doctr/datasets/ic13.py
@@ -6,7 +6,7 @@
 import csv
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 

--- a/doctr/datasets/ic13.py
+++ b/doctr/datasets/ic13.py
@@ -29,7 +29,7 @@ class IC13(AbstractDataset):
     Args:
         img_folder: folder with all the images of the dataset
         label_folder: folder with all annotation files for the images
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
     """
 
@@ -37,11 +37,11 @@ class IC13(AbstractDataset):
         self,
         img_folder: str,
         label_folder: str,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
     ) -> None:
         super().__init__(img_folder)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
 
         # File existence check
         if not os.path.exists(label_folder) or not os.path.exists(img_folder):
@@ -78,8 +78,8 @@ class IC13(AbstractDataset):
     def __getitem__(self, index: int) -> Tuple[np.ndarray, Dict[str, Any]]:
         img, target = self._read_sample(index)
         h, w = self._get_img_shape(img)
-        if self.sample_transforms is not None:
-            img = self.sample_transforms(img)
+        if self.img_transforms is not None:
+            img = self.img_transforms(img)
 
         # Boxes
         boxes = target['boxes'].copy()

--- a/doctr/datasets/ic13.py
+++ b/doctr/datasets/ic13.py
@@ -29,7 +29,6 @@ class IC13(AbstractDataset):
     Args:
         img_folder: folder with all the images of the dataset
         label_folder: folder with all annotation files for the images
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
     """
 
@@ -37,11 +36,10 @@ class IC13(AbstractDataset):
         self,
         img_folder: str,
         label_folder: str,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(img_folder)
-        self.img_transforms = img_transforms
+        super().__init__(img_folder, **kwargs)
 
         # File existence check
         if not os.path.exists(label_folder) or not os.path.exists(img_folder):

--- a/doctr/datasets/iiit5k.py
+++ b/doctr/datasets/iiit5k.py
@@ -28,7 +28,6 @@ class IIIT5K(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -39,13 +38,11 @@ class IIIT5K(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, None, file_hash=self.SHA256, extract_archive=True, **kwargs)
-        self.img_transforms = img_transforms
         self.train = train
 
         # Load mat data

--- a/doctr/datasets/iiit5k.py
+++ b/doctr/datasets/iiit5k.py
@@ -28,7 +28,7 @@ class IIIT5K(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -39,13 +39,13 @@ class IIIT5K(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, None, file_hash=self.SHA256, extract_archive=True, **kwargs)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
         self.train = train
 
         # Load mat data

--- a/doctr/datasets/iiit5k.py
+++ b/doctr/datasets/iiit5k.py
@@ -5,7 +5,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import scipy.io as sio

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -21,17 +21,15 @@ class OCRDataset(AbstractDataset):
     Args:
         img_folder: local path to image folder (all jpg at the root)
         label_file: local path to the label file
-        img_transforms: composable transformations that will be applied to each image
     """
 
     def __init__(
         self,
         img_folder: str,
         label_file: str,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(img_folder)
-        self.img_transforms = img_transforms
+        super().__init__(img_folder, **kwargs)
 
         # List images
         self.data: List[Tuple[str, Dict[str, Any]]] = []

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -21,17 +21,17 @@ class OCRDataset(AbstractDataset):
     Args:
         img_folder: local path to image folder (all jpg at the root)
         label_file: local path to the label file
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
     """
 
     def __init__(
         self,
         img_folder: str,
         label_file: str,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
     ) -> None:
         super().__init__(img_folder)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
 
         # List images
         self.data: List[Tuple[str, Dict[str, Any]]] = []

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -6,7 +6,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -24,17 +24,15 @@ class RecognitionDataset(AbstractDataset):
     Args:
         img_folder: path to the images folder
         labels_path: pathe to the json file containing all labels (character sequences)
-        img_transforms: composable transformations that will be applied to each image
     """
 
     def __init__(
         self,
         img_folder: str,
         labels_path: str,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(img_folder)
-        self.img_transforms = (lambda x: x) if img_transforms is None else img_transforms
+        super().__init__(img_folder, **kwargs)
 
         self.data: List[Tuple[str, str]] = []
         with open(labels_path) as f:

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -24,17 +24,17 @@ class RecognitionDataset(AbstractDataset):
     Args:
         img_folder: path to the images folder
         labels_path: pathe to the json file containing all labels (character sequences)
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
     """
 
     def __init__(
         self,
         img_folder: str,
         labels_path: str,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
     ) -> None:
         super().__init__(img_folder)
-        self.sample_transforms = (lambda x: x) if sample_transforms is None else sample_transforms
+        self.img_transforms = (lambda x: x) if img_transforms is None else img_transforms
 
         self.data: List[Tuple[str, str]] = []
         with open(labels_path) as f:

--- a/doctr/datasets/recognition.py
+++ b/doctr/datasets/recognition.py
@@ -6,7 +6,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 from .datasets import AbstractDataset
 

--- a/doctr/datasets/sroie.py
+++ b/doctr/datasets/sroie.py
@@ -26,7 +26,7 @@ class SROIE(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -39,14 +39,14 @@ class SROIE(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         url, sha256 = self.TRAIN if train else self.TEST
         super().__init__(url, None, sha256, True, **kwargs)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
         self.train = train
 
         tmp_root = os.path.join(self.root, 'images')

--- a/doctr/datasets/sroie.py
+++ b/doctr/datasets/sroie.py
@@ -6,7 +6,7 @@
 import csv
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 

--- a/doctr/datasets/sroie.py
+++ b/doctr/datasets/sroie.py
@@ -26,7 +26,6 @@ class SROIE(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -39,14 +38,12 @@ class SROIE(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         url, sha256 = self.TRAIN if train else self.TEST
         super().__init__(url, None, sha256, True, **kwargs)
-        self.img_transforms = img_transforms
         self.train = train
 
         tmp_root = os.path.join(self.root, 'images')

--- a/doctr/datasets/svhn.py
+++ b/doctr/datasets/svhn.py
@@ -26,7 +26,6 @@ class SVHN(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -41,14 +40,12 @@ class SVHN(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         url, sha256, name = self.TRAIN if train else self.TEST
         super().__init__(url, file_name=name, file_hash=sha256, extract_archive=True, **kwargs)
-        self.img_transforms = img_transforms
         self.train = train
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         np_dtype = np.float32

--- a/doctr/datasets/svhn.py
+++ b/doctr/datasets/svhn.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import h5py
 import numpy as np

--- a/doctr/datasets/svhn.py
+++ b/doctr/datasets/svhn.py
@@ -26,7 +26,7 @@ class SVHN(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -41,14 +41,14 @@ class SVHN(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         url, sha256, name = self.TRAIN if train else self.TEST
         super().__init__(url, file_name=name, file_hash=sha256, extract_archive=True, **kwargs)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
         self.train = train
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         np_dtype = np.float32

--- a/doctr/datasets/svt.py
+++ b/doctr/datasets/svt.py
@@ -25,7 +25,7 @@ class SVT(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -36,13 +36,13 @@ class SVT(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, None, self.SHA256, True, **kwargs)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
         self.train = train
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         np_dtype = np.float32

--- a/doctr/datasets/svt.py
+++ b/doctr/datasets/svt.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import defusedxml.ElementTree as ET
 import numpy as np

--- a/doctr/datasets/svt.py
+++ b/doctr/datasets/svt.py
@@ -25,7 +25,6 @@ class SVT(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -36,13 +35,11 @@ class SVT(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, None, self.SHA256, True, **kwargs)
-        self.img_transforms = img_transforms
         self.train = train
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         np_dtype = np.float32

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -27,7 +27,6 @@ class SynthText(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -38,13 +37,11 @@ class SynthText(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, None, file_hash=None, extract_archive=True, **kwargs)
-        self.img_transforms = img_transforms
         self.train = train
 
         # Load mat data

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -27,7 +27,7 @@ class SynthText(VisionDataset):
 
     Args:
         train: whether the subset should be the training one
-        sample_transforms: composable transformations that will be applied to each image
+        img_transforms: composable transformations that will be applied to each image
         rotated_bbox: whether polygons should be considered as rotated bounding box (instead of straight ones)
         **kwargs: keyword arguments from `VisionDataset`.
     """
@@ -38,13 +38,13 @@ class SynthText(VisionDataset):
     def __init__(
         self,
         train: bool = True,
-        sample_transforms: Optional[Callable[[Any], Any]] = None,
+        img_transforms: Optional[Callable[[Any], Any]] = None,
         rotated_bbox: bool = False,
         **kwargs: Any,
     ) -> None:
 
         super().__init__(self.URL, None, file_hash=None, extract_archive=True, **kwargs)
-        self.sample_transforms = sample_transforms
+        self.img_transforms = img_transforms
         self.train = train
 
         # Load mat data

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import scipy.io as sio

--- a/doctr/models/predictor/base.py
+++ b/doctr/models/predictor/base.py
@@ -73,8 +73,8 @@ class _OCRPredictor:
         orientations = [self.crop_orientation_predictor(page_crops) for page_crops in crops]
         rect_crops = [rectify_crops(page_crops, orientation) for page_crops, orientation in zip(crops, orientations)]
         rect_loc_preds = [
-            rectify_loc_preds(page_loc_preds, orientation) for page_loc_preds, orientation
-            in zip(loc_preds, orientations)
+            rectify_loc_preds(page_loc_preds, orientation) if len(page_loc_preds) > 0 else page_loc_preds
+            for page_loc_preds, orientation in zip(loc_preds, orientations)
         ]
         return rect_crops, rect_loc_preds
 

--- a/references/classification/train_pytorch.py
+++ b/references/classification/train_pytorch.py
@@ -191,7 +191,7 @@ def main(args):
         vocab=vocab,
         num_samples=args.val_samples * len(vocab),
         cache_samples=True,
-        sample_transforms=T.Resize((args.input_size, args.input_size)),
+        img_transforms=T.Resize((args.input_size, args.input_size)),
         font_family=args.font,
     )
     val_loader = DataLoader(
@@ -244,7 +244,7 @@ def main(args):
         vocab=vocab,
         num_samples=args.train_samples * len(vocab),
         cache_samples=True,
-        sample_transforms=Compose([
+        img_transforms=Compose([
             T.Resize((args.input_size, args.input_size)),
             # Augmentations
             RandomPerspective(),

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -94,7 +94,7 @@ def main(args):
         vocab=vocab,
         num_samples=args.val_samples * len(vocab),
         cache_samples=True,
-        sample_transforms=T.Resize((args.input_size, args.input_size)),
+        img_transforms=T.Resize((args.input_size, args.input_size)),
         font_family=args.font,
     )
     val_loader = DataLoader(
@@ -137,7 +137,7 @@ def main(args):
         vocab=vocab,
         num_samples=args.train_samples * len(vocab),
         cache_samples=True,
-        sample_transforms=T.Compose([
+        img_transforms=T.Compose([
             T.Resize((args.input_size, args.input_size)),
             # Augmentations
             T.RandomApply(T.ColorInversion(), .7),

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -188,7 +188,7 @@ def main(args):
     val_set = DetectionDataset(
         img_folder=os.path.join(args.val_path, 'images'),
         label_path=os.path.join(args.val_path, 'labels.json'),
-        sample_transforms=T.Resize((args.input_size, args.input_size)),
+        img_transforms=T.Resize((args.input_size, args.input_size)),
     )
     val_loader = DataLoader(
         val_set,
@@ -245,7 +245,7 @@ def main(args):
     train_set = DetectionDataset(
         img_folder=os.path.join(args.train_path, 'images'),
         label_path=os.path.join(args.train_path, 'labels.json'),
-        sample_transforms=Compose([
+        img_transforms=Compose([
             T.Resize((args.input_size, args.input_size)),
             # Augmentations
             T.RandomApply(T.ColorInversion(), .1),

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -85,7 +85,7 @@ def main(args):
     val_set = DetectionDataset(
         img_folder=os.path.join(args.val_path, 'images'),
         label_path=os.path.join(args.val_path, 'labels.json'),
-        sample_transforms=T.Resize((args.input_size, args.input_size)),
+        img_transforms=T.Resize((args.input_size, args.input_size)),
     )
     val_loader = DataLoader(
         val_set,
@@ -129,7 +129,7 @@ def main(args):
     train_set = DetectionDataset(
         img_folder=os.path.join(args.train_path, 'images'),
         label_path=os.path.join(args.train_path, 'labels.json'),
-        sample_transforms=T.Compose([
+        img_transforms=T.Compose([
             T.Resize((args.input_size, args.input_size)),
             # Augmentations
             T.RandomApply(T.ColorInversion(), .1),

--- a/references/obj_detection/train_pytorch.py
+++ b/references/obj_detection/train_pytorch.py
@@ -190,7 +190,7 @@ def main(args):
     val_set = DocArtefacts(
         train=False,
         download=True,
-        sample_transforms=T.Resize((args.input_size, args.input_size)),
+        img_transforms=T.Resize((args.input_size, args.input_size)),
     )
     val_loader = DataLoader(
         val_set,
@@ -242,7 +242,7 @@ def main(args):
     train_set = DocArtefacts(
         train=True,
         download=True,
-        sample_transforms=T.Resize((args.input_size, args.input_size)),
+        img_transforms=T.Resize((args.input_size, args.input_size)),
     )
 
     train_loader = DataLoader(

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -193,7 +193,7 @@ def main(args):
     val_set = RecognitionDataset(
         img_folder=os.path.join(args.val_path, 'images'),
         labels_path=os.path.join(args.val_path, 'labels.json'),
-        sample_transforms=T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
+        img_transforms=T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
     )
     val_loader = DataLoader(
         val_set,
@@ -254,7 +254,7 @@ def main(args):
     train_set = RecognitionDataset(
         parts[0].joinpath('images'),
         parts[0].joinpath('labels.json'),
-        sample_transforms=Compose([
+        img_transforms=Compose([
             T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
             # Augmentations
             T.RandomApply(T.ColorInversion(), .1),

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -88,7 +88,7 @@ def main(args):
     val_set = RecognitionDataset(
         img_folder=os.path.join(args.val_path, 'images'),
         labels_path=os.path.join(args.val_path, 'labels.json'),
-        sample_transforms=T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
+        img_transforms=T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
     )
     val_loader = DataLoader(
         val_set,
@@ -135,7 +135,7 @@ def main(args):
     train_set = RecognitionDataset(
         parts[0].joinpath('images'),
         parts[0].joinpath('labels.json'),
-        sample_transforms=T.Compose([
+        img_transforms=T.Compose([
             T.RandomApply(T.ColorInversion(), .1),
             T.Resize((args.input_size, 4 * args.input_size), preserve_aspect_ratio=True),
             # Augmentations

--- a/tests/common/test_datasets.py
+++ b/tests/common/test_datasets.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+import numpy as np
 import pytest
 
 from doctr import datasets
@@ -13,6 +16,29 @@ def test_visiondataset():
     assert repr(dataset) == 'VisionDataset()'
 
 
-def test_abstractdataset():
+def test_abstractdataset(mock_image_path):
+
     with pytest.raises(ValueError):
         datasets.datasets.AbstractDataset('my/fantasy/folder')
+
+    # Check transforms
+    path = Path(mock_image_path)
+    ds = datasets.datasets.AbstractDataset(path.parent)
+    # Patch some data
+    ds.data = [(path.name, 0)]
+
+    # Fetch the img
+    img, target = ds[0]
+    assert isinstance(target, int) and target == 0
+
+    # Check img_transforms
+    ds.img_transforms = lambda x: 1 - x
+    img2, target2 = ds[0]
+    assert np.all(img2.numpy() == 1 - img.numpy())
+    assert target == target2
+
+    # Check sample_transforms
+    ds.img_transforms = None
+    ds.sample_transforms = lambda x, y: (x, y + 1)
+    img3, target3 = ds[0]
+    assert np.all(img3.numpy() == img.numpy()) and (target3 == (target + 1))

--- a/tests/common/test_transforms.py
+++ b/tests/common/test_transforms.py
@@ -1,0 +1,28 @@
+from doctr.transforms import modules as T
+
+
+def test_imagetransform():
+
+    transfo = T.ImageTransform(lambda x: 1 - x)
+    assert transfo(0, 1) == (1, 1)
+
+
+def test_samplecompose():
+
+    transfos = [lambda x, y: (1 - x, y), lambda x, y: (x, 2 * y)]
+    transfo = T.SampleCompose(transfos)
+    assert transfo(0, 1) == (1, 2)
+
+
+def test_oneof():
+    transfos = [lambda x: 1 - x, lambda x: x + 10]
+    transfo = T.OneOf(transfos)
+    out = transfo(1)
+    assert out == 0 or out == 11
+
+
+def test_randomapply():
+    transfo = T.RandomApply(lambda x: 1 - x)
+    out = transfo(1)
+    assert out == 0 or out == 1
+    assert repr(transfo).endswith(", p=0.5)")

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -54,7 +54,7 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     ds = datasets.DetectionDataset(
         img_folder=mock_image_folder,
         label_path=mock_detection_label,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
     )
 
     assert len(ds) == 5
@@ -76,7 +76,7 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     rotated_ds = datasets.DetectionDataset(
         img_folder=mock_image_folder,
         label_path=mock_detection_label,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
         rotated_bbox=True
     )
     _, r_target = rotated_ds[0]
@@ -95,7 +95,7 @@ def test_recognition_dataset(mock_image_folder, mock_recognition_label):
     ds = datasets.RecognitionDataset(
         img_folder=mock_image_folder,
         labels_path=mock_recognition_label,
-        sample_transforms=Resize(input_size, preserve_aspect_ratio=True),
+        img_transforms=Resize(input_size, preserve_aspect_ratio=True),
     )
     assert len(ds) == 5
     image, label = ds[0]
@@ -123,7 +123,7 @@ def test_ocrdataset(mock_ocrdataset):
 
     ds = datasets.OCRDataset(
         *mock_ocrdataset,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
     )
 
     assert len(ds) == 3
@@ -146,7 +146,7 @@ def test_charactergenerator():
         vocab=vocab,
         num_samples=10,
         cache_samples=True,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
     )
 
     assert len(ds) == 10
@@ -175,7 +175,7 @@ def test_ic13_dataset(num_samples, rotate, mock_ic13):
     input_size = (512, 512)
     ds = datasets.IC13(
         *mock_ic13,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
         rotated_bbox=rotate,
     )
 
@@ -195,7 +195,7 @@ def test_svhn(input_size, num_samples, rotate, mock_svhn_dataset):
     datasets.SVHN.TRAIN = (mock_svhn_dataset, None, "svhn_train.tar")
 
     ds = datasets.SVHN(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_svhn_dataset.split("/")[:-2]), cache_subdir=mock_svhn_dataset.split("/")[-2],
     )
 
@@ -216,7 +216,7 @@ def test_sroie(input_size, num_samples, rotate, mock_sroie_dataset):
     datasets.SROIE.TRAIN = (mock_sroie_dataset, None)
 
     ds = datasets.SROIE(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_sroie_dataset.split("/")[:-2]), cache_subdir=mock_sroie_dataset.split("/")[-2],
     )
 
@@ -239,7 +239,7 @@ def test_funsd(input_size, num_samples, rotate, mock_funsd_dataset):
     datasets.FUNSD.FILE_NAME = "funsd.zip"
 
     ds = datasets.FUNSD(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_funsd_dataset.split("/")[:-2]), cache_subdir=mock_funsd_dataset.split("/")[-2],
     )
 
@@ -260,7 +260,7 @@ def test_cord(input_size, num_samples, rotate, mock_cord_dataset):
     datasets.CORD.TRAIN = (mock_cord_dataset, None)
 
     ds = datasets.CORD(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_cord_dataset.split("/")[:-2]), cache_subdir=mock_cord_dataset.split("/")[-2],
     )
 
@@ -282,7 +282,7 @@ def test_synthtext(input_size, num_samples, rotate, mock_synthtext_dataset):
     datasets.SynthText.SHA256 = None
 
     ds = datasets.SynthText(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_synthtext_dataset.split("/")[:-2]), cache_subdir=mock_synthtext_dataset.split("/")[-2],
     )
 
@@ -304,7 +304,7 @@ def test_artefact_detection(input_size, num_samples, rotate, mock_doc_artefacts)
     datasets.DocArtefacts.SHA256 = None
 
     ds = datasets.DocArtefacts(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_doc_artefacts.split("/")[:-2]), cache_subdir=mock_doc_artefacts.split("/")[-2],
     )
 
@@ -326,7 +326,7 @@ def test_iiit5k(input_size, num_samples, rotate, mock_iiit5k_dataset):
     datasets.IIIT5K.SHA256 = None
 
     ds = datasets.IIIT5K(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_iiit5k_dataset.split("/")[:-2]), cache_subdir=mock_iiit5k_dataset.split("/")[-2],
     )
 
@@ -348,7 +348,7 @@ def test_svt(input_size, num_samples, rotate, mock_svt_dataset):
     datasets.SVT.SHA256 = None
 
     ds = datasets.SVT(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_svt_dataset.split("/")[:-2]), cache_subdir=mock_svt_dataset.split("/")[-2],
     )
 
@@ -369,7 +369,7 @@ def test_ic03(input_size, num_samples, rotate, mock_ic03_dataset):
     datasets.IC03.TRAIN = (mock_ic03_dataset, None, "ic03_train.zip")
 
     ds = datasets.IC03(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_ic03_dataset.split("/")[:-2]), cache_subdir=mock_ic03_dataset.split("/")[-2],
     )
 

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -42,7 +42,7 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     ds = datasets.DetectionDataset(
         img_folder=mock_image_folder,
         label_path=mock_detection_label,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
     )
 
     assert len(ds) == 5
@@ -64,7 +64,7 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     rotated_ds = datasets.DetectionDataset(
         img_folder=mock_image_folder,
         label_path=mock_detection_label,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
         rotated_bbox=True
     )
     _, r_target = rotated_ds[0]
@@ -83,7 +83,7 @@ def test_recognition_dataset(mock_image_folder, mock_recognition_label):
     ds = datasets.RecognitionDataset(
         img_folder=mock_image_folder,
         labels_path=mock_recognition_label,
-        sample_transforms=Resize(input_size, preserve_aspect_ratio=True),
+        img_transforms=Resize(input_size, preserve_aspect_ratio=True),
     )
     assert len(ds) == 5
     image, label = ds[0]
@@ -111,7 +111,7 @@ def test_ocrdataset(mock_ocrdataset):
 
     ds = datasets.OCRDataset(
         *mock_ocrdataset,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
     )
     assert len(ds) == 3
     img, target = ds[0]
@@ -149,7 +149,7 @@ def test_charactergenerator():
         vocab=vocab,
         num_samples=10,
         cache_samples=True,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
     )
 
     assert len(ds) == 10
@@ -178,7 +178,7 @@ def test_ic13_dataset(mock_ic13, num_samples, rotate):
     input_size = (512, 512)
     ds = datasets.IC13(
         *mock_ic13,
-        sample_transforms=Resize(input_size),
+        img_transforms=Resize(input_size),
         rotated_bbox=rotate,
     )
 
@@ -210,7 +210,7 @@ def test_svhn(input_size, num_samples, rotate, mock_svhn_dataset):
     datasets.SVHN.TRAIN = (mock_svhn_dataset, None, "svhn_train.tar")
 
     ds = datasets.SVHN(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_svhn_dataset.split("/")[:-2]), cache_subdir=mock_svhn_dataset.split("/")[-2],
     )
 
@@ -231,7 +231,7 @@ def test_sroie(input_size, num_samples, rotate, mock_sroie_dataset):
     datasets.SROIE.TRAIN = (mock_sroie_dataset, None)
 
     ds = datasets.SROIE(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_sroie_dataset.split("/")[:-2]), cache_subdir=mock_sroie_dataset.split("/")[-2],
     )
 
@@ -254,7 +254,7 @@ def test_funsd(input_size, num_samples, rotate, mock_funsd_dataset):
     datasets.FUNSD.FILE_NAME = "funsd.zip"
 
     ds = datasets.FUNSD(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_funsd_dataset.split("/")[:-2]), cache_subdir=mock_funsd_dataset.split("/")[-2],
     )
 
@@ -275,7 +275,7 @@ def test_cord(input_size, num_samples, rotate, mock_cord_dataset):
     datasets.CORD.TRAIN = (mock_cord_dataset, None)
 
     ds = datasets.CORD(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_cord_dataset.split("/")[:-2]), cache_subdir=mock_cord_dataset.split("/")[-2],
     )
 
@@ -297,7 +297,7 @@ def test_synthtext(input_size, num_samples, rotate, mock_synthtext_dataset):
     datasets.SynthText.SHA256 = None
 
     ds = datasets.SynthText(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_synthtext_dataset.split("/")[:-2]), cache_subdir=mock_synthtext_dataset.split("/")[-2],
     )
 
@@ -319,7 +319,7 @@ def test_artefact_detection(input_size, num_samples, rotate, mock_doc_artefacts)
     datasets.DocArtefacts.SHA256 = None
 
     ds = datasets.DocArtefacts(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_doc_artefacts.split("/")[:-2]), cache_subdir=mock_doc_artefacts.split("/")[-2],
     )
 
@@ -341,7 +341,7 @@ def test_iiit5k(input_size, num_samples, rotate, mock_iiit5k_dataset):
     datasets.IIIT5K.SHA256 = None
 
     ds = datasets.IIIT5K(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_iiit5k_dataset.split("/")[:-2]), cache_subdir=mock_iiit5k_dataset.split("/")[-2],
     )
 
@@ -364,7 +364,7 @@ def test_svt(input_size, num_samples, rotate, mock_svt_dataset):
     datasets.SVT.SHA256 = None
 
     ds = datasets.SVT(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_svt_dataset.split("/")[:-2]), cache_subdir=mock_svt_dataset.split("/")[-2],
     )
 
@@ -385,7 +385,7 @@ def test_ic03(input_size, num_samples, rotate, mock_ic03_dataset):
     datasets.IC03.TRAIN = (mock_ic03_dataset, None, "ic03_train.zip")
 
     ds = datasets.IC03(
-        train=True, download=True, sample_transforms=Resize(input_size), rotated_bbox=rotate,
+        train=True, download=True, img_transforms=Resize(input_size), rotated_bbox=rotate,
         cache_dir="/".join(mock_ic03_dataset.split("/")[:-2]), cache_subdir=mock_ic03_dataset.split("/")[-2],
     )
 


### PR DESCRIPTION
Following up on #352, this PR introduces the following modifications:
- renames "sample_transforms" into "img_transforms" to be more explicit (hesitated with "input_transforms" but we only cover Vision, so I don't think it's necessary)
- adds "sample_transforms" which are performed after "img_transforms" on both the image and the target
- reflected changes in datasets, unittests and training scripts
- added `SampleCompose` (to compose sample_transforms) and `ImgTransformation` (to wrap an img_transform as a sample_transform) utils
- added dedicated unittests

With this PR, the way to pass thransforms becomes the following:
- if you only have transformations that don't modify the target, pass them as `img_transforms`
- if you have both, there are two options:
    - passing the image transformations that have to be performed before the first one to modify the target & pass the rest as `sample_transforms`:
    - passing all transformations as `sample_transforms` and when there is one that is only implemented for image, wrap it with `ImageTransform`


Any feedback is welcome!