### PR TITLE
feat: Added support of GPU for predictors in PyTorch

### DIFF
--- a/doctr/models/detection/predictor/pytorch.py
+++ b/doctr/models/detection/predictor/pytorch.py
@@ -44,8 +44,9 @@ class DetectionPredictor(nn.Module):
             raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")
 
         processed_batches = self.pre_processor(pages)
+        _device = next(self.model.parameters()).device
         predicted_batches = [
-            self.model(batch, return_preds=True, **kwargs)['preds']  # type:ignore[operator]
+            self.model(batch.to(device=_device), return_preds=True, **kwargs)['preds']  # type:ignore[operator]
             for batch in processed_batches
         ]
         return [pred for batch in predicted_batches for pred in batch]

--- a/doctr/models/recognition/predictor/pytorch.py
+++ b/doctr/models/recognition/predictor/pytorch.py
@@ -70,8 +70,9 @@ class RecognitionPredictor(nn.Module):
         processed_batches = self.pre_processor(crops)
 
         # Forward it
+        _device = next(self.model.parameters()).device
         raw = [
-            self.model(batch, return_preds=True, **kwargs)['preds']  # type: ignore[operator]
+            self.model(batch.to(device=_device), return_preds=True, **kwargs)['preds']  # type: ignore[operator]
             for batch in processed_batches
         ]
 


### PR DESCRIPTION
This PR simply adds a dynamic device selection for predictor inference.
This snippet:
```python
import os

os.environ['USE_TORCH'] = '1'
from doctr.io import DocumentFile
from doctr.models import ocr_predictor

doc = DocumentFile.from_pdf('/path/to/sample.pdf').as_images()
predictor = ocr_predictor(pretrained=True).cuda()

out = predictor(doc)
```
used to yield:
```
RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same or input should be a MKLDNN tensor and weight is a dense tensor
```
because the model is on cuda, while the inputs are never moved to GPU.
And now, the snippet executes perfectly (& much faster than on CPU)

Since the predictions returned by each postprocessor are in numpy (automatically moved to CPU), this doesn't break any previous behaviour :) 

Any feedback is welcome!