### PR TITLE
ci: Fixed PR label check job

### DIFF
--- a/.github/verify_pr_labels.py
+++ b/.github/verify_pr_labels.py
@@ -7,8 +7,7 @@ Note: we ping the merger only, not the reviewers, as the reviewers can sometimes
 with no labeling responsibility, so we don't want to bother them.
 """
 
-import sys
-from typing import Any, Optional, Set, Tuple
+from typing import Any, Set, Tuple
 
 import requests
 
@@ -51,30 +50,18 @@ def query_repo(cmd: str, *, accept) -> Any:
     return response.json()
 
 
-def get_pr_number(commit_hash: str) -> Optional[int]:
-    # See https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
-    data = query_repo(f"commits/{commit_hash}/pulls", accept="application/vnd.github.groot-preview+json")
-    if not data:
-        return None
-    return data[0]["number"]
-
-
 def get_pr_merger_and_labels(pr_number: int) -> Tuple[str, Set[str]]:
     # See https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
     data = query_repo(f"pulls/{pr_number}", accept="application/vnd.github.v3+json")
-    merger = data["merged_by"]["login"]
+    merger = data.get("merged_by", {}).get("login")
     labels = {label["name"] for label in data["labels"]}
     return merger, labels
 
 
 def main(args):
-    pr_number = get_pr_number(args.commit_hash)
-    if not pr_number:
-        sys.exit(0)
-
-    merger, labels = get_pr_merger_and_labels(pr_number)
+    merger, labels = get_pr_merger_and_labels(args.pr)
     is_properly_labeled = bool(PRIMARY_LABELS.intersection(labels) and SECONDARY_LABELS.intersection(labels))
-    if not is_properly_labeled:
+    if isinstance(merger, str) and not is_properly_labeled:
         print(f"@{merger}")
 
 
@@ -83,7 +70,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='PR label checker',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    parser.add_argument('commit_hash', type=str, help='Hash of the commit')
+    parser.add_argument('pr', type=int, help='PR number')
     args = parser.parse_args()
 
     return args

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,33 +1,28 @@
 name: pr-labels
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    branches: main
+    types: closed
 
 jobs:
   is-properly-labeled:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Set up python
-        uses: actions/setup-python@v2
-
-      - name: Install requests
-        run: pip install requests
-
       - name: Checkout repository
         uses: actions/checkout@v2
-
+      - name: Set up python
+        uses: actions/setup-python@v2
+      - name: Install requests
+        run: pip install requests
       - name: Process commit and find merger responsible for labeling
         id: commit
-        run: echo "::set-output name=merger::$(python .github/process_commit.py ${{ github.sha }})"
-
-      - name: Ping merger responsible for labeling if necessary
+        run: echo "::set-output name=merger::$(python .github/verify_labels.py ${{ github.event.pull_request.number }})"
+      - name: 'Comment PR'
+        uses: actions/github-script@0.3.0
         if: ${{ steps.commit.outputs.merger != '' }}
-        uses: mshick/add-pr-comment@v1
         with:
-          repo_token: ${{ secrets.SSH_DEPLOY_KEY }}
-          message: |
-            Hey ${{ steps.commit.outputs.merger }}!
-            You merged this PR, but no labels were added. The list of valid labels is available at https://github.com/mindee/doctr/blob/main/.github/process_commit.py
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: 'Hey ${{ steps.commit.outputs.merger }} 👋\nYou merged this PR, but it isn't correctly labeled. The list of valid labels is available at https://github.com/mindee/doctr/blob/main/.github/verify_labels.py' });

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   is-properly-labeled:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -25,4 +26,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            github.issues.createComment({ issue_number, owner, repo, body: 'Hey ${{ steps.commit.outputs.merger }} 👋\nYou merged this PR, but it isn't correctly labeled. The list of valid labels is available at https://github.com/mindee/doctr/blob/main/.github/verify_labels.py' });
+            github.issues.createComment({ issue_number, owner, repo, body: 'Hey ${{ steps.commit.outputs.merger }} 👋\nYou merged this PR, but it is not correctly labeled. The list of valid labels is available at https://github.com/mindee/doctr/blob/main/.github/verify_labels.py' });


### PR DESCRIPTION
In order to better automate release notes, this PR fixes the PR label check action.

To illustrate this, I didn't add all required labels to this PR (needs one of the primary labels, AND one of the secondary labels defined in https://github.com/mindee/doctr/blob/pr-labels/.github/verify_pr_labels.py). Once merged, the bot will ping me (since I will merge it) to remind me to correctly label the PR.

Any feedback is welcome!