### PR TITLE
refactor: Removed contiguous param since it's included in torch>=1.7

### DIFF
--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -60,7 +60,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[torch] --upgrade
           pip install -r references/requirements.txt
-          pip install contiguous-params
           sudo apt-get update && sudo apt-get install fonts-freefont-ttf -y
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF)
@@ -121,7 +120,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[torch] --upgrade
           pip install -r references/requirements.txt
-          pip install contiguous-params
       - name: Download and extract toy set
         run: |
           wget https://github.com/mindee/doctr/releases/download/v0.3.1/toy_recogition_set-036a4d80.zip
@@ -240,7 +238,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[torch] --upgrade
           pip install -r references/requirements.txt
-          pip install contiguous-params
       - name: Download and extract toy set
         run: |
           wget https://github.com/mindee/doctr/releases/download/v0.3.1/toy_detection_set-bbbb4243.zip

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -11,11 +11,6 @@ pip install -e . --upgrade
 pip install -r references/requirements.txt
 ```
 
-if you are using PyTorch back-end, there is an extra dependency (to optimize data loading):
-```shell
-pip install contiguous-params>=1.0.0
-```
-
 ## Usage
 
 You can start your training in TensorFlow:

--- a/references/classification/train_pytorch.py
+++ b/references/classification/train_pytorch.py
@@ -15,7 +15,6 @@ import time
 import numpy as np
 import torch
 import wandb
-from contiguous_params import ContiguousParams
 from fastprogress.fastprogress import master_bar, progress_bar
 from torch.nn.functional import cross_entropy
 from torch.optim.lr_scheduler import CosineAnnealingLR, MultiplicativeLR, OneCycleLR

--- a/references/classification/train_pytorch.py
+++ b/references/classification/train_pytorch.py
@@ -271,8 +271,7 @@ def main(args):
         return
 
     # Optimizer
-    model_params = ContiguousParams([p for p in model.parameters() if p.requires_grad]).contiguous()
-    optimizer = torch.optim.Adam(model_params, args.lr,
+    optimizer = torch.optim.Adam([p for p in model.parameters() if p.requires_grad], args.lr,
                                  betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
 
     # LR Finder

--- a/references/classification/train_pytorch.py
+++ b/references/classification/train_pytorch.py
@@ -111,10 +111,8 @@ def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, m
         scaler = torch.cuda.amp.GradScaler()
 
     model.train()
-    train_iter = iter(train_loader)
     # Iterate over the batches of the dataset
-    for _ in progress_bar(range(len(train_loader)), parent=mb):
-        images, targets = next(train_iter)
+    for images, targets in progress_bar(train_loader, parent=mb):
 
         if torch.cuda.is_available():
             images = images.cuda()
@@ -147,8 +145,7 @@ def evaluate(model, val_loader, batch_transforms, amp=False):
     model.eval()
     # Validation loop
     val_loss, correct, samples, batch_cnt = 0, 0, 0, 0
-    val_iter = iter(val_loader)
-    for images, targets in val_iter:
+    for images, targets in val_loader:
         images = batch_transforms(images)
 
         if torch.cuda.is_available():

--- a/references/detection/README.md
+++ b/references/detection/README.md
@@ -11,11 +11,6 @@ pip install -e . --upgrade
 pip install -r references/requirements.txt
 ```
 
-if you are using PyTorch back-end, there is an extra dependency (to optimize data loading):
-```shell
-pip install contiguous-params>=1.0.0
-```
-
 ## Usage
 
 You can start your training in TensorFlow:

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -16,7 +16,6 @@ import time
 import numpy as np
 import torch
 import wandb
-from contiguous_params import ContiguousParams
 from fastprogress.fastprogress import master_bar, progress_bar
 from torch.optim.lr_scheduler import CosineAnnealingLR, MultiplicativeLR, OneCycleLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
@@ -278,8 +277,7 @@ def main(args):
             p.reguires_grad_(False)
 
     # Optimizer
-    model_params = ContiguousParams([p for p in model.parameters() if p.requires_grad]).contiguous()
-    optimizer = torch.optim.Adam(model_params, args.lr,
+    optimizer = torch.optim.Adam([p for p in model.parameters() if p.requires_grad], args.lr,
                                  betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
     # LR Finder
     if args.find_lr:

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -112,9 +112,8 @@ def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, m
         scaler = torch.cuda.amp.GradScaler()
 
     model.train()
-    train_iter = iter(train_loader)
     # Iterate over the batches of the dataset
-    for images, targets in progress_bar(train_iter, parent=mb):
+    for images, targets in progress_bar(train_loader, parent=mb):
 
         if torch.cuda.is_available():
             images = images.cuda()
@@ -150,8 +149,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
     val_metric.reset()
     # Validation loop
     val_loss, batch_cnt = 0, 0
-    val_iter = iter(val_loader)
-    for images, targets in val_iter:
+    for images, targets in val_loader:
         if torch.cuda.is_available():
             images = images.cuda()
         images = batch_transforms(images)

--- a/references/obj_detection/train_pytorch.py
+++ b/references/obj_detection/train_pytorch.py
@@ -122,9 +122,8 @@ def fit_one_epoch(model, train_loader, optimizer, scheduler, mb, amp=False):
         scaler = torch.cuda.amp.GradScaler()
 
     model.train()
-    train_iter = iter(train_loader)
     # Iterate over the batches of the dataset
-    for images, targets in progress_bar(train_iter, parent=mb):
+    for images, targets in progress_bar(train_loader, parent=mb):
 
         targets = convert_to_abs_coords(targets, images.shape)
         if torch.cuda.is_available():
@@ -154,10 +153,7 @@ def fit_one_epoch(model, train_loader, optimizer, scheduler, mb, amp=False):
 def evaluate(model, val_loader, metric, amp=False):
     model.eval()
     metric.reset()
-    val_iter = iter(val_loader)
-    for images, targets in val_iter:
-
-        images, targets = next(val_iter)
+    for images, targets in val_loader:
         targets = convert_to_abs_coords(targets, images.shape)
         if torch.cuda.is_available():
             images = images.cuda()

--- a/references/recognition/README.md
+++ b/references/recognition/README.md
@@ -11,11 +11,6 @@ pip install -e . --upgrade
 pip install -r references/requirements.txt
 ```
 
-if you are using PyTorch back-end, there is an extra dependency (to optimize data loading):
-```shell
-pip install contiguous-params>=1.0.0
-```
-
 ## Usage
 
 You can start your training in TensorFlow:

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -113,9 +113,8 @@ def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, m
         scaler = torch.cuda.amp.GradScaler()
 
     model.train()
-    train_iter = iter(train_loader)
     # Iterate over the batches of the dataset
-    for images, targets in progress_bar(train_iter, parent=mb):
+    for images, targets in progress_bar(train_loader, parent=mb):
 
         if torch.cuda.is_available():
             images = images.cuda()
@@ -153,8 +152,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
     val_metric.reset()
     # Validation loop
     val_loss, batch_cnt = 0, 0
-    val_iter = iter(val_loader)
-    for images, targets in val_iter:
+    for images, targets in val_loader:
         if torch.cuda.is_available():
             images = images.cuda()
         images = batch_transforms(images)

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import numpy as np
 import torch
 import wandb
-from contiguous_params import ContiguousParams
 from fastprogress.fastprogress import master_bar, progress_bar
 from torch.optim.lr_scheduler import CosineAnnealingLR, MultiplicativeLR, OneCycleLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
@@ -285,8 +284,7 @@ def main(args):
         return
 
     # Optimizer
-    model_params = ContiguousParams([p for p in model.parameters() if p.requires_grad]).contiguous()
-    optimizer = torch.optim.Adam(model_params, args.lr,
+    optimizer = torch.optim.Adam([p for p in model.parameters() if p.requires_grad], args.lr,
                                  betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
     # LR Finder
     if args.find_lr:


### PR DESCRIPTION
This PR introduces the following modifications:
- removes the Pytorch to force params in a contiguous chunk to speed up optimization (now it's included in the core library)
- updates the CI & documentation accordingly
- removes unneeded loader operations in training scripts

Any feedback is welcome!