### PR TITLE
ci: Fixed CI training job for TF

### DIFF
--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -54,7 +54,7 @@ jobs:
           sudo apt-get update && sudo apt-get install fonts-freefont-ttf -y
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF)
-        run: python references/classification/train_tensorflow.py mobilenet_v3_small -b 32 --val-samples 1 --train-samples 1 --epochs 1
+        run: python references/classification/train_tensorflow.py resnet18 -b 32 --val-samples 1 --train-samples 1 --epochs 1
       - if: matrix.framework == 'pytorch'
         name: Train for a short epoch (PT)
         run: python references/classification/train_pytorch.py mobilenet_v3_small -b 32 --val-samples 1 --train-samples 1 --epochs 1


### PR DESCRIPTION
This PR simply changes the architecture to train in the CI job since mobilenet V3 has grouped convolutions for which TF does not support backprop on CPU :man_shrugging: 

Any feedback is welcome!