### PR TITLE
feat: Added Random Horizontal Flip augmentation

### DIFF
--- a/doctr/transforms/modules/pytorch.py
+++ b/doctr/transforms/modules/pytorch.py
@@ -12,7 +12,7 @@ from torch.nn.functional import pad
 from torchvision.transforms import functional as F
 from torchvision.transforms import transforms as T
 
-__all__ = ['Resize', 'GaussianNoise', 'ChannelShuffle', 'RandHorizontalFlip']
+__all__ = ['Resize', 'GaussianNoise', 'ChannelShuffle', 'RandomHorizontalFlip']
 
 
 class Resize(T.Resize):
@@ -98,7 +98,7 @@ class ChannelShuffle(torch.nn.Module):
         return img[chan_order]
 
 
-class RandHorizontalFlip(T.RandomHorizontalFlip):
+class RandomHorizontalFlip(T.RandomHorizontalFlip):
 
     def forward(
             self,

--- a/references/obj_detection/train_pytorch.py
+++ b/references/obj_detection/train_pytorch.py
@@ -239,7 +239,7 @@ def main(args):
             ColorJitter(brightness=0.3, contrast=0.3, saturation=0.3, hue=0.02),
             T.RandomApply(GaussianBlur(kernel_size=(3, 3), sigma=(0.1, 3)), .3),
         ]),
-        sample_transforms=T.RandHorizontalFlip(p=0.5),
+        sample_transforms=T.RandomHorizontalFlip(p=0.5),
     )
     train_loader = DataLoader(
         train_set,

--- a/references/obj_detection/train_pytorch.py
+++ b/references/obj_detection/train_pytorch.py
@@ -238,8 +238,9 @@ def main(args):
             T.RandomApply(T.GaussianNoise(0., 0.25), p=0.5),
             ColorJitter(brightness=0.3, contrast=0.3, saturation=0.3, hue=0.02),
             T.RandomApply(GaussianBlur(kernel_size=(3, 3), sigma=(0.1, 3)), .3),
-        ]))
-
+        ]),
+        sample_transforms=T.RandHorizontalFlip(p=0.5),
+    )
     train_loader = DataLoader(
         train_set,
         batch_size=args.batch_size,

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import torch
 
-from doctr.transforms import (ChannelShuffle, ColorInversion, GaussianNoise, RandHorizontalFlip, RandomCrop,
+from doctr.transforms import (ChannelShuffle, ColorInversion, GaussianNoise, RandomCrop, RandomHorizontalFlip,
                               RandomRotate, Resize)
 from doctr.transforms.functional import crop_detection, rotate
 
@@ -222,9 +222,9 @@ def test_gaussian_noise(input_dtype, input_shape):
 
 
 @pytest.mark.parametrize("p", [1, 0])
-def test_rand_horizontalflip(p):
+def test_randomhorizontalflip(p):
     # testing for 2 cases, with flip probability 1 and 0.
-    transform = RandHorizontalFlip(p)
+    transform = RandomHorizontalFlip(p)
     input_t = torch.ones((3, 32, 32), dtype=torch.float32)
     input_t[..., :16] = 0
     target = {"boxes": np.array([[0.1, 0.1, 0.3, 0.4]], dtype=np.float32), "labels": np.ones(1, dtype=np.int64)}

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -225,15 +225,22 @@ def test_gaussian_noise(input_dtype, input_shape):
 def test_rand_horizontalflip(p):
     # testing for 2 cases, with flip probability 1 and 0.
     transform = RandHorizontalFlip(p)
-    input_t = torch.rand((3, 64, 64), dtype=torch.float32)
-    bbox = {"boxes": [[0.1, 0.1, 0.3, 0.4]], "labels": [1]}
-    transformed, t_bbox = transform(input_t, bbox)
+    input_t = torch.ones((3, 32, 32), dtype=torch.float32)
+    input_t[..., :16] = 0
+    target = {"boxes": np.array([[0.1, 0.1, 0.3, 0.4]], dtype=np.float32), "labels": np.ones(1, dtype=np.int64)}
+    transformed, _target = transform(input_t, target)
     assert isinstance(transformed, torch.Tensor)
     assert transformed.shape == input_t.shape
     assert transformed.dtype == input_t.dtype
+    # integrity check of targets
+    assert isinstance(_target, dict)
+    assert all(isinstance(val, np.ndarray) for val in _target.values())
+    assert _target["boxes"].dtype == np.float32
+    assert _target["labels"].dtype == np.int64
     if p == 1:
-        assert t_bbox["boxes"][0][0] == 0.7  # shifted x_min
-        assert t_bbox["boxes"][0][2] == 0.9  # shifted x_max
-        assert t_bbox["boxes"][1::2] == bbox["boxes"][1::2]
-    else:
-        assert t_bbox["boxes"] == bbox["boxes"]
+        assert np.all(_target["boxes"] == np.array([[0.7, 0.1, 0.9, 0.4]], dtype=np.float32))
+        assert torch.all(transformed.mean((0, 1)) == torch.tensor([1] * 16 + [0] * 16, dtype=torch.float32))
+    elif p == 0:
+        assert np.all(_target["boxes"] == np.array([[0.1, 0.1, 0.3, 0.4]], dtype=np.float32))
+        assert torch.all(transformed.mean((0, 1)) == torch.tensor([0] * 16 + [1] * 16, dtype=torch.float32))
+    assert np.all(_target["labels"] == np.ones(1, dtype=np.int64))


### PR DESCRIPTION
This PR introduces the following changes:

- It adds Random horizontal Flip as an augmentation that transforms images as well as the labels.

           from doctr.transforms import RandHorizontalFlip
           import torch
           transformed = RandHorizontalFlip(p = 0.5)
           target = {"boxes": [ [0.1, 0.1, 0.4, 0.5] ], "labels": [1]}
           image, target = transformed(torch.rand((3, 224, 224)), target)

- It adds a uniitest for the same

Any feedback is welcome!