### PR TITLE
docs: Fixed README link & update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ What you can expect from this repository:
 ### Getting your pretrained model
 
 End-to-End OCR is achieved in docTR using a two-stage approach: text detection (localizing words), then text recognition (identify all characters in the word).
-As such, you can select the architecture used for [text detection](https://mindee.github.io/doctr/latest/models.html#id2), and the one for [text recognition](https://mindee.github.io/doctr/latest/models.html#id3) from the list of available implementations.
+As such, you can select the architecture used for [text detection](https://mindee.github.io/doctr/latest/models.html#doctr-models-detection), and the one for [text recognition](https://mindee.github.io/doctr/latest/models.html#doctr-models-recognition) from the list of available implementations.
 
 ```python
 from doctr.models import ocr_predictor
@@ -245,7 +245,6 @@ PORT=8002 docker-compose up -d --build
 Your API should now be running locally on your port 8002. Access your automatically-built documentation at [http://localhost:8002/redoc](http://localhost:8002/redoc) and enjoy your three functional routes ("/detection", "/recognition", "/ocr"). Here is an example with Python to send a request to the OCR route:
 
 ```python
-
 import requests
 with open('/path/to/your/doc.jpg', 'rb') as f:
     data = f.read()

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -32,7 +32,7 @@ function addGithubButton() {
 
 function addVersionControl() {
     // To grab the version currently in view, we parse the url
-    const parts = location.toString().split('/');
+    const parts = location.toString().split('#')[0].split('/');
     let versionIndex = parts.length - 2;
     // Index page may not have a last part with filename.html so we need to go up
     if (parts[parts.length - 1] != "" && ! parts[parts.length - 1].match(/\.html$|^search.html?/)) {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,12 @@ Supported datasets
    * FUNSD from `"FUNSD: A Dataset for Form Understanding in Noisy Scanned Documents" <https://arxiv.org/pdf/1905.13538.pdf>`_.
    * CORD from `"CORD: A Consolidated Receipt Dataset forPost-OCR Parsing" <https://openreview.net/pdf?id=SJl3z659UH>`_.
    * SROIE from `ICDAR 2019 <https://rrc.cvc.uab.es/?ch=13>`_.
+   * IIIT-5k from `CVIT <https://cvit.iiit.ac.in/research/projects/cvit-projects/the-iiit-5k-word-dataset>`_.
+   * Street View Text from `"End-to-End Scene Text Recognition" <http://vision.ucsd.edu/~kai/pubs/wang_iccv2011.pdf>`_.
+   * SynthText from `Visual Geometry Group <https://www.robots.ox.ac.uk/~vgg/data/scenetext/>`_.
+   * SVHN from `"Reading Digits in Natural Images with Unsupervised Feature Learning" <http://ufldl.stanford.edu/housenumbers/nips2011_housenumbers.pdf>`_.
+   * IC03 from `ICDAR 2003 <http://www.iapr-tc11.org/mediawiki/index.php?title=ICDAR_2003_Robust_Reading_Competitions>`_.
+   * IC13 from `ICDAR 2013 <http://dagdata.cvc.uab.es/icdar2013competition/>`_.
 
 
 .. toctree::


### PR DESCRIPTION
This PR introduces the following modifications:
- fixed the hyperlinks to the documentation in the README
- adds the new datasets to the list on the documentation landing page
- fixed the version display on the documentation: when accessing a subtag of a page, the URL included a part `.html#mytag` and the parser was failing to show the correct part. This is now fixed

Any feedback is welcome!