### PR TITLE
fix: polygon orientation + line aggregation

### DIFF
--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -74,7 +74,7 @@ def extract_rcrops(
         _boxes[:, :, 0] *= width
         _boxes[:, :, 1] *= height
 
-    src_pts = _boxes[:, 1:].astype(np.float32)
+    src_pts = _boxes[:, :3].astype(np.float32)
     # Preserve size
     d1 = np.linalg.norm(src_pts[:, 0] - src_pts[:, 1], axis=-1)
     d2 = np.linalg.norm(src_pts[:, 1] - src_pts[:, 2], axis=-1)
@@ -216,7 +216,7 @@ def rectify_loc_preds(
     return np.stack(
         [np.roll(
             page_loc_pred,
-            orientation - 1,
+            orientation,
             axis=0) for orientation, page_loc_pred in zip(orientations, page_loc_preds)],
         axis=0
     ) if len(orientations) > 0 else None

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -216,7 +216,7 @@ def rectify_loc_preds(
     return np.stack(
         [np.roll(
             page_loc_pred,
-            orientation,
+            orientation - 1,
             axis=0) for orientation, page_loc_pred in zip(orientations, page_loc_preds)],
         axis=0
     ) if len(orientations) > 0 else None

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -230,12 +230,13 @@ def estimate_page_angle(polys: np.ndarray) -> float:
     """Takes a batch of rotated previously ORIENTED polys (N, 4, 2) (rectified by the classifier) and return the
     estimated angle ccw in degrees
     """
-    x1 = (polys[:, 0, 0] + polys[:, 3, 0]) / 2
-    y1 = (polys[:, 0, 1] + polys[:, 3, 1]) / 2
-    x2 = (polys[:, 1, 0] + polys[:, 2, 0]) / 2
-    y2 = (polys[:, 1, 1] + polys[:, 2, 1]) / 2
+    # Compute mean left points and mean right point with respect to the reading direction (oriented polygon)
+    xleft = polys[:, 0, 0] + polys[:, 3, 0]
+    yleft = polys[:, 0, 1] + polys[:, 3, 1]
+    xright = polys[:, 1, 0] + polys[:, 2, 0]
+    yright = polys[:, 1, 1] + polys[:, 2, 1]
     return np.median(np.arctan(
-        (y1 - y2) / (x2 - x1)  # Y axis from top to bottom!
+        (yleft - yright) / (xright - xleft)  # Y axis from top to bottom!
     )) * 180 / np.pi
 
 

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -230,9 +230,12 @@ def estimate_page_angle(polys: np.ndarray) -> float:
     """Takes a batch of rotated previously ORIENTED polys (N, 4, 2) (rectified by the classifier) and return the
     estimated angle ccw in degrees
     """
+    x1 = (polys[:, 0, 0] + polys[:, 3, 0]) / 2
+    y1 = (polys[:, 0, 1] + polys[:, 3, 1]) / 2
+    x2 = (polys[:, 1, 0] + polys[:, 2, 0]) / 2
+    y2 = (polys[:, 1, 1] + polys[:, 2, 1]) / 2
     return np.median(np.arctan(
-        (polys[:, 0, 1] - polys[:, 1, 1]) /  # Y axis from top to bottom!
-        (polys[:, 1, 0] - polys[:, 0, 0])
+        (y1 - y2) / (x2 - x1)  # Y axis from top to bottom!
     )) * 180 / np.pi
 
 

--- a/tests/common/test_utils_geometry.py
+++ b/tests/common/test_utils_geometry.py
@@ -109,3 +109,16 @@ def test_convert_to_relative_coords(abs_geoms, img_size, rel_geoms):
     # Wrong format
     with pytest.raises(ValueError):
         geometry.convert_to_relative_coords(np.zeros((3, 5)), (32, 32))
+
+
+def test_estimate_page_angle():
+    straight_polys = np.array(
+        [
+            [[0.3, 0.3], [0.4, 0.3], [0.4, 0.4], [0.3, 0.4]],
+            [[0.4, 0.4], [0.5, 0.4], [0.5, 0.5], [0.4, 0.5]],
+            [[0.5, 0.5], [0.6, 0.5], [0.6, 0.6], [0.5, 0.6]],
+        ]
+    )
+    rotated_polys = geometry.rotate_boxes(straight_polys, angle=20, orig_shape=(512, 512))
+    angle = geometry.estimate_page_angle(rotated_polys)
+    assert np.isclose(angle, 20)


### PR DESCRIPTION
This PR fixes the polygon orientations, which was bot left, top left, top rigth, bot right instead of top left, top rigth, bot right, bot left.
This fixes the line aggregation.
Any feedback is welcome!