### PR TITLE
refactor: Enforced relative coordinates for all dataset geometries

### DIFF
--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 
 from .datasets import VisionDataset
+from .utils import convert_target_to_relative
 
 __all__ = ['CORD']
 
@@ -43,7 +44,7 @@ class CORD(VisionDataset):
     ) -> None:
 
         url, sha256 = self.TRAIN if train else self.TEST
-        super().__init__(url, None, sha256, True, **kwargs)
+        super().__init__(url, None, sha256, True, pre_transforms=convert_target_to_relative, **kwargs)
 
         # # List images
         tmp_root = os.path.join(self.root, 'image')

--- a/doctr/datasets/datasets/pytorch.py
+++ b/doctr/datasets/datasets/pytorch.py
@@ -17,10 +17,6 @@ __all__ = ['AbstractDataset', 'VisionDataset']
 
 class AbstractDataset(_AbstractDataset):
 
-    @staticmethod
-    def _get_img_shape(img: Any) -> Tuple[int, int]:
-        return img.shape[-2:]
-
     def _read_sample(self, index: int) -> Tuple[torch.Tensor, Any]:
         img_name, target = self.data[index]
         # Read image

--- a/doctr/datasets/datasets/tensorflow.py
+++ b/doctr/datasets/datasets/tensorflow.py
@@ -17,10 +17,6 @@ __all__ = ['AbstractDataset', 'VisionDataset']
 
 class AbstractDataset(_AbstractDataset):
 
-    @staticmethod
-    def _get_img_shape(img: Any) -> Tuple[int, int]:
-        return img.shape[:2]
-
     def _read_sample(self, index: int) -> Tuple[tf.Tensor, Any]:
         img_name, target = self.data[index]
         # Read image

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -9,9 +9,10 @@ from typing import Any, List, Tuple
 
 import numpy as np
 
-from .datasets import AbstractDataset
-from doctr.utils.geometry import convert_to_relative_coords
 from doctr.io.image import get_img_shape
+from doctr.utils.geometry import convert_to_relative_coords
+
+from .datasets import AbstractDataset
 
 __all__ = ["DetectionDataset"]
 

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 
 from .datasets import VisionDataset
+from .utils import convert_target_to_relative
 
 __all__ = ['FUNSD']
 
@@ -41,7 +42,14 @@ class FUNSD(VisionDataset):
         **kwargs: Any,
     ) -> None:
 
-        super().__init__(self.URL, self.FILE_NAME, self.SHA256, True, **kwargs)
+        super().__init__(
+            self.URL,
+            self.FILE_NAME,
+            self.SHA256,
+            True,
+            pre_transforms=convert_target_to_relative,
+            **kwargs
+        )
         self.train = train
 
         # Use the subset
@@ -66,11 +74,17 @@ class FUNSD(VisionDataset):
                 # box_targets: xmin, ymin, xmax, ymax -> x, y, w, h, alpha = 0
                 box_targets = [
                     [
-                        (box[0] + box[2]) / 2, (box[1] + box[3]) / 2, box[2] - box[0], box[3] - box[1], 0
+                        [box[0], box[1]],
+                        [box[2], box[1]],
+                        [box[2], box[3]],
+                        [box[0], box[3]],
                     ] for box in box_targets
                 ]
 
-            self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=int), labels=list(text_targets))))
+            self.data.append((
+                img_path,
+                dict(boxes=np.asarray(box_targets, dtype=np.float32), labels=list(text_targets)),
+            ))
 
         self.root = tmp_root
 

--- a/doctr/datasets/iiit5k.py
+++ b/doctr/datasets/iiit5k.py
@@ -11,6 +11,7 @@ import numpy as np
 import scipy.io as sio
 
 from .datasets import VisionDataset
+from .utils import convert_target_to_relative
 
 __all__ = ['IIIT5K']
 
@@ -42,7 +43,14 @@ class IIIT5K(VisionDataset):
         **kwargs: Any,
     ) -> None:
 
-        super().__init__(self.URL, None, file_hash=self.SHA256, extract_archive=True, **kwargs)
+        super().__init__(
+            self.URL,
+            None,
+            file_hash=self.SHA256,
+            extract_archive=True,
+            pre_transforms=convert_target_to_relative,
+            **kwargs
+        )
         self.train = train
 
         # Load mat data

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -48,8 +48,8 @@ class OCRDataset(AbstractDataset):
             if len(annotations["typed_words"]) == 0:
                 self.data.append((img_name, dict(boxes=np.zeros((0, 4), dtype=np_dtype), labels=[])))
                 continue
-            # Unpack
-            box_targets = [tuple(map(float, obj['geometry'])) for obj in annotations['typed_words']]
+            # Unpack the straight boxes
+            geoms = [tuple(map(float, obj['geometry'][:4])) for obj in annotations['typed_words']]
             text_targets = [obj['value'] for obj in annotations['typed_words']]
 
-            self.data.append((img_name, dict(boxes=np.asarray(box_targets, dtype=np_dtype), labels=text_targets)))
+            self.data.append((img_name, dict(boxes=np.asarray(geoms, dtype=np_dtype), labels=text_targets)))

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -51,10 +51,10 @@ class OCRDataset(AbstractDataset):
                 self.data.append((img_name, dict(boxes=np.zeros((0, 4), dtype=np_dtype), labels=[])))
                 continue
             # Unpack the straight boxes
-            geoms = [tuple(map(float, obj['geometry'][:4])) for obj in annotations['typed_words']]
+            geoms = [list(map(float, obj['geometry'][:4])) for obj in annotations['typed_words']]
             if use_polygons:
                 geoms = [
-                    [geom[:2], [geom[2], geom[1]], geom[2:], [geom[0], geom[3]]]
+                    [geom[:2], [geom[2], geom[1]], geom[2:], [geom[0], geom[3]]]  # type: ignore[list-item]
                     for geom in geoms
                 ]
 

--- a/doctr/datasets/ocr.py
+++ b/doctr/datasets/ocr.py
@@ -21,12 +21,14 @@ class OCRDataset(AbstractDataset):
     Args:
         img_folder: local path to image folder (all jpg at the root)
         label_file: local path to the label file
+        use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
     """
 
     def __init__(
         self,
         img_folder: str,
         label_file: str,
+        use_polygons: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(img_folder, **kwargs)
@@ -50,6 +52,12 @@ class OCRDataset(AbstractDataset):
                 continue
             # Unpack the straight boxes
             geoms = [tuple(map(float, obj['geometry'][:4])) for obj in annotations['typed_words']]
+            if use_polygons:
+                geoms = [
+                    [geom[:2], [geom[2], geom[1]], geom[2:], [geom[0], geom[3]]]
+                    for geom in geoms
+                ]
+
             text_targets = [obj['value'] for obj in annotations['typed_words']]
 
             self.data.append((img_name, dict(boxes=np.asarray(geoms, dtype=np_dtype), labels=text_targets)))

--- a/doctr/datasets/sroie.py
+++ b/doctr/datasets/sroie.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 
 from .datasets import VisionDataset
+from .utils import convert_target_to_relative
 
 __all__ = ['SROIE']
 
@@ -43,7 +44,7 @@ class SROIE(VisionDataset):
     ) -> None:
 
         url, sha256 = self.TRAIN if train else self.TEST
-        super().__init__(url, None, sha256, True, **kwargs)
+        super().__init__(url, None, sha256, True, pre_transforms=convert_target_to_relative, **kwargs)
         self.train = train
 
         tmp_root = os.path.join(self.root, 'images')

--- a/doctr/datasets/svhn.py
+++ b/doctr/datasets/svhn.py
@@ -11,6 +11,7 @@ import numpy as np
 from tqdm import tqdm
 
 from .datasets import VisionDataset
+from .utils import convert_target_to_relative
 
 __all__ = ['SVHN']
 
@@ -45,7 +46,14 @@ class SVHN(VisionDataset):
     ) -> None:
 
         url, sha256, name = self.TRAIN if train else self.TEST
-        super().__init__(url, file_name=name, file_hash=sha256, extract_archive=True, **kwargs)
+        super().__init__(
+            url,
+            file_name=name,
+            file_hash=sha256,
+            extract_archive=True,
+            pre_transforms=convert_target_to_relative,
+            **kwargs
+        )
         self.train = train
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         np_dtype = np.float32

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -7,7 +7,7 @@ import os
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
-from scipy import io as scio
+from scipy import io as sio
 from tqdm import tqdm
 
 from .datasets import VisionDataset
@@ -71,7 +71,7 @@ class SynthText(VisionDataset):
             if not os.path.exists(os.path.join(tmp_root, img_path[0])):
                 raise FileNotFoundError(f"unable to locate {os.path.join(tmp_root, img_path[0])}")
 
-            labels = ''.join(txt).split()
+            labels = [elt for word in txt.tolist() for elt in word.split()]
             word_boxes = word_boxes.transpose(2, 1, 0) if word_boxes.ndim == 3 else np.expand_dims(word_boxes, axis=0)
 
             if not use_polygons:

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -70,7 +70,7 @@ class SynthText(VisionDataset):
                 raise FileNotFoundError(f"unable to locate {os.path.join(tmp_root, img_path[0])}")
 
             labels = ''.join(txt).split()
-            word_boxes = word_boxes.transpose(2, 1, 0)
+            word_boxes = word_boxes.transpose(2, 1, 0) if word_boxes.ndim == 3 else np.expand_dims(word_boxes, axis=0)
 
             if not use_polygons:
                 word_boxes = np.concatenate((word_boxes.min(axis=1), word_boxes.max(axis=1)), axis=1)

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -55,10 +55,12 @@ class SynthText(VisionDataset):
         # Load mat data
         tmp_root = os.path.join(self.root, 'SynthText') if self.SHA256 else self.root
         mat_data = sio.loadmat(os.path.join(tmp_root, 'gt.mat'))
-        split = int(len(mat_data['imnames'][0]) * 0.9)
-        paths = mat_data['imnames'][0][slice(split) if self.train else slice(split, None)]
-        boxes = mat_data['wordBB'][0][slice(split) if self.train else slice(split, None)]
-        labels = mat_data['txt'][0][slice(split) if self.train else slice(split, None)]
+        train_samples = int(len(mat_data['imnames'][0]) * 0.9)
+        set_slice = slice(train_samples) if self.train else slice(train_samples, None)
+        paths = mat_data['imnames'][0][set_slice]
+        boxes = mat_data['wordBB'][0][set_slice]
+        labels = mat_data['txt'][0][set_slice]
+        del mat_data
 
         self.data: List[Tuple[str, Dict[str, Any]]] = []
         np_dtype = np.float32

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -11,6 +11,7 @@ import scipy.io as sio
 from tqdm import tqdm
 
 from .datasets import VisionDataset
+from .utils import convert_target_to_relative
 
 __all__ = ['SynthText']
 
@@ -41,7 +42,14 @@ class SynthText(VisionDataset):
         **kwargs: Any,
     ) -> None:
 
-        super().__init__(self.URL, None, file_hash=None, extract_archive=True, **kwargs)
+        super().__init__(
+            self.URL,
+            None,
+            file_hash=None,
+            extract_archive=True,
+            pre_transforms=convert_target_to_relative,
+            **kwargs
+        )
         self.train = train
 
         # Load mat data
@@ -61,8 +69,8 @@ class SynthText(VisionDataset):
             if not os.path.exists(os.path.join(tmp_root, img_path[0])):
                 raise FileNotFoundError(f"unable to locate {os.path.join(tmp_root, img_path[0])}")
 
-            labels = [elt for word in txt.tolist() for elt in word.split()]
-            word_boxes = word_boxes.transpose(2, 1, 0) if word_boxes.ndim == 3 else np.expand_dims(word_boxes, axis=0)
+            labels = ''.join(txt).split()
+            word_boxes = word_boxes.transpose(2, 1, 0)
 
             if not use_polygons:
                 word_boxes = np.concatenate((word_boxes.min(axis=1), word_boxes.max(axis=1)), axis=1)

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -7,7 +7,7 @@ import os
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
-import scipy.io as sio
+from scipy import io as scio
 from tqdm import tqdm
 
 from .datasets import VisionDataset

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -7,15 +7,20 @@ import string
 import unicodedata
 from collections.abc import Sequence
 from functools import partial
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from typing import Sequence as SequenceType
-from typing import Union
+from typing import Tuple, TypeVar, Union
 
 import numpy as np
+
+from doctr.io.image import get_img_shape
+from doctr.utils.geometry import convert_to_relative_coords
 
 from .vocabs import VOCABS
 
 __all__ = ['translate', 'encode_string', 'decode_sequence', 'encode_sequences']
+
+I = TypeVar('I')
 
 
 def translate(
@@ -150,3 +155,9 @@ def encode_sequences(
         encoded_data[:, 0] = sos
 
     return encoded_data
+
+
+def convert_target_to_relative(img: I, target: Dict[str, Any]) -> Tuple[I, Dict[str, Any]]:
+
+    target['boxes'] = convert_to_relative_coords(target['boxes'], get_img_shape(img))
+    return img, target

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -20,7 +20,7 @@ from .vocabs import VOCABS
 
 __all__ = ['translate', 'encode_string', 'decode_sequence', 'encode_sequences']
 
-I = TypeVar('I')
+ImageTensor = TypeVar('ImageTensor')
 
 
 def translate(
@@ -157,7 +157,7 @@ def encode_sequences(
     return encoded_data
 
 
-def convert_target_to_relative(img: I, target: Dict[str, Any]) -> Tuple[I, Dict[str, Any]]:
+def convert_target_to_relative(img: ImageTensor, target: Dict[str, Any]) -> Tuple[ImageTensor, Dict[str, Any]]:
 
     target['boxes'] = convert_to_relative_coords(target['boxes'], get_img_shape(img))
     return img, target

--- a/doctr/io/image/pytorch.py
+++ b/doctr/io/image/pytorch.py
@@ -99,5 +99,6 @@ def tensor_from_numpy(npy_img: np.ndarray, dtype: torch.dtype = torch.float32) -
 
     return img
 
+
 def get_img_shape(img: torch.Tensor) -> Tuple[int, int]:
-    return img.shape[-2:]
+    return img.shape[-2:]  # type: ignore[return-value]

--- a/doctr/io/image/pytorch.py
+++ b/doctr/io/image/pytorch.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from io import BytesIO
+from typing import Tuple
 
 import numpy as np
 import torch
@@ -12,7 +13,7 @@ from torchvision.transforms.functional import to_tensor
 
 from doctr.utils.common_types import AbstractPath
 
-__all__ = ['tensor_from_pil', 'read_img_as_tensor', 'decode_img_as_tensor', 'tensor_from_numpy']
+__all__ = ['tensor_from_pil', 'read_img_as_tensor', 'decode_img_as_tensor', 'tensor_from_numpy', 'get_img_shape']
 
 
 def tensor_from_pil(pil_img: Image, dtype: torch.dtype = torch.float32) -> torch.Tensor:
@@ -97,3 +98,6 @@ def tensor_from_numpy(npy_img: np.ndarray, dtype: torch.dtype = torch.float32) -
             img = img.to(dtype=torch.float16).div(255)
 
     return img
+
+def get_img_shape(img: torch.Tensor) -> Tuple[int, int]:
+    return img.shape[-2:]

--- a/doctr/io/image/tensorflow.py
+++ b/doctr/io/image/tensorflow.py
@@ -3,6 +3,8 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
+from typing import Tuple
+
 import numpy as np
 import tensorflow as tf
 from PIL import Image
@@ -14,7 +16,7 @@ else:
 
 from doctr.utils.common_types import AbstractPath
 
-__all__ = ['tensor_from_pil', 'read_img_as_tensor', 'decode_img_as_tensor', 'tensor_from_numpy']
+__all__ = ['tensor_from_pil', 'read_img_as_tensor', 'decode_img_as_tensor', 'tensor_from_numpy', 'get_img_shape']
 
 
 def tensor_from_pil(pil_img: Image, dtype: tf.dtypes.DType = tf.float32) -> tf.Tensor:
@@ -101,3 +103,6 @@ def tensor_from_numpy(npy_img: np.ndarray, dtype: tf.dtypes.DType = tf.float32) 
         img = tf.clip_by_value(img, 0, 1)
 
     return img
+
+def get_img_shape(img: tf.Tensor) -> Tuple[int, int]:
+    return img.shape[:2]

--- a/doctr/io/image/tensorflow.py
+++ b/doctr/io/image/tensorflow.py
@@ -104,5 +104,6 @@ def tensor_from_numpy(npy_img: np.ndarray, dtype: tf.dtypes.DType = tf.float32) 
 
     return img
 
+
 def get_img_shape(img: tf.Tensor) -> Tuple[int, int]:
     return img.shape[:2]

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -12,7 +12,8 @@ import numpy as np
 from .common_types import BoundingBox, Polygon4P
 
 __all__ = ['bbox_to_polygon', 'polygon_to_bbox', 'resolve_enclosing_bbox', 'resolve_enclosing_rbbox',
-           'rotate_boxes', 'rotate_abs_boxes', 'compute_expanded_shape', 'rotate_image', 'estimate_page_angle']
+           'rotate_boxes', 'rotate_abs_boxes', 'compute_expanded_shape', 'rotate_image', 'estimate_page_angle',
+           'convert_to_relative_coords']
 
 
 def bbox_to_polygon(bbox: BoundingBox) -> Polygon4P:
@@ -244,3 +245,29 @@ def estimate_page_angle(polys: np.ndarray) -> float:
         (polys[:, 0, 1] - polys[:, 1, 1]) /  # Y axis from top to bottom!
         (polys[:, 1, 0] - polys[:, 0, 0])
     )) * 180 / np.pi
+
+
+def convert_to_relative_coords(geoms: np.ndarray, img_shape: Tuple[int, int]) -> np.ndarray:
+    """Convert a geometry to relative coordinates
+
+    Args:
+        geoms: a set of polygons of shape (N, 4, 2) or of straight boxes of shape (N, 4)
+        img_shape: the height and width of the image
+
+    Returns:
+        the updated geometry
+    """
+
+    # Polygon
+    if geoms.ndim == 3 and geoms.shape[1:] == (4, 2):
+        polygons = np.empty(geoms.shape, dtype=np.float32)
+        polygons[..., 0] = geoms[..., 0] / img_shape[1]
+        polygons[..., 1] = geoms[..., 1] / img_shape[0]
+        return polygons.clip(0, 1)
+    if geoms.ndim == 2 and geoms.shape[1] == 4:
+        boxes = np.empty(geoms.shape, dtype=np.float32)
+        boxes[:, ::2] = geoms[:, ::2] / img_shape[1]
+        boxes[:, 1::2] = geoms[:, 1::2] / img_shape[0]
+        return boxes.clip(0, 1)
+
+    raise ValueError(f"invalid format for arg `geoms`: {geoms.shape}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -344,13 +344,12 @@ def mock_cord_dataset(tmpdir_factory, mock_image_stream):
 def mock_synthtext_dataset(tmpdir_factory, mock_image_stream):
     root = tmpdir_factory.mktemp('datasets')
     synthtext_root = root.mkdir('SynthText')
-    # sub_root = synthtext_root.mkdir('SynthText')
     image_folder = synthtext_root.mkdir("8")
     annotation_file = synthtext_root.join('gt.mat')
     labels = {
         "imnames": [[["8/ballet_106_0.jpg"], ["8/ballet_106_1.jpg"], ["8/ballet_106_2.jpg"]]],
-        "wordBB": [np.random.randint(1000, size=(2, 4, 3)) for _ in range(3)],
-        "txt": np.array([['I      ', 'am\na      ', 'Jedi   ', '!'] for _ in range(3)])
+        "wordBB": [[np.random.randint(1000, size=(2, 4, 5)) for _ in range(3)]],
+        "txt": [np.array([['I      ', 'am\na      ', 'Jedi   ', '!'] for _ in range(3)])],
     }
     # hacky trick to write file into a LocalPath object with scipy.io.savemat
     with tempfile.NamedTemporaryFile(mode='wb', delete=True) as f:

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -10,7 +10,7 @@ from doctr import datasets
 from doctr.transforms import Resize
 
 
-def _validate_dataset(ds, input_size, batch_size=2, relative_coords=True, class_indices=False):
+def _validate_dataset(ds, input_size, batch_size=2, class_indices=False):
 
     # Fetch one sample
     img, target = ds[0]
@@ -19,8 +19,7 @@ def _validate_dataset(ds, input_size, batch_size=2, relative_coords=True, class_
     assert img.dtype == torch.float32
     assert isinstance(target, dict)
     assert isinstance(target['boxes'], np.ndarray)
-    if relative_coords:
-        assert np.all((target['boxes'][:, :4] <= 1) & (target['boxes'][:, :4] >= 0))
+    assert np.all((target['boxes'][:, :4] <= 1) & (target['boxes'][:, :4] >= 0))
     if class_indices:
         assert isinstance(target['labels'], np.ndarray) and target['labels'].dtype == np.int64
     else:
@@ -230,7 +229,7 @@ def test_svhn(input_size, num_samples, rotate, mock_svhn_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SVHN(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -251,7 +250,7 @@ def test_sroie(input_size, num_samples, rotate, mock_sroie_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SROIE(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -274,7 +273,7 @@ def test_funsd(input_size, num_samples, rotate, mock_funsd_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"FUNSD(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -295,7 +294,7 @@ def test_cord(input_size, num_samples, rotate, mock_cord_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"CORD(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size, )
 
 
 @pytest.mark.parametrize(
@@ -317,7 +316,7 @@ def test_synthtext(input_size, num_samples, rotate, mock_synthtext_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SynthText(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -361,7 +360,7 @@ def test_iiit5k(input_size, num_samples, rotate, mock_iiit5k_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"IIIT5K(train={True})"
-    _validate_dataset(ds, input_size, batch_size=1, relative_coords=False)
+    _validate_dataset(ds, input_size, batch_size=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -10,7 +10,7 @@ from doctr.datasets import DataLoader
 from doctr.transforms import Resize
 
 
-def _validate_dataset(ds, input_size, batch_size=2, relative_coords=True, class_indices=False):
+def _validate_dataset(ds, input_size, batch_size=2, class_indices=False):
 
     # Fetch one sample
     img, target = ds[0]
@@ -19,8 +19,7 @@ def _validate_dataset(ds, input_size, batch_size=2, relative_coords=True, class_
     assert img.dtype == tf.float32
     assert isinstance(target, dict)
     assert isinstance(target['boxes'], np.ndarray)
-    if relative_coords:
-        assert np.all((target['boxes'][:, :4] <= 1) & (target['boxes'][:, :4] >= 0))
+    assert np.all((target['boxes'][:, :4] <= 1) & (target['boxes'][:, :4] >= 0))
     if class_indices:
         assert isinstance(target['labels'], np.ndarray) and target['labels'].dtype == np.int64
     else:
@@ -245,7 +244,7 @@ def test_svhn(input_size, num_samples, rotate, mock_svhn_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SVHN(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -266,7 +265,7 @@ def test_sroie(input_size, num_samples, rotate, mock_sroie_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SROIE(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -289,7 +288,7 @@ def test_funsd(input_size, num_samples, rotate, mock_funsd_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"FUNSD(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -310,7 +309,7 @@ def test_cord(input_size, num_samples, rotate, mock_cord_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"CORD(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -332,7 +331,7 @@ def test_synthtext(input_size, num_samples, rotate, mock_synthtext_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SynthText(train={True})"
-    _validate_dataset(ds, input_size, relative_coords=False)
+    _validate_dataset(ds, input_size)
 
 
 @pytest.mark.parametrize(
@@ -377,7 +376,7 @@ def test_iiit5k(input_size, num_samples, rotate, mock_iiit5k_dataset):
     assert len(ds) == num_samples
     assert repr(ds) == f"IIIT5K(train={True})"
     img, target = ds[0]
-    _validate_dataset(ds, input_size, batch_size=1, relative_coords=False)
+    _validate_dataset(ds, input_size, batch_size=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -10,7 +10,7 @@ from doctr.datasets import DataLoader
 from doctr.transforms import Resize
 
 
-def _validate_dataset(ds, input_size, batch_size=2, class_indices=False):
+def _validate_dataset(ds, input_size, batch_size=2, class_indices=False, is_polygons=False):
 
     # Fetch one sample
     img, target = ds[0]
@@ -19,7 +19,11 @@ def _validate_dataset(ds, input_size, batch_size=2, class_indices=False):
     assert img.dtype == tf.float32
     assert isinstance(target, dict)
     assert isinstance(target['boxes'], np.ndarray)
-    assert np.all((target['boxes'][:, :4] <= 1) & (target['boxes'][:, :4] >= 0))
+    if is_polygons:
+        assert target['boxes'].ndim == 3 and target['boxes'].shape[1:] == (4, 2)
+    else:
+        assert target['boxes'].ndim == 2 and target['boxes'].shape[1:] == (4,)
+    assert np.all(np.logical_and(target['boxes'] <= 1, target['boxes'] >= 0))
     if class_indices:
         assert isinstance(target['labels'], np.ndarray) and target['labels'].dtype == np.int64
     else:
@@ -104,32 +108,20 @@ def test_recognition_dataset(mock_image_folder, mock_recognition_label):
     move(os.path.join(ds.root, "tmp_file"), os.path.join(ds.root, img_name))
 
 
-def test_ocrdataset(mock_ocrdataset):
+@pytest.mark.parametrize(
+    "use_polygons", [False, True],
+)
+def test_ocrdataset(mock_ocrdataset, use_polygons):
 
     input_size = (512, 512)
 
     ds = datasets.OCRDataset(
         *mock_ocrdataset,
         img_transforms=Resize(input_size),
+        use_polygons=use_polygons,
     )
     assert len(ds) == 3
-    img, target = ds[0]
-    assert isinstance(img, tf.Tensor)
-    assert img.dtype == tf.float32
-    assert img.shape[:2] == input_size
-    # Bounding boxes
-    assert isinstance(target['boxes'], np.ndarray) and target['boxes'].dtype == np.float32
-    assert np.all(np.logical_and(target['boxes'][:, :4] >= 0, target['boxes'][:, :4] <= 1))
-    assert target['boxes'].shape[1] == 5
-    # Flags
-    assert isinstance(target['labels'], list) and all(isinstance(s, str) for s in target['labels'])
-    # Cardinality consistency
-    assert target['boxes'].shape[0] == len(target['labels'])
-
-    loader = DataLoader(ds, batch_size=2)
-    images, targets = next(iter(loader))
-    assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
-    assert isinstance(targets, list) and all(isinstance(elt, dict) for elt in targets)
+    _validate_dataset(ds, input_size, is_polygons=use_polygons)
 
     # File existence check
     img_name, _ = ds.data[0]
@@ -211,19 +203,7 @@ def test_ic13_dataset(mock_ic13, num_samples, rotate):
     )
 
     assert len(ds) == num_samples
-    img, target = ds[0]
-    assert isinstance(img, tf.Tensor)
-    assert img.shape[:2] == input_size
-    assert img.dtype == tf.float32
-    assert isinstance(target, dict)
-    assert isinstance(target['boxes'], np.ndarray) and np.all((target['boxes'] <= 1) & (target['boxes'] >= 0))
-    assert isinstance(target['labels'], list) and all(isinstance(s, str) for s in target['labels'])
-    assert len(target['labels']) == len(target['boxes'])
-
-    loader = DataLoader(ds, batch_size=2)
-    images, targets = next(iter(loader))
-    assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
-    assert isinstance(targets, list) and all(isinstance(elt, dict) for elt in targets)
+    _validate_dataset(ds, input_size, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -244,7 +224,7 @@ def test_svhn(input_size, num_samples, rotate, mock_svhn_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SVHN(train={True})"
-    _validate_dataset(ds, input_size)
+    _validate_dataset(ds, input_size, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -265,7 +245,7 @@ def test_sroie(input_size, num_samples, rotate, mock_sroie_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SROIE(train={True})"
-    _validate_dataset(ds, input_size)
+    _validate_dataset(ds, input_size, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -288,7 +268,7 @@ def test_funsd(input_size, num_samples, rotate, mock_funsd_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"FUNSD(train={True})"
-    _validate_dataset(ds, input_size)
+    _validate_dataset(ds, input_size, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -309,7 +289,7 @@ def test_cord(input_size, num_samples, rotate, mock_cord_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"CORD(train={True})"
-    _validate_dataset(ds, input_size)
+    _validate_dataset(ds, input_size, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -331,7 +311,7 @@ def test_synthtext(input_size, num_samples, rotate, mock_synthtext_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SynthText(train={True})"
-    _validate_dataset(ds, input_size)
+    _validate_dataset(ds, input_size, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -353,7 +333,7 @@ def test_artefact_detection(input_size, num_samples, rotate, mock_doc_artefacts)
 
     assert len(ds) == num_samples
     assert repr(ds) == f"DocArtefacts(train={True})"
-    _validate_dataset(ds, input_size, class_indices=True)
+    _validate_dataset(ds, input_size, class_indices=True, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -376,7 +356,7 @@ def test_iiit5k(input_size, num_samples, rotate, mock_iiit5k_dataset):
     assert len(ds) == num_samples
     assert repr(ds) == f"IIIT5K(train={True})"
     img, target = ds[0]
-    _validate_dataset(ds, input_size, batch_size=1)
+    _validate_dataset(ds, input_size, batch_size=1, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -398,7 +378,7 @@ def test_svt(input_size, num_samples, rotate, mock_svt_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"SVT(train={True})"
-    _validate_dataset(ds, input_size)
+    _validate_dataset(ds, input_size, is_polygons=rotate)
 
 
 @pytest.mark.parametrize(
@@ -419,4 +399,4 @@ def test_ic03(input_size, num_samples, rotate, mock_ic03_dataset):
 
     assert len(ds) == num_samples
     assert repr(ds) == f"IC03(train={True})"
-    _validate_dataset(ds, input_size)
+    _validate_dataset(ds, input_size, is_polygons=rotate)


### PR DESCRIPTION
Following up on #750, this PR introduces the following modifications:
- adds a pre_transforms mechanism to perform conversion before any transformation
- adds a abs coord to rel coords function (for both boxes & polygons)
- uses both of these to switch all geometry targets to relative coords
- adds corresponding unittests
- fixed FUNSD when `use_polygons=True`
- fixed `OCRDataset` straight boxes
- added option `use_polygons` in `OCRDataset`

Overrules #702 (cc @felixdittrich92)

Any feedback is welcome!