### PR TITLE
fix: Fixed rotation of img + target

### DIFF
--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -50,18 +50,19 @@ def rotate_sample(
         A tuple of rotated img (tensor), rotated geometries of shape (N, 4, 2)
     """
     rotated_img = F.rotate(img, angle=angle, fill=0, expand=expand)  # Interpolation NEAREST by default
-
+    rotated_img = rotated_img[:3]  # when expand=True, it expands to RGBA channels
     # Get absolute coords
     _geoms = deepcopy(geoms)
-    if np.max(_geoms) <= 1:
-        if _geoms.shape[1:] == (4,):
+    if _geoms.shape[1:] == (4,):
+        if np.max(_geoms) <= 1:
             _geoms[:, [0, 2]] *= img.shape[-1]
             _geoms[:, [1, 3]] *= img.shape[-2]
-        elif _geoms.shape[1:] == (4, 2):
+    elif _geoms.shape[1:] == (4, 2):
+        if np.max(_geoms) <= 1:
             _geoms[..., 0] *= img.shape[-1]
             _geoms[..., 1] *= img.shape[-2]
-        else:
-            raise AssertionError("invalid format for arg `geoms`")
+    else:
+        raise AssertionError("invalid format for arg `geoms`")
 
     # Rotate the boxes: xmin, ymin, xmax, ymax or polygons --> (4, 2) polygon
     rotated_geoms = rotate_abs_geoms(_geoms, angle, img.shape[1:], expand).astype(np.float32)  # type: ignore[arg-type]

--- a/doctr/transforms/functional/pytorch.py
+++ b/doctr/transforms/functional/pytorch.py
@@ -10,11 +10,11 @@ import numpy as np
 import torch
 from torchvision.transforms import functional as F
 
-from doctr.utils.geometry import rotate_abs_boxes
+from doctr.utils.geometry import rotate_abs_geoms
 
 from .base import crop_boxes
 
-__all__ = ["invert_colors", "rotate", "crop_detection"]
+__all__ = ["invert_colors", "rotate_sample", "crop_detection"]
 
 
 def invert_colors(img: torch.Tensor, min_val: float = 0.6) -> torch.Tensor:
@@ -32,9 +32,9 @@ def invert_colors(img: torch.Tensor, min_val: float = 0.6) -> torch.Tensor:
     return out
 
 
-def rotate(
+def rotate_sample(
     img: torch.Tensor,
-    boxes: np.ndarray,
+    geoms: np.ndarray,
     angle: float,
     expand: bool = False,
 ) -> Tuple[torch.Tensor, np.ndarray]:
@@ -42,29 +42,35 @@ def rotate(
 
     Args:
         img: image to rotate
-        boxes: array of boxes to rotate as well
+        geoms: array of geometries of shape (N, 4) or (N, 4, 2)
         angle: angle in degrees. +: counter-clockwise, -: clockwise
         expand: whether the image should be padded before the rotation
 
     Returns:
-        A tuple of rotated img (tensor), rotated boxes (np array)
+        A tuple of rotated img (tensor), rotated geometries of shape (N, 4, 2)
     """
     rotated_img = F.rotate(img, angle=angle, fill=0, expand=expand)  # Interpolation NEAREST by default
 
     # Get absolute coords
-    _boxes = deepcopy(boxes)
-    if np.max(_boxes) <= 1:
-        _boxes[:, [0, 2]] = _boxes[:, [0, 2]] * img.shape[2]
-        _boxes[:, [1, 3]] = _boxes[:, [1, 3]] * img.shape[1]
+    _geoms = deepcopy(geoms)
+    if np.max(_geoms) <= 1:
+        if _geoms.shape[1:] == (4,):
+            _geoms[:, [0, 2]] *= img.shape[-1]
+            _geoms[:, [1, 3]] *= img.shape[-2]
+        elif _geoms.shape[1:] == (4, 2):
+            _geoms[..., 0] *= img.shape[-1]
+            _geoms[..., 1] *= img.shape[-2]
+        else:
+            raise AssertionError("invalid format for arg `geoms`")
 
     # Rotate the boxes: xmin, ymin, xmax, ymax or polygons --> (4, 2) polygon
-    r_boxes = rotate_abs_boxes(_boxes, angle, img.shape[1:], expand).astype(np.float32)  # type: ignore[arg-type]
+    rotated_geoms = rotate_abs_geoms(_geoms, angle, img.shape[1:], expand).astype(np.float32)  # type: ignore[arg-type]
 
     # Always return relative boxes to avoid label confusions when resizing is performed aferwards
-    r_boxes[..., 0] = r_boxes[..., 0] / rotated_img.shape[2]
-    r_boxes[..., 1] = r_boxes[..., 1] / rotated_img.shape[1]
+    rotated_geoms[..., 0] = rotated_geoms[..., 0] / rotated_img.shape[2]
+    rotated_geoms[..., 1] = rotated_geoms[..., 1] / rotated_img.shape[1]
 
-    return rotated_img, r_boxes
+    return rotated_img, rotated_geoms
 
 
 def crop_detection(

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -51,7 +51,7 @@ def rotated_img_tensor(img: tf.Tensor, angle: float, expand: bool = False) -> tf
         h_diff, w_diff = int(math.ceil(exp_h - img.shape[0])), int(math.ceil(exp_w - img.shape[1]))
         h_pad, w_pad = max(h_diff, 0), max(w_diff, 0)
         exp_img = tf.pad(img, tf.constant([[h_pad // 2, h_pad - h_pad // 2], [w_pad // 2, w_pad - w_pad // 2], [0, 0]]))
-        h_crop, w_crop = int(max(exp_img.shape[0] - exp_h, 0)), int(min(exp_img.shape[1] - exp_w, 0))
+        h_crop, w_crop = int(round(max(exp_img.shape[0] - exp_h, 0))), int(round(min(exp_img.shape[1] - exp_w, 0)))
     else:
         exp_img = img
     # Rotate the padded image
@@ -87,15 +87,16 @@ def rotate_sample(
 
     # Get absolute coords
     _geoms = deepcopy(geoms)
-    if np.max(_geoms) <= 1:
-        if _geoms.shape[1:] == (4,):
+    if _geoms.shape[1:] == (4,):
+        if np.max(_geoms) <= 1:
             _geoms[:, [0, 2]] *= img.shape[1]
             _geoms[:, [1, 3]] *= img.shape[0]
-        elif _geoms.shape[1:] == (4, 2):
+    elif _geoms.shape[1:] == (4, 2):
+        if np.max(_geoms) <= 1:
             _geoms[..., 0] *= img.shape[1]
             _geoms[..., 1] *= img.shape[0]
-        else:
-            raise AssertionError
+    else:
+        raise AssertionError
 
     # Rotate the boxes: xmin, ymin, xmax, ymax or polygons --> (4, 2) polygon
     rotated_geoms = rotate_abs_geoms(_geoms, angle, img.shape[:-1], expand).astype(np.float32)

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -11,11 +11,11 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_addons as tfa
 
-from doctr.utils.geometry import compute_expanded_shape, rotate_abs_boxes
+from doctr.utils.geometry import compute_expanded_shape, rotate_abs_geoms
 
 from .base import crop_boxes
 
-__all__ = ["invert_colors", "rotate", "crop_detection"]
+__all__ = ["invert_colors", "rotate_sample", "crop_detection"]
 
 
 def invert_colors(img: tf.Tensor, min_val: float = 0.6) -> tf.Tensor:
@@ -33,9 +33,41 @@ def invert_colors(img: tf.Tensor, min_val: float = 0.6) -> tf.Tensor:
     return out
 
 
-def rotate(
+def rotated_img_tensor(img: tf.Tensor, angle: float, expand: bool = False) -> tf.Tensor:
+    """Rotate image around the center, interpolation=NEAREST, pad with 0 (black)
+
+    Args:
+        img: image to rotate
+        angle: angle in degrees. +: counter-clockwise, -: clockwise
+        expand: whether the image should be padded before the rotation
+
+    Returns:
+        the rotated image (tensor)
+    """
+    # Compute the expanded padding
+    h_crop, w_crop = 0, 0
+    if expand:
+        exp_h, exp_w = compute_expanded_shape(img.shape[:-1], angle)
+        h_diff, w_diff = int(math.ceil(exp_h - img.shape[0])), int(math.ceil(exp_w - img.shape[1]))
+        h_pad, w_pad = max(h_diff, 0), max(w_diff, 0)
+        exp_img = tf.pad(img, tf.constant([[h_pad // 2, h_pad - h_pad // 2], [w_pad // 2, w_pad - w_pad // 2], [0, 0]]))
+        h_crop, w_crop = int(max(exp_img.shape[0] - exp_h, 0)), int(min(exp_img.shape[1] - exp_w, 0))
+    else:
+        exp_img = img
+    # Rotate the padded image
+    rotated_img = tfa.image.rotate(exp_img, angle * math.pi / 180)  # Interpolation NEAREST by default
+    # Crop the rest
+    if h_crop > 0 or w_crop > 0:
+        h_slice = slice(h_crop // 2, -h_crop // 2) if h_crop > 0 else slice(rotated_img.shape[0])
+        w_slice = slice(-w_crop // 2, -w_crop // 2) if w_crop > 0 else slice(rotated_img.shape[1])
+        rotated_img = rotated_img[h_slice, w_slice]
+
+    return rotated_img
+
+
+def rotate_sample(
     img: tf.Tensor,
-    boxes: np.ndarray,
+    geoms: np.ndarray,
     angle: float,
     expand: bool = False,
 ) -> Tuple[tf.Tensor, np.ndarray]:
@@ -43,39 +75,36 @@ def rotate(
 
     Args:
         img: image to rotate
-        boxes: array of boxes to rotate as well
+        geoms: array of geometries of shape (N, 4) or (N, 4, 2)
         angle: angle in degrees. +: counter-clockwise, -: clockwise
         expand: whether the image should be padded before the rotation
 
     Returns:
         A tuple of rotated img (tensor), rotated boxes (np array)
     """
-    # Compute the expanded padding
-    if expand:
-        exp_shape = compute_expanded_shape(img.shape[:-1], angle)
-        h_pad, w_pad = int(math.ceil(exp_shape[0] - img.shape[0])), int(math.ceil(exp_shape[1] - img.shape[1]))
-        if min(h_pad, w_pad) < 0:
-            h_pad, w_pad = int(math.ceil(exp_shape[1] - img.shape[0])), int(math.ceil(exp_shape[0] - img.shape[1]))
-        exp_img = tf.pad(img, tf.constant([[h_pad // 2, h_pad - h_pad // 2], [w_pad // 2, w_pad - w_pad // 2], [0, 0]]))
-    else:
-        exp_img = img
-    # Rotate the padded image
-    rotated_img = tfa.image.rotate(exp_img, angle * math.pi / 180)  # Interpolation NEAREST by default
+    # Rotated the image
+    rotated_img = rotated_img_tensor(img, angle, expand)
 
     # Get absolute coords
-    _boxes = deepcopy(boxes)
-    if np.max(_boxes) <= 1:
-        _boxes[:, [0, 2]] = _boxes[:, [0, 2]] * img.shape[1]
-        _boxes[:, [1, 3]] = _boxes[:, [1, 3]] * img.shape[0]
+    _geoms = deepcopy(geoms)
+    if np.max(_geoms) <= 1:
+        if _geoms.shape[1:] == (4,):
+            _geoms[:, [0, 2]] *= img.shape[1]
+            _geoms[:, [1, 3]] *= img.shape[0]
+        elif _geoms.shape[1:] == (4, 2):
+            _geoms[..., 0] *= img.shape[1]
+            _geoms[..., 1] *= img.shape[0]
+        else:
+            raise AssertionError
 
     # Rotate the boxes: xmin, ymin, xmax, ymax or polygons --> (4, 2) polygon
-    r_boxes = rotate_abs_boxes(_boxes, angle, img.shape[:-1], expand).astype(np.float32)
+    rotated_geoms = rotate_abs_geoms(_geoms, angle, img.shape[:-1], expand).astype(np.float32)
 
     # Always return relative boxes to avoid label confusions when resizing is performed aferwards
-    r_boxes[..., 0] = r_boxes[..., 0] / rotated_img.shape[1]
-    r_boxes[..., 1] = r_boxes[..., 1] / rotated_img.shape[0]
+    rotated_geoms[..., 0] = rotated_geoms[..., 0] / rotated_img.shape[1]
+    rotated_geoms[..., 1] = rotated_geoms[..., 1] / rotated_img.shape[0]
 
-    return rotated_img, r_boxes
+    return rotated_img, rotated_geoms
 
 
 def crop_detection(

--- a/doctr/transforms/modules/base.py
+++ b/doctr/transforms/modules/base.py
@@ -155,7 +155,7 @@ class RandomRotate(NestedObject):
 
     def __call__(self, img: Any, target: np.ndarray) -> Tuple[Any, np.ndarray]:
         angle = random.uniform(-self.max_angle, self.max_angle)
-        r_img, r_boxes = F.rotate(img, target, angle, self.expand)
+        r_img, r_boxes = F.rotate_sample(img, target, angle, self.expand)
         return r_img, r_boxes
 
 

--- a/doctr/transforms/modules/base.py
+++ b/doctr/transforms/modules/base.py
@@ -155,8 +155,10 @@ class RandomRotate(NestedObject):
 
     def __call__(self, img: Any, target: np.ndarray) -> Tuple[Any, np.ndarray]:
         angle = random.uniform(-self.max_angle, self.max_angle)
-        r_img, r_boxes = F.rotate_sample(img, target, angle, self.expand)
-        return r_img, r_boxes
+        r_img, r_polys = F.rotate_sample(img, target, angle, self.expand)
+        # Removes deleted boxes
+        is_kept = (r_polys.max(1) > r_polys.min(1)).sum(1) == 2
+        return r_img, r_polys[is_kept]
 
 
 class RandomCrop(NestedObject):

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -88,7 +88,10 @@ def test_rotate_sample():
     boxes = np.array([0, 0, 100, 200])[None, ...]
     polys = np.stack((boxes[..., [0, 1]], boxes[..., [2, 1]], boxes[..., [2, 3]], boxes[..., [0, 3]]), axis=1)
     rel_boxes = np.array([0, 0, 1, 1], dtype=np.float32)[None, ...]
-    rel_polys = np.stack((rel_boxes[..., [0, 1]], rel_boxes[..., [2, 1]], rel_boxes[..., [2, 3]], rel_boxes[..., [0, 3]]), axis=1)
+    rel_polys = np.stack(
+        (rel_boxes[..., [0, 1]], rel_boxes[..., [2, 1]], rel_boxes[..., [2, 3]], rel_boxes[..., [0, 3]]),
+        axis=1
+    )
 
     # No angle
     rotated_img, rotated_geoms = rotate_sample(img, boxes, 0, False)

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -6,7 +6,7 @@ import torch
 
 from doctr.transforms import (ChannelShuffle, ColorInversion, GaussianNoise, RandomCrop, RandomHorizontalFlip,
                               RandomRotate, Resize)
-from doctr.transforms.functional import crop_detection, rotate
+from doctr.transforms.functional import crop_detection, rotate_sample
 
 
 def test_resize():
@@ -83,32 +83,50 @@ def test_invert_colorize(rgb_min):
     assert out.dtype == torch.float16
 
 
-def test_rotate():
-    input_t = torch.ones((3, 50, 50), dtype=torch.float32)
-    boxes = np.array([
-        [15, 20, 35, 30]
-    ])
-    r_img, r_boxes = rotate(input_t, boxes, angle=12., expand=False)
-    assert r_img.shape == (3, 50, 50)
-    assert r_img[0, 0, 0] == 0.
+def test_rotate_sample():
+    img = torch.ones((3, 200, 100), dtype=torch.float32)
+    boxes = np.array([0, 0, 100, 200])[None, ...]
+    polys = np.stack((boxes[..., [0, 1]], boxes[..., [2, 1]], boxes[..., [2, 3]], boxes[..., [0, 3]]), axis=1)
+    rel_boxes = np.array([0, 0, 1, 1], dtype=np.float32)[None, ...]
+    rel_polys = np.stack((rel_boxes[..., [0, 1]], rel_boxes[..., [2, 1]], rel_boxes[..., [2, 3]], rel_boxes[..., [0, 3]]), axis=1)
 
-    # Expand
-    r_img, r_boxes = rotate(input_t, boxes, angle=12., expand=True)
-    assert r_img.shape == (3, 60, 60)
-    # With the expansion, there should be a maximum of 1 pixel of the initial image on the first row
-    assert r_img[0, 0, :].sum() <= 1
+    # No angle
+    rotated_img, rotated_geoms = rotate_sample(img, boxes, 0, False)
+    assert torch.all(rotated_img == img) and np.all(rotated_geoms == rel_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, boxes, 0, True)
+    assert torch.all(rotated_img == img) and np.all(rotated_geoms == rel_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, polys, 0, False)
+    assert torch.all(rotated_img == img) and np.all(rotated_geoms == rel_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, polys, 0, True)
+    assert torch.all(rotated_img == img) and np.all(rotated_geoms == rel_polys)
 
-    # Relative coords
-    rel_boxes = np.array([[.3, .4, .7, .6]])
-    r_img, r_boxes = rotate(input_t, rel_boxes, angle=90)
-    assert r_boxes.shape == (1, 4, 2)
-    assert np.isclose(r_boxes, np.asarray([[[0.4, 0.7], [0.4, 0.3], [0.6, 0.3], [0.6, 0.7]]])).all()
+    # No expansion
+    expected_img = torch.zeros((3, 200, 100), dtype=torch.float32)
+    expected_img[:, 50: 150] = 1
+    expected_polys = np.array([[0, .75], [0, .25], [1, .25], [1, .75]])[None, ...]
+    rotated_img, rotated_geoms = rotate_sample(img, boxes, 90, False)
+    assert torch.all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, polys, 90, False)
+    assert torch.all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, rel_boxes, 90, False)
+    assert torch.all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, rel_polys, 90, False)
+    assert torch.all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
 
-    # FP16 (only on GPU)
-    if torch.cuda.is_available():
-        input_t = torch.ones((3, 50, 50), dtype=torch.float16).cuda()
-        r_img, _ = rotate(input_t, boxes, angle=12.)
-        assert r_img.dtype == torch.float16
+    # Expansion
+    expected_img = torch.ones((3, 100, 200), dtype=torch.float32)
+    expected_polys = np.array([[0, 1], [0, 0], [1, 0], [1, 1]], dtype=np.float32)[None, ...]
+    rotated_img, rotated_geoms = rotate_sample(img, boxes, 90, True)
+    assert torch.all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, polys, 90, True)
+    assert torch.all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, rel_boxes, 90, True)
+    assert torch.all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, rel_polys, 90, True)
+    assert torch.all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+
+    with pytest.raises(AssertionError):
+        rotate_sample(img, boxes[None, ...], 90, False)
 
 
 def test_random_rotate():

--- a/tests/tensorflow/test_transforms_tf.py
+++ b/tests/tensorflow/test_transforms_tf.py
@@ -5,7 +5,7 @@ import pytest
 import tensorflow as tf
 
 from doctr import transforms as T
-from doctr.transforms.functional import crop_detection, rotate
+from doctr.transforms.functional import crop_detection, rotate_sample
 
 
 def test_resize():
@@ -230,32 +230,52 @@ def test_jpegquality():
     assert out.dtype == tf.float16
 
 
-def test_rotate():
-    input_t = tf.ones((50, 50, 3), dtype=tf.float32)
-    boxes = np.array([
-        [15, 20, 35, 30]
-    ])
-    r_img, r_boxes = rotate(input_t, boxes, angle=12., expand=False)
-    assert r_img.shape == (50, 50, 3)
-    assert r_img[0, 0, 0] == 0.
-    assert r_boxes.shape == (1, 4, 2)
+def test_rotate_sample():
+    img = tf.ones((200, 100, 3), dtype=tf.float32)
+    boxes = np.array([0, 0, 100, 200])[None, ...]
+    polys = np.stack((boxes[..., [0, 1]], boxes[..., [2, 1]], boxes[..., [2, 3]], boxes[..., [0, 3]]), axis=1)
+    rel_boxes = np.array([0, 0, 1, 1], dtype=np.float32)[None, ...]
+    rel_polys = np.stack((rel_boxes[..., [0, 1]], rel_boxes[..., [2, 1]], rel_boxes[..., [2, 3]], rel_boxes[..., [0, 3]]), axis=1)
 
-    # Expand
-    r_img, r_boxes = rotate(input_t, boxes, angle=12., expand=True)
-    assert r_img.shape == (60, 60, 3)
-    # With the expansion, there should be a maximum of 1 pixel of the initial image on the first row
-    assert r_img[0, :, 0].numpy().sum() <= 1
+    # No angle
+    rotated_img, rotated_geoms = rotate_sample(img, boxes, 0, False)
+    assert tf.math.reduce_all(rotated_img == img) and np.all(rotated_geoms == rel_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, boxes, 0, True)
+    assert tf.math.reduce_all(rotated_img == img) and np.all(rotated_geoms == rel_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, polys, 0, False)
+    assert tf.math.reduce_all(rotated_img == img) and np.all(rotated_geoms == rel_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, polys, 0, True)
+    assert tf.math.reduce_all(rotated_img == img) and np.all(rotated_geoms == rel_polys)
 
-    # Relative coords
-    rel_boxes = np.array([[.3, .4, .7, .6]])
-    r_img, r_boxes = rotate(input_t, rel_boxes, angle=90)
-    assert r_boxes.shape == (1, 4, 2)
-    assert np.isclose(r_boxes, np.asarray([[[0.4, 0.7], [0.4, 0.3], [0.6, 0.3], [0.6, 0.7]]])).all()
+    # No expansion
+    expected_img = np.zeros((200, 100, 3), dtype=np.float32)
+    expected_img[50: 150] = 1
+    expected_img = tf.convert_to_tensor(expected_img)
+    expected_polys = np.array([[0, .75], [0, .25], [1, .25], [1, .75]])[None, ...]
+    rotated_img, rotated_geoms = rotate_sample(img, boxes, 90, False)
+    assert tf.math.reduce_all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, polys, 90, False)
+    assert tf.math.reduce_all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, rel_boxes, 90, False)
+    assert tf.math.reduce_all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, rel_polys, 90, False)
+    assert tf.math.reduce_all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
 
-    # FP16
-    input_t = tf.ones((50, 50, 3), dtype=tf.float16)
-    r_img, _ = rotate(input_t, boxes, angle=12.)
-    assert r_img.dtype == tf.float16
+    # Expansion
+    expected_img = tf.ones((100, 200, 3), dtype=tf.float32)
+    expected_polys = np.array([[0, 1], [0, 0], [1, 0], [1, 1]], dtype=np.float32)[None, ...]
+    rotated_img, rotated_geoms = rotate_sample(img, boxes, 90, True)
+    # import ipdb; ipdb.set_trace()
+    assert tf.math.reduce_all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, polys, 90, True)
+    assert tf.math.reduce_all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, rel_boxes, 90, True)
+    assert tf.math.reduce_all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+    rotated_img, rotated_geoms = rotate_sample(img, rel_polys, 90, True)
+    assert tf.math.reduce_all(rotated_img == expected_img) and np.all(rotated_geoms == expected_polys)
+
+    with pytest.raises(AssertionError):
+        rotate_sample(img, boxes[None, ...], 90, False)
 
 
 def test_random_rotate():

--- a/tests/tensorflow/test_transforms_tf.py
+++ b/tests/tensorflow/test_transforms_tf.py
@@ -235,7 +235,10 @@ def test_rotate_sample():
     boxes = np.array([0, 0, 100, 200])[None, ...]
     polys = np.stack((boxes[..., [0, 1]], boxes[..., [2, 1]], boxes[..., [2, 3]], boxes[..., [0, 3]]), axis=1)
     rel_boxes = np.array([0, 0, 1, 1], dtype=np.float32)[None, ...]
-    rel_polys = np.stack((rel_boxes[..., [0, 1]], rel_boxes[..., [2, 1]], rel_boxes[..., [2, 3]], rel_boxes[..., [0, 3]]), axis=1)
+    rel_polys = np.stack(
+        (rel_boxes[..., [0, 1]], rel_boxes[..., [2, 1]], rel_boxes[..., [2, 3]], rel_boxes[..., [0, 3]]),
+        axis=1
+    )
 
     # No angle
     rotated_img, rotated_geoms = rotate_sample(img, boxes, 0, False)


### PR DESCRIPTION
Following the refactoring of rotation, some edge cases weren't handled. This PR restarts fresh and introduces the following modifications:
- deleted `rotate` to introduce `rotate_sample`
- the function can take boxes or polygons, with or without expansion
- unittests were considerably extended to avoid further issues
- added box filtering in `RandomRotate`

Here is a snippet to show this:
```python
from doctr.transforms.functional import rotate_sample
import matplotlib.pyplot as plt
import numpy as np
import torch

# Get the inputs
img = torch.ones((3, 200, 100), dtype=torch.float32)
h, w = img.shape[1:]
box = np.array([0, 0, .5, .25])[None, ...]
target = np.zeros((*img.shape[1:], 3), dtype=np.uint8)
for xmin, ymin, xmax, ymax in box:
    target[int(ymin * h): int(ymax * h), int(xmin * w): int(xmax * w)] = (255, 255, 255)

# Rotate without expansion
out_img, out_poly = rotate_sample(img, box, 90, expand=False)
h, w = out_img.shape[1:]
# Make an image for the target
out_target = np.zeros((*out_img.shape[1:], 3), dtype=np.uint8)
out_box = np.concatenate((out_poly.min(1), out_poly.max(1)), -1)
for xmin, ymin, xmax, ymax in out_box:
    out_target[int(ymin * h): int(ymax * h), int(xmin * w): int(xmax * w)] = (255, 255, 255)

# Rotate with expansion
exp_img, exp_poly = rotate_sample(img, box, 90, expand=True)
h, w = exp_img.shape[1:]
exp_target = np.zeros((*exp_img.shape[1:], 3), dtype=np.uint8)
exp_box = np.concatenate((exp_poly.min(1), exp_poly.max(1)), -1)
for xmin, ymin, xmax, ymax in exp_box:
    exp_target[int(ymin * h): int(ymax * h), int(xmin * w): int(xmax * w)] = (255, 255, 255)

_, axes = plt.subplots(2, 3)
# First col = Inputs
axes[0, 0].imshow(img.permute(1, 2, 0).numpy())
axes[1, 0].imshow(target)
# 2nd col = no expansion
axes[0, 1].imshow(out_img.permute(1, 2, 0).numpy())
axes[1, 1].imshow(out_target)
# 3rd col = expansion
axes[0, 2].imshow(exp_img.permute(1, 2, 0).numpy())
axes[1, 2].imshow(exp_target)

plt.show()
```

which produces:
![rotate_fix](https://user-images.githubusercontent.com/76527547/148101449-9edcfb42-8411-4ff4-9f53-0af85f38d4e2.png)

top row = image
bot row = target
1st col = original
2nd col = 90° rotation without expansion
3rd col = 90° rotation with expansion

(without expansion, the box is out of the image)



Any feedback is welcome!