### PR TITLE
feat: add preserve aspect ratio to predictor and vizualisation utils

### DIFF
--- a/doctr/io/elements.py
+++ b/doctr/io/elements.py
@@ -246,15 +246,16 @@ class Page(Element):
         return f"dimensions={self.dimensions}"
 
     def show(
-        self, page: np.ndarray, interactive: bool = True, **kwargs
+        self, page: np.ndarray, interactive: bool = True, preserve_aspect_ratio: bool = False, **kwargs
     ) -> None:
         """Overlay the result on a given image
 
         Args:
             page: image encoded as a numpy array in uint8
             interactive: whether the display should be interactive
+            preserve_aspect_ratio: pass True if you passed True to the predictor
         """
-        visualize_page(self.export(), page, interactive=interactive)
+        visualize_page(self.export(), page, interactive=interactive, preserve_aspect_ratio=preserve_aspect_ratio)
         plt.show(**kwargs)
 
     def synthesize(self, **kwargs) -> np.ndarray:

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -17,6 +17,7 @@ def _predictor(
     reco_arch: str,
     pretrained: bool,
     assume_straight_pages: bool = True,
+    preserve_aspect_ratio: bool = False,
     det_bs: int = 2,
     reco_bs: int = 128,
     **kwargs,
@@ -28,6 +29,7 @@ def _predictor(
         pretrained=pretrained,
         batch_size=det_bs,
         assume_straight_pages=assume_straight_pages,
+        preserve_aspect_ratio=preserve_aspect_ratio,
     )
 
     # Recognition
@@ -47,6 +49,7 @@ def ocr_predictor(
     pretrained: bool = False,
     assume_straight_pages: bool = True,
     export_as_straight_boxes: bool = False,
+    preserve_aspect_ratio: bool = False,
     **kwargs: Any
 ) -> OCRPredictor:
     """End-to-end OCR architecture using one model for localization, and another for text recognition.
@@ -77,5 +80,6 @@ def ocr_predictor(
         pretrained,
         assume_straight_pages=assume_straight_pages,
         export_as_straight_boxes=export_as_straight_boxes,
+        preserve_aspect_ratio=preserve_aspect_ratio,
         **kwargs,
     )

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -69,6 +69,8 @@ def ocr_predictor(
             without rotated textual elements.
         export_as_straight_boxes: when assume_straight_pages is set to False, export final predictions
             (potentially rotated) as straight bounding boxes.
+        preserve_aspect_ratio: If True, pad the input document image to preserve the aspect ratio before
+            running the detection model on it.
 
     Returns:
         OCR predictor

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -29,6 +29,7 @@ def rect_patch(
     alpha: float = 0.3,
     linewidth: int = 2,
     fill: bool = True,
+    preserve_aspect_ratio: bool = False
 ) -> patches.Rectangle:
     """Create a matplotlib rectangular patch for the element
 
@@ -40,6 +41,7 @@ def rect_patch(
         alpha: opacity parameter to fill the boxes, 0 = transparent
         linewidth: line width
         fill: whether the patch should be filled
+        preserve_aspect_ratio: pass True if you passed True to the predictor
 
     Returns:
         a rectangular Patch
@@ -52,6 +54,8 @@ def rect_patch(
     height, width = page_dimensions
     (xmin, ymin), (xmax, ymax) = geometry
     # Switch to absolute coords
+    if preserve_aspect_ratio:
+        width = height = max(height, width)
     xmin, w = xmin * width, (xmax - xmin) * width
     ymin, h = ymin * height, (ymax - ymin) * height
 
@@ -75,6 +79,7 @@ def polygon_patch(
     alpha: float = 0.3,
     linewidth: int = 2,
     fill: bool = True,
+    preserve_aspect_ratio: bool = False
 ) -> patches.Polygon:
     """Create a matplotlib polygon patch for the element
 
@@ -86,6 +91,7 @@ def polygon_patch(
         alpha: opacity parameter to fill the boxes, 0 = transparent
         linewidth: line width
         fill: whether the patch should be filled
+        preserve_aspect_ratio: pass True if you passed True to the predictor
 
     Returns:
         a polygon Patch
@@ -96,8 +102,8 @@ def polygon_patch(
 
     # Unpack
     height, width = page_dimensions
-    geometry[:, 0] = geometry[:, 0] * width
-    geometry[:, 1] = geometry[:, 1] * height
+    geometry[:, 0] = geometry[:, 0] * (max(width, height) if preserve_aspect_ratio else width)
+    geometry[:, 1] = geometry[:, 1] * (max(width, height) if preserve_aspect_ratio else height)
 
     return patches.Polygon(
         geometry,


### PR DESCRIPTION
This PR allows to use the `preserve_aspect_ratio` flag in the predictor:

```
model = ocr_predictor(pretrained=True, assume_straight_pages=False, preserve_aspect_ratio=True)
doc = DocumentFile.from_images(path)
result = model(doc)
result.show(doc, preserve_aspect_ratio=True)

```

Yields:
![ar](https://user-images.githubusercontent.com/70526046/147554907-93f403ba-686b-4029-9ef2-5adc821e7776.png)

Instead of:
![withourar](https://user-images.githubusercontent.com/70526046/147554339-24f64e68-bf16-4217-9f99-1300200b8501.png)

Any feedback is welcome!
