### PR TITLE
feat: add boosted edges for rotated pages

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -224,7 +224,7 @@ class _DBNet:
         padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
         padded_polygon = np.array(padding.Execute(distance)[0])
 
-        # Fill the mask with 1 on the new shrinked polygon
+        # Fill the mask with 1 on the new shrank polygon
         cv2.fillPoly(mask, [padded_polygon.astype(np.int32)], 1.0)
 
         # Get min/max to recover polygon after distance computation
@@ -322,17 +322,17 @@ class _DBNet:
                 subject = [tuple(coor) for coor in poly]
                 padding = pyclipper.PyclipperOffset()
                 padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
-                shrinked = padding.Execute(-distance)
+                shrank = padding.Execute(-distance)
 
                 # Draw polygon on gt if it is valid
-                if len(shrinked) == 0:
+                if len(shrank) == 0:
                     seg_mask[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = False
                     continue
-                shrinked = np.array(shrinked[0]).reshape(-1, 2)
-                if shrinked.shape[0] <= 2 or not Polygon(shrinked).is_valid:
+                shrank = np.array(shrank[0]).reshape(-1, 2)
+                if shrank.shape[0] <= 2 or not Polygon(shrank).is_valid:
                     seg_mask[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = False
                     continue
-                cv2.fillPoly(seg_target[idx], [shrinked.astype(np.int32)], 1)
+                cv2.fillPoly(seg_target[idx], [shrank.astype(np.int32)], 1)
 
                 # Draw on both thresh map and thresh mask
                 poly, thresh_target[idx], thresh_mask[idx] = self.draw_thresh_map(poly, thresh_target[idx],

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -224,7 +224,7 @@ class _DBNet:
         padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
         padded_polygon = np.array(padding.Execute(distance)[0])
 
-        # Fill the mask with 1 on the new shrank polygon
+        # Fill the mask with 1 on the new shrunken polygon
         cv2.fillPoly(mask, [padded_polygon.astype(np.int32)], 1.0)
 
         # Get min/max to recover polygon after distance computation
@@ -322,17 +322,17 @@ class _DBNet:
                 subject = [tuple(coor) for coor in poly]
                 padding = pyclipper.PyclipperOffset()
                 padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
-                shrank = padding.Execute(-distance)
+                shrunken = padding.Execute(-distance)
 
                 # Draw polygon on gt if it is valid
-                if len(shrank) == 0:
+                if len(shrunken) == 0:
                     seg_mask[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = False
                     continue
-                shrank = np.array(shrank[0]).reshape(-1, 2)
-                if shrank.shape[0] <= 2 or not Polygon(shrank).is_valid:
+                shrunken = np.array(shrunken[0]).reshape(-1, 2)
+                if shrunken.shape[0] <= 2 or not Polygon(shrunken).is_valid:
                     seg_mask[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = False
                     continue
-                cv2.fillPoly(seg_target[idx], [shrank.astype(np.int32)], 1)
+                cv2.fillPoly(seg_target[idx], [shrunken.astype(np.int32)], 1)
 
                 # Draw on both thresh map and thresh mask
                 poly, thresh_target[idx], thresh_mask[idx] = self.draw_thresh_map(poly, thresh_target[idx],

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -216,7 +216,7 @@ class _DBNet:
         if polygon.ndim != 2 or polygon.shape[1] != 2:
             raise AttributeError("polygon should be a 2 dimensional array of coords")
 
-        # Augment polygon by shrink_ratio
+        # Reduce polygon by shrink_ratio
         polygon_shape = Polygon(polygon)
         distance = polygon_shape.area * (1 - np.power(self.shrink_ratio, 2)) / polygon_shape.length
         subject = [tuple(coor) for coor in polygon]  # Get coord as list of tuples
@@ -224,7 +224,7 @@ class _DBNet:
         padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
         padded_polygon = np.array(padding.Execute(distance)[0])
 
-        # Fill the mask with 1 on the new padded polygon
+        # Fill the mask with 1 on the new shrinked polygon
         cv2.fillPoly(mask, [padded_polygon.astype(np.int32)], 1.0)
 
         # Get min/max to recover polygon after distance computation

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -176,9 +176,9 @@ class _LinkNet(BaseModel):
                         distance = area * (1 - np.power(0.4, 2)) / length
                         padding = pyclipper.PyclipperOffset()
                         padding.AddPath(points, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
-                        shrank_polygon = np.array(padding.Execute(distance))
-                        if len(shrank_polygon) >= 1:
-                            cv2.fillPoly(edge_mask[idx], [shrank_polygon.astype(np.int32)[0]], 0)
+                        shrunken_polygon = np.array(padding.Execute(distance))
+                        if len(shrunken_polygon) >= 1:
+                            cv2.fillPoly(edge_mask[idx], [shrunken_polygon.astype(np.int32)[0]], 0)
                 else:
                     if box.shape == (4, 2):
                         box = [np.min(box[:, 0]), np.min(box[:, 1]), np.max(box[:, 0]), np.max(box[:, 1])]

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -176,9 +176,9 @@ class _LinkNet(BaseModel):
                         distance = area * (1 - np.power(0.4, 2)) / length
                         padding = pyclipper.PyclipperOffset()
                         padding.AddPath(points, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
-                        shrinked_polygon = np.array(padding.Execute(distance))
-                        if len(shrinked_polygon) >= 1:
-                            cv2.fillPoly(edge_mask[idx], [shrinked_polygon.astype(np.int32)[0]], 0)
+                        shrank_polygon = np.array(padding.Execute(distance))
+                        if len(shrank_polygon) >= 1:
+                            cv2.fillPoly(edge_mask[idx], [shrank_polygon.astype(np.int32)[0]], 0)
                 else:
                     if box.shape == (4, 2):
                         box = [np.min(box[:, 0]), np.min(box[:, 1]), np.max(box[:, 0]), np.max(box[:, 1])]


### PR DESCRIPTION
This PR adds boosted edges for rotated polygons: we successively draw a dilated polygon and fill the inside of the shrank polygon with 0, so that we drew the edges. We can choose the edges thickness with 2 parameters, which are for the moment set to 1.5 and 0.4 (such as in the DB paper).

Any feedback is welcome!