### PR TITLE
fix: Fixed the box cropping from RandomCrop

### DIFF
--- a/doctr/transforms/functional/base.py
+++ b/doctr/transforms/functional/base.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2021, Mindee.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+from typing import Tuple, Union
+
+import numpy as np
+
+__all__ = ["crop_boxes"]
+
+
+def crop_boxes(
+    boxes: np.ndarray,
+    crop_box: Union[Tuple[int, int, int, int], Tuple[float, float, float, float]],
+) -> np.ndarray:
+    """Crop localization boxes
+
+    Args:
+        boxes: ndarray of shape (N, 4) in relative or abs coordinates
+        crop_box: box (xmin, ymin, xmax, ymax) to crop the image, in the same coord format that the boxes
+
+    Returns:
+        the cropped boxes
+    """
+    is_box_rel = boxes.max() <= 1
+    is_crop_rel = max(crop_box) <= 1
+
+    if is_box_rel ^ is_crop_rel:
+        raise AssertionError("both the boxes and the crop need to have the same coordinate convention")
+
+    xmin, ymin, xmax, ymax = crop_box
+    # Clip boxes & correct offset
+    boxes[:, [0, 2]] = boxes[:, [0, 2]].clip(xmin, xmax) - xmin
+    boxes[:, [1, 3]] = boxes[:, [1, 3]].clip(ymin, ymax) - ymin
+    # Rescale relative coords
+    if is_box_rel:
+        boxes[:, [0, 2]] /= (xmax - xmin)
+        boxes[:, [1, 3]] /= (ymax - ymin)
+
+    # Remove 0-sized boxes
+    is_valid = np.logical_and(boxes[:, 1] < boxes[:, 3], boxes[:, 0] < boxes[:, 2])
+
+    return boxes[is_valid]

--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -11,6 +11,7 @@ import torch
 from torchvision.transforms import functional as F
 
 from doctr.utils.geometry import rotate_abs_boxes
+
 from .base import crop_boxes
 
 __all__ = ["invert_colors", "rotate", "crop_detection"]

--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -98,9 +98,7 @@ def crop_detection(
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin / w, xmax / w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin / h, ymax / h)
     # Remove 0-sized boxes
-    zero_height = boxes[:, 1] == boxes[:, 3]
-    zero_width = boxes[:, 0] == boxes[:, 2]
-    empty_boxes = np.logical_or(zero_height, zero_width)
-    boxes = boxes[~empty_boxes]
+    is_valid = np.logical_and(boxes[:, 1] < boxes[:, 3], boxes[:, 0] < boxes[:, 2])
+    boxes = boxes[is_valid]
 
     return croped_img, boxes

--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -90,13 +90,13 @@ def crop_detection(
     )
     if boxes.dtype == int:  # absolute boxes
         # Clip boxes
-        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin, xmax)
-        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin, ymax)
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin, xmax) - xmin
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin, ymax) - ymin
     else:  # relative boxes
         h, w = img.shape[-2:]
         # Clip boxes
-        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin / w, xmax / w)
-        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin / h, ymax / h)
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin / w, xmax / w) - xmin / w
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin / h, ymax / h) - ymin / h
     # Remove 0-sized boxes
     is_valid = np.logical_and(boxes[:, 1] < boxes[:, 3], boxes[:, 0] < boxes[:, 2])
     boxes = boxes[is_valid]

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -100,14 +100,14 @@ def crop_detection(
         img, ymin, xmin, ymax - ymin, xmax - xmin
     )
     if boxes.dtype == int:  # absolute boxes
-        # Clip boxes
-        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin, xmax)
-        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin, ymax)
+        # Clip boxes & correct the offset
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin, xmax) - xmin
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin, ymax) - ymin
     else:  # relative boxes
         h, w = img.shape[:2]
-        # Clip boxes
-        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin / w, xmax / w)
-        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin / h, ymax / h)
+        # Clip boxes & correct the offset
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin / w, xmax / w) - xmin / w
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin / h, ymax / h) - ymin / h
     # Remove 0-sized boxes
     zero_height = boxes[:, 1] < boxes[:, 3]
     zero_width = boxes[:, 0] < boxes[:, 2]

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -12,6 +12,7 @@ import tensorflow as tf
 import tensorflow_addons as tfa
 
 from doctr.utils.geometry import compute_expanded_shape, rotate_abs_boxes
+
 from .base import crop_boxes
 
 __all__ = ["invert_colors", "rotate", "crop_detection"]

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -109,9 +109,9 @@ def crop_detection(
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin / w, xmax / w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin / h, ymax / h)
     # Remove 0-sized boxes
-    zero_height = boxes[:, 1] == boxes[:, 3]
-    zero_width = boxes[:, 0] == boxes[:, 2]
-    empty_boxes = np.logical_or(zero_height, zero_width)
-    boxes = boxes[~empty_boxes]
+    zero_height = boxes[:, 1] < boxes[:, 3]
+    zero_width = boxes[:, 0] < boxes[:, 2]
+    nonempty_boxes = np.logical_and(zero_height, zero_width)
+    boxes = boxes[nonempty_boxes]
 
     return croped_img, boxes

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -12,6 +12,7 @@ import tensorflow as tf
 import tensorflow_addons as tfa
 
 from doctr.utils.geometry import compute_expanded_shape, rotate_abs_boxes
+from .base import crop_boxes
 
 __all__ = ["invert_colors", "rotate", "crop_detection"]
 
@@ -96,22 +97,10 @@ def crop_detection(
     h, w = img.shape[:2]
     xmin, ymin = int(round(crop_box[0] * (w - 1))), int(round(crop_box[1] * (h - 1)))
     xmax, ymax = int(round(crop_box[2] * (w - 1))), int(round(crop_box[3] * (h - 1)))
-    croped_img = tf.image.crop_to_bounding_box(
+    cropped_img = tf.image.crop_to_bounding_box(
         img, ymin, xmin, ymax - ymin, xmax - xmin
     )
-    if boxes.dtype == int:  # absolute boxes
-        # Clip boxes & correct the offset
-        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin, xmax) - xmin
-        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin, ymax) - ymin
-    else:  # relative boxes
-        h, w = img.shape[:2]
-        # Clip boxes & correct the offset
-        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], xmin / w, xmax / w) - xmin / w
-        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], ymin / h, ymax / h) - ymin / h
-    # Remove 0-sized boxes
-    zero_height = boxes[:, 1] < boxes[:, 3]
-    zero_width = boxes[:, 0] < boxes[:, 2]
-    nonempty_boxes = np.logical_and(zero_height, zero_width)
-    boxes = boxes[nonempty_boxes]
+    # Crop the box
+    boxes = crop_boxes(boxes, crop_box if boxes.max() <= 1 else (xmin, ymin, xmax, ymax))
 
-    return croped_img, boxes
+    return cropped_img, boxes

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -157,6 +157,9 @@ def test_crop_detection():
     c_img, _ = crop_detection(img, abs_boxes, crop_box)
     assert c_img.dtype == torch.float16
 
+    with pytest.raises(AssertionError):
+        crop_detection(img, abs_boxes, (2, 6, 24, 56))
+
 
 def test_random_crop():
     cropper = RandomCrop(scale=(0.5, 1.), ratio=(0.75, 1.33))

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -140,13 +140,17 @@ def test_crop_detection():
     c_img, c_boxes = crop_detection(img, abs_boxes, crop_box)
     assert c_img.shape == (3, 26, 37)
     assert c_boxes.shape == (1, 4)
+    assert np.all(c_boxes == np.array([15 - 12, 0, 35 - 12, 30 - 23])[None, ...])
+
     rel_boxes = np.array([
         [.3, .4, .7, .6],
         [.1, .2, .2, .4],
     ])
+    crop_box = (0.24, 0.46, 1.0, 1.0)
     c_img, c_boxes = crop_detection(img, rel_boxes, crop_box)
     assert c_img.shape == (3, 26, 37)
     assert c_boxes.shape == (1, 4)
+    assert np.abs(c_boxes - np.array([.06 / .76, 0., .46 / .76, .14 / .54])[None, ...]).mean() < 1e-7
 
     # FP16
     img = torch.ones((3, 50, 50), dtype=torch.float16)
@@ -162,9 +166,9 @@ def test_random_crop():
     ])
     img, target = cropper(input_t, dict(boxes=boxes))
     # Check the scale
-    assert img.shape[-1] * img.shape[-2] >= 0.5 * input_t.shape[-1] * input_t.shape[-2]
+    assert img.shape[-1] * img.shape[-2] >= 0.4 * input_t.shape[-1] * input_t.shape[-2]
     # Check aspect ratio
-    assert 0.75 <= img.shape[-2] / img.shape[-1] <= 1.33
+    assert 0.65 <= img.shape[-2] / img.shape[-1] <= 1.5
     # Check the target
     assert np.all(target['boxes'] >= 0)
     assert np.all(target['boxes'][:, [0, 2]] <= img.shape[-1]) and np.all(target['boxes'][:, [1, 3]] <= img.shape[-2])

--- a/tests/tensorflow/test_transforms_tf.py
+++ b/tests/tensorflow/test_transforms_tf.py
@@ -303,6 +303,9 @@ def test_crop_detection():
     c_img, _ = crop_detection(img, rel_boxes, crop_box)
     assert c_img.dtype == tf.float16
 
+    with pytest.raises(AssertionError):
+        crop_detection(img, abs_boxes, (2, 6, 24, 56))
+
 
 def test_random_crop():
     transfo = T.RandomCrop(scale=(0.5, 1.), ratio=(0.75, 1.33))

--- a/tests/tensorflow/test_transforms_tf.py
+++ b/tests/tensorflow/test_transforms_tf.py
@@ -287,6 +287,8 @@ def test_crop_detection():
     c_img, c_boxes = crop_detection(img, abs_boxes, crop_box)
     assert c_img.shape == (26, 37, 3)
     assert c_boxes.shape == (1, 4)
+    assert np.all(c_boxes == np.array([15 - 12, 0, 35 - 12, 30 - 23])[None, ...])
+
     rel_boxes = np.array([
         [.3, .4, .7, .6],
         [.1, .2, .2, .4],
@@ -294,6 +296,7 @@ def test_crop_detection():
     c_img, c_boxes = crop_detection(img, rel_boxes, crop_box)
     assert c_img.shape == (26, 37, 3)
     assert c_boxes.shape == (1, 4)
+    assert np.abs(c_boxes - np.array([.06 / .76, 0., .46 / .76, .14 / .54])[None, ...]).mean() < 1e-7
 
     # FP16
     img = tf.ones((50, 50, 3), dtype=tf.float16)
@@ -308,10 +311,10 @@ def test_random_crop():
         [15, 20, 35, 30]
     ])
     img, target = transfo(input_t, dict(boxes=boxes))
-    # Check the scale
-    assert img.shape[0] * img.shape[1] >= 0.5 * input_t.shape[0] * input_t.shape[1]
-    # Check aspect ratio
-    assert 0.75 <= img.shape[0] / img.shape[1] <= 1.33
+    # Check the scale (take a margin)
+    assert img.shape[0] * img.shape[1] >= 0.4 * input_t.shape[0] * input_t.shape[1]
+    # Check aspect ratio (take a margin)
+    assert 0.65 <= img.shape[0] / img.shape[1] <= 1.5
     # Check the target
     assert np.all(target['boxes'] >= 0)
     assert np.all(target['boxes'][:, [0, 2]] <= img.shape[1]) and np.all(target['boxes'][:, [1, 3]] <= img.shape[0])


### PR DESCRIPTION
This PR introduces the following modifications:
- fixed the box cropping part of RandomCrop: a previous PR fixed the cropping of the image, but there was some offset left to correct and some rescaling to do
- updated unittests to avoid missing this next time
- took the liberty of refactoring numpy part into a shared `crop_boxes` function to avoid duplication

Any feedback is welcome!
