### PR TITLE
refacto: tensorflow rotate transform uses PIL instead of tfa rotate function

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -297,7 +297,7 @@ class _DBNet:
                 abs_boxes[:, :, 1] *= output_shape[-2]
                 polys = abs_boxes
                 boxes_size = np.linalg.norm(abs_boxes[:, 2, :] - abs_boxes[:, 0, :], axis=-1)
-                abs_boxes = np.concatenate((abs_boxes.min(1), abs_boxes.max(1)), -1)
+                abs_boxes = np.concatenate((abs_boxes.min(1), abs_boxes.max(1)), -1).round().astype(np.int32)
             else:
                 abs_boxes[:, [0, 2]] *= output_shape[-1]
                 abs_boxes[:, [1, 3]] *= output_shape[-2]


### PR DESCRIPTION
This PR replaces the rotation function inside the tensorflow rotate function:
The tfa _`rotate`_ doesn't include the `expand` arg, and the manual computation of the padding leads to strange errors when angles are high, it is easier to replace it by the PIL _`rotate`_ which includes the `expand` parameter, it is the function used by torchvision.

Any feedback is welcome!