### PR TITLE
test: Fixed TensorFlow predictor unittest

### DIFF
--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -23,7 +23,7 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
     det_predictor = DetectionPredictor(
         PreProcessor(output_size=(512, 512), batch_size=det_bsize),
         detection.db_mobilenet_v3_large(
-            pretrained=False,
+            pretrained=True,
             pretrained_backbone=False,
             input_shape=(512, 512, 3),
             assume_straight_pages=assume_straight_pages,


### PR DESCRIPTION
This PR reduces the number of crops processed in unittests by using a pretrained detection model. It changed the number of crops from several thousands to a maximum of a few dozens.

It also prevents degraded localization candidates, and will hopefully fix the ongoing issue with current PR unittests in TensorFlow.

Any feedback is welcome!