### PR TITLE
[DRAFT] feat: Added RandomPerspective augmentation

### DIFF
--- a/doctr/transforms/modules/pytorch.py
+++ b/doctr/transforms/modules/pytorch.py
@@ -151,7 +151,11 @@ class RandomPerspective(T.RandomPerspective):
 
             #  Preparing mask
             mask = np.zeros_like(img.permute(1, 2, 0))
-            width, height = F._get_image_size(img)
+
+            if isinstance(img, torch.Tensor):
+                height, width = img.shape[-2:]
+            elif isinstance(img, Image.Image):
+                width, height = img.size
 
             #  Drawing bounding boxes on mask with respective color
             for ind, val in enumerate(target["boxes"]):

--- a/doctr/transforms/modules/pytorch.py
+++ b/doctr/transforms/modules/pytorch.py
@@ -150,12 +150,12 @@ class RandomPerspective(T.RandomPerspective):
             label = []
 
             #  Preparing mask
-            mask = np.zeros_like(img.permute(1, 2, 0))
-
             if isinstance(img, torch.Tensor):
                 height, width = img.shape[-2:]
-            elif isinstance(img, Image.Image):
+                mask = np.zeros_like(img.permute(1, 2, 0))
+            else:
                 width, height = img.size
+                mask = np.zeros_like(img)
 
             #  Drawing bounding boxes on mask with respective color
             for ind, val in enumerate(target["boxes"]):

--- a/doctr/transforms/modules/pytorch.py
+++ b/doctr/transforms/modules/pytorch.py
@@ -140,7 +140,7 @@ class RandomPerspective(T.RandomPerspective):
         fill = self.fill
         if isinstance(img, torch.Tensor):
             if isinstance(fill, (int, float)):
-                fill = [float(fill)] * F._get_image_num_channels(img)
+                fill = [float(fill)] * self._get_num_channels(img)
             else:
                 fill = [float(f) for f in fill]
 
@@ -204,3 +204,10 @@ class RandomPerspective(T.RandomPerspective):
             ddic.update({"boxes": np.array(bbox, dtype=np.float32).reshape(-1, 4), "labels": np.array(label)})
             return new_img, ddic
         return img, target
+
+    @staticmethod
+    def _get_num_channels(img):
+        if img.ndim == 2:
+            return 1
+        elif img.ndim > 2:
+            return img.shape[-3]

--- a/references/obj_detection/train_pytorch.py
+++ b/references/obj_detection/train_pytorch.py
@@ -15,6 +15,7 @@ import time
 import numpy as np
 import torch
 import torch.optim as optim
+import torchvision
 import wandb
 from fastprogress.fastprogress import master_bar, progress_bar
 from torch.optim.lr_scheduler import MultiplicativeLR, StepLR
@@ -239,7 +240,9 @@ def main(args):
             ColorJitter(brightness=0.3, contrast=0.3, saturation=0.3, hue=0.02),
             T.RandomApply(GaussianBlur(kernel_size=(3, 3), sigma=(0.1, 3)), .3),
         ]),
-        sample_transforms=T.RandomHorizontalFlip(p=0.5),
+        sample_transforms=T.SampleCompose([
+            T.RandomPerspective(0.2, 0.5, interpolation=torchvision.transforms.functional.InterpolationMode("nearest")),
+            T.RandomHorizontalFlip(p=0.5)])
     )
     train_loader = DataLoader(
         train_set,

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -280,7 +280,7 @@ def test_randomperspective(p):
     # testing for 2 cases, with transformation probability 1 and 0.
     torch.manual_seed(23)
     transform = RandomPerspective(0.2, p, interpolation=torchvision.transforms.functional.InterpolationMode("nearest"))
-    input_t = torch.ones((3, 32, 32), dtype=torch.float32)
+    input_t = torch.zeros((3, 32, 32), dtype=torch.float32)
     target = {"boxes": np.array([[0., 0., 1., 1.]], dtype=np.float32), "labels": np.ones(1, dtype=np.int64)}
     transformed, _target = transform(input_t, target)
     assert isinstance(transformed, torch.Tensor)
@@ -292,7 +292,6 @@ def test_randomperspective(p):
     assert _target["boxes"].dtype == np.float32
     assert _target["labels"].dtype == np.int64
     if p == 1:
-        print(_target)
         assert np.all(_target["boxes"] == np.array([[0.03125, 0., 0.90625, 0.96875]], dtype=np.float32))
 
     elif p == 0:

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -280,7 +280,9 @@ def test_randomhorizontalflip(p):
     "p, input_image, input_type",
     [
         [1, Image.new('RGB', (32, 32), (0, 0, 0)), Image.Image],
-        [0, torch.zeros((3, 32, 32), dtype=torch.float32), torch.Tensor]
+        [1, torch.zeros((3, 32, 32), dtype=torch.float32), torch.Tensor],
+        [0, torch.zeros((3, 32, 32), dtype=torch.float32), torch.Tensor],
+        [0, Image.new('RGB', (32, 32), (0, 0, 0)), Image.Image]
     ]
 )
 def test_randomperspective(p, input_image, input_type):


### PR DESCRIPTION
This PR introduces the following changes to the existing repo:

>It adds Random Perspective augmentation that transforms the bboxes along with the image.
 
      from doctr.transforms import RandomPerspective
       import torchvision; import numpy as np; import torch
       transformed = RandomPerspective(0.2, 1, interpolation=torchvision.transforms.functional.InterpolationMode("nearest"))
       target = {"boxes": np.array([[0.1, 0.1, 0.4, 0.5] ], dtype= np.float32), "labels": np.ones(1, dtype= np.int64)}
       image, target = transformed(torch.rand((3, 224, 224)), target) 
![2x3_artefact](https://user-images.githubusercontent.com/90187114/148848141-c987667d-6f3b-48b4-b672-0ffb057647ff.jpg)

> It adds unittest for the same. The entire page is taken as a bbox to test the transformation of the image as well as the target bounding boxes

General outline

1.   A mask(with zeros) is computed with the same shape as of the original image
2.    Bboxes are drawn over the mask and filled with respective color for each label (this will be helpful to us in label identification after the transform)
3.    Both mask and original image are transformed
4.    Mask of each label is obtained by filtering the color ranges
5.    Contours of each mask are calculated and later using the extreme points, the new coordinates are obtained

Any feedback is welcome!