### PR TITLE
feat: Added shadow augmentation for all backends

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -27,6 +27,7 @@ Here are all transformations that are available through docTR:
 .. autoclass:: ChannelShuffle
 .. autoclass:: GaussianNoise
 .. autoclass:: RandomHorizontalFlip
+.. autoclass:: RandomShadow
 
 
 Composing transformations

--- a/doctr/transforms/functional/base.py
+++ b/doctr/transforms/functional/base.py
@@ -62,7 +62,7 @@ def expand_line(line: np.ndarray, target_shape: Tuple[int, int]) -> Tuple[int, i
         return line[0]
     # Get the line equation
     _tmp = line[1] - line[0]
-    _valid = _tmp > 0
+    _direction = _tmp > 0
     alpha = _tmp[1] / _tmp[0]
     beta = line[1, 1] - alpha * line[1, 0]
 
@@ -78,10 +78,10 @@ def expand_line(line: np.ndarray, target_shape: Tuple[int, int]) -> Tuple[int, i
         ((target_shape[0] - beta) / alpha, target_shape[0]),
     ]
     for point in solutions:
-        # Within the shape
+        # Skip points that are out of the final image
         if any(val < 0 or val > size for val, size in zip(point, target_shape[::-1])):
             continue
-        if all(val < ref if pos else val > ref for val, ref, pos in zip(point, line[1], _valid)):
+        if all(val < ref if _dir else val > ref for val, ref, _dir in zip(point, line[1], _direction)):
             return point
     raise ValueError
 
@@ -137,7 +137,6 @@ def create_shadow_mask(
     )[0].round().astype(np.int32)
     # Check approx quadrant
     quad_idx = int(_params[0] / .25)
-    print(quad_idx)
     # Top-bot
     if quad_idx % 2 == 0:
         intensity_mask = np.repeat(np.arange(target_shape[0])[:, None], target_shape[1], axis=1) / (target_shape[0] - 1)

--- a/doctr/transforms/functional/base.py
+++ b/doctr/transforms/functional/base.py
@@ -48,6 +48,16 @@ def crop_boxes(
 
 
 def expand_line(line: np.ndarray, target_shape: Tuple[int, int]) -> Tuple[int, int]:
+    """Expands a 2-point line, so that the first is on the edge. In other terms, we extend the line in
+    the same direction until we meet one of the edges.
+
+    Args:
+        line: array of shape (2, 2) of the point supposed to be on one edge, and the shadow tip.
+        target_shape: the desired mask shape
+
+    Returns:
+        2D coordinates of the first point once we extended the line (on one of the edges)
+    """
     if any(coord == 0 or coord == size for coord, size in zip(line[0], target_shape[::-1])):
         return line[0]
     # Get the line equation
@@ -82,6 +92,17 @@ def create_shadow_mask(
     max_tip_width=0.5,
     max_tip_height=0.3,
 ) -> np.ndarray:
+    """Creates a random shadow mask
+
+    Args:
+        target_shape: the target shape (H, W)
+        min_base_width: the relative minimum shadow base width
+        max_tip_width: the relative maximum shadow tip width
+        max_tip_height: the relative maximum shadow tip height
+
+    Returns:
+        a numpy ndarray of shape (H, W, 1) with values in the range [0, 1]
+    """
 
     # Default base is top
     _params = np.random.rand(6)

--- a/doctr/transforms/functional/base.py
+++ b/doctr/transforms/functional/base.py
@@ -3,11 +3,14 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
+import cv2
 import numpy as np
 
-__all__ = ["crop_boxes"]
+from doctr.utils.geometry import rotate_abs_geoms
+
+__all__ = ["crop_boxes", "create_shadow_mask"]
 
 
 def crop_boxes(
@@ -42,3 +45,102 @@ def crop_boxes(
     is_valid = np.logical_and(boxes[:, 1] < boxes[:, 3], boxes[:, 0] < boxes[:, 2])
 
     return boxes[is_valid]
+
+
+def expand_line(line: np.ndarray, target_shape: Tuple[int, int]) -> Tuple[int, int]:
+    if any(coord == 0 or coord == size for coord, size in zip(line[0], target_shape[::-1])):
+        return line[0]
+    # Get the line equation
+    _tmp = line[1] - line[0]
+    _valid = _tmp > 0
+    alpha = _tmp[1] / _tmp[0]
+    beta = line[1, 1] - alpha * line[1, 0]
+
+    # Solve it for edges
+    solutions: List[Tuple[int, int]] = [
+        # x = 0
+        (0, beta),
+        # y = 0
+        (-beta / alpha, 0),
+        # x = right
+        (target_shape[1], alpha * target_shape[1] + beta),
+        # y = bot
+        ((target_shape[0] - beta) / alpha, target_shape[0]),
+    ]
+    for point in solutions:
+        # Within the shape
+        if any(val < 0 or val > size for val, size in zip(point, target_shape[::-1])):
+            continue
+        if all(val < ref if pos else val > ref for val, ref, pos in zip(point, line[1], _valid)):
+            return point
+    raise ValueError
+
+
+def create_shadow_mask(
+    target_shape: Tuple[int, int],
+    min_base_width=0.3,
+    max_tip_width=0.5,
+    max_tip_height=0.3,
+) -> np.ndarray:
+
+    # Default base is top
+    _params = np.random.rand(6)
+    base_width = min_base_width + (1 - min_base_width) * _params[0]
+    base_center = base_width / 2 + (1 - base_width) * _params[1]
+    # Ensure tip width is smaller for shadow consistency
+    tip_width = min(_params[2] * base_width * target_shape[0] / target_shape[1], max_tip_width)
+    tip_center = tip_width / 2 + (1 - tip_width) * _params[3]
+    tip_height = _params[4] * max_tip_height
+    tip_mid = tip_height / 2 + (1 - tip_height) * _params[5]
+    _order = tip_center < base_center
+    contour = np.array([
+        [base_center - base_width / 2, 0],
+        [base_center + base_width / 2, 0],
+        [tip_center + tip_width / 2, tip_mid + tip_height / 2 if _order else tip_mid - tip_height / 2],
+        [tip_center - tip_width / 2, tip_mid - tip_height / 2 if _order else tip_mid + tip_height / 2],
+    ], dtype=np.float32)
+
+    # Convert to absolute coords
+    abs_contour = np.stack(
+        (contour[:, 0] * target_shape[1], contour[:, 1] * target_shape[0]),
+        axis=-1,
+    ).round().astype(np.int32)
+
+    # Direction
+    _params = np.random.rand(1)
+    rotated_contour = rotate_abs_geoms(
+        abs_contour[None, ...],
+        360 * _params[0],
+        target_shape,
+        expand=False,
+    )[0].round().astype(np.int32)
+    # Check approx quadrant
+    quad_idx = int(_params[0] / .25)
+    print(quad_idx)
+    # Top-bot
+    if quad_idx % 2 == 0:
+        intensity_mask = np.repeat(np.arange(target_shape[0])[:, None], target_shape[1], axis=1) / (target_shape[0] - 1)
+        if quad_idx == 0:
+            intensity_mask = 1 - intensity_mask
+    # Left - right
+    else:
+        intensity_mask = np.repeat(np.arange(target_shape[1])[None, :], target_shape[0], axis=0) / (target_shape[1] - 1)
+        if quad_idx == 1:
+            intensity_mask = 1 - intensity_mask
+
+    # Expand base
+    final_contour = rotated_contour.copy()
+    final_contour[0] = expand_line(final_contour[[0, 3]], target_shape)
+    final_contour[1] = expand_line(final_contour[[1, 2]], target_shape)
+    # If both base are not on the same side, add a point
+    if not np.any(final_contour[0] == final_contour[1]):
+        corner_x = 0 if max(final_contour[0, 0], final_contour[1, 0]) < target_shape[1] else target_shape[1]
+        corner_y = 0 if max(final_contour[0, 1], final_contour[1, 1]) < target_shape[0] else target_shape[0]
+        corner = np.array([corner_x, corner_y])
+        final_contour = np.concatenate((final_contour[:1], corner[None, ...], final_contour[1:]), axis=0)
+
+    # Direction & rotate
+    mask = np.zeros((*target_shape, 1), dtype=np.uint8)
+    mask = cv2.fillPoly(mask, [final_contour], (255,), lineType=cv2.LINE_AA)[..., 0]
+
+    return (mask / 255).astype(np.float32).clip(0, 1) * intensity_mask.astype(np.float32)

--- a/doctr/transforms/modules/pytorch.py
+++ b/doctr/transforms/modules/pytorch.py
@@ -12,7 +12,9 @@ from torch.nn.functional import pad
 from torchvision.transforms import functional as F
 from torchvision.transforms import transforms as T
 
-__all__ = ['Resize', 'GaussianNoise', 'ChannelShuffle', 'RandomHorizontalFlip']
+from ..functional.pytorch import random_shadow
+
+__all__ = ['Resize', 'GaussianNoise', 'ChannelShuffle', 'RandomHorizontalFlip', 'RandomShadow']
 
 
 class Resize(T.Resize):
@@ -119,3 +121,33 @@ class RandomHorizontalFlip(T.RandomHorizontalFlip):
             _target["boxes"][:, ::2] = 1 - target["boxes"][:, [2, 0]]
             return _img, _target
         return img, target
+
+
+class RandomShadow(torch.nn.Module):
+    """Adds random shade to the input image
+
+       Example::
+           >>> from doctr.transforms import RandomShadow
+           >>> import tensorflow as tf
+           >>> transfo = RandomShadow(0., 1.)
+           >>> out = transfo(torch.rand((3, 64, 64)))
+
+       Args:
+           opacity_range : minimum and maximum opacity of the shade
+       """
+    def __init__(self, opacity_range: Tuple[float, float] = None) -> None:
+        super().__init__()
+        self.opacity_range = opacity_range if isinstance(opacity_range, tuple) else (.2, .8)
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        # Reshape the distribution
+        if x.dtype == torch.uint8:
+            return (255 * random_shadow(
+                x.to(dtype=torch.float32) / 255,
+                self.opacity_range,
+            )).round().clip(0, 255).to(dtype=torch.uint8)
+        else:
+            return random_shadow(x, self.opacity_range)
+
+    def extra_repr(self) -> str:
+        return f"opacity_range={self.opacity_range}"

--- a/doctr/transforms/modules/tensorflow.py
+++ b/doctr/transforms/modules/tensorflow.py
@@ -12,9 +12,11 @@ import tensorflow_addons as tfa
 
 from doctr.utils.repr import NestedObject
 
+from ..functional.tensorflow import random_shadow
+
 __all__ = ['Compose', 'Resize', 'Normalize', 'LambdaTransformation', 'ToGray', 'RandomBrightness',
            'RandomContrast', 'RandomSaturation', 'RandomHue', 'RandomGamma', 'RandomJpegQuality', 'GaussianBlur',
-           'ChannelShuffle', 'GaussianNoise', 'RandomHorizontalFlip']
+           'ChannelShuffle', 'GaussianNoise', 'RandomHorizontalFlip', 'RandomShadow']
 
 
 class Compose(NestedObject):
@@ -392,8 +394,9 @@ class RandomHorizontalFlip(NestedObject):
             }
            >>> out = transfo(image, target)
 
-       Args:
-           p : probability of Horizontal Flip"""
+   Args:
+       p : probability of Horizontal Flip
+    """
     def __init__(self, p: float) -> None:
         super().__init__()
         self.p = p
@@ -417,3 +420,37 @@ class RandomHorizontalFlip(NestedObject):
             _target["boxes"][:, ::2] = 1 - target["boxes"][:, [2, 0]]
             return _img, _target
         return img, target
+
+
+class RandomShadow(NestedObject):
+    """Adds random shade to the input image
+
+       Example::
+           >>> from doctr.transforms import RandomShadow
+           >>> import tensorflow as tf
+           >>> transfo = RandomShadow(0., 1.)
+           >>> out = transfo(tf.random.uniform(shape=[64, 64, 3], minval=0, maxval=1))
+
+       Args:
+           opacity_range : minimum and maximum opacity of the shade
+       """
+    def __init__(self, opacity_range: Tuple[float, float] = None) -> None:
+        super().__init__()
+        self.opacity_range = opacity_range if isinstance(opacity_range, tuple) else (.2, .8)
+
+    def __call__(self, x: tf.Tensor) -> tf.Tensor:
+        # Reshape the distribution
+        if x.dtype == tf.uint8:
+            return tf.cast(
+                tf.clip_by_value(
+                    tf.math.round(255 * random_shadow(tf.cast(x, dtype=tf.float32) / 255, self.opacity_range)),
+                    0,
+                    255,
+                ),
+                dtype=tf.uint8
+            )
+        else:
+            return random_shadow(x, self.opacity_range)
+
+    def extra_repr(self) -> str:
+        return f"opacity_range={self.opacity_range}"

--- a/tests/pytorch/test_transforms_pt.py
+++ b/tests/pytorch/test_transforms_pt.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from doctr.transforms import (ChannelShuffle, ColorInversion, GaussianNoise, RandomCrop, RandomHorizontalFlip,
-                              RandomRotate, Resize)
+                              RandomRotate, RandomShadow, Resize)
 from doctr.transforms.functional import crop_detection, rotate_sample
 
 
@@ -272,3 +272,31 @@ def test_randomhorizontalflip(p):
         assert np.all(_target["boxes"] == np.array([[0.1, 0.1, 0.3, 0.4]], dtype=np.float32))
         assert torch.all(transformed.mean((0, 1)) == torch.tensor([0] * 16 + [1] * 16, dtype=torch.float32))
     assert np.all(_target["labels"] == np.ones(1, dtype=np.int64))
+
+
+@pytest.mark.parametrize(
+    "input_dtype,input_shape",
+    [
+        [torch.float32, (3, 32, 32)],
+        [torch.uint8, (3, 32, 32)],
+        [torch.float32, (3, 64, 32)],
+        [torch.uint8, (3, 64, 32)],
+    ]
+)
+def test_random_shadow(input_dtype, input_shape):
+    transform = RandomShadow((.2, .8))
+    input_t = torch.ones(input_shape, dtype=torch.float32)
+    if input_dtype == torch.uint8:
+        input_t = (255 * input_t).round()
+    input_t = input_t.to(dtype=input_dtype)
+    transformed = transform(input_t)
+    assert isinstance(transformed, torch.Tensor)
+    assert transformed.shape == input_shape
+    assert transformed.dtype == input_dtype
+    # The shadow will darken the picture
+    assert input_t.float().mean() > transformed.float().mean()
+    assert torch.all(transformed >= 0)
+    if input_dtype == torch.uint8:
+        assert torch.all(transformed <= 255)
+    else:
+        assert torch.all(transformed <= 1.)

--- a/tests/tensorflow/test_transforms_tf.py
+++ b/tests/tensorflow/test_transforms_tf.py
@@ -429,3 +429,31 @@ def test_randomhorizontalflip(p):
             tf.math.reduce_mean(transformed, (0, 2)) == tf.constant([0] * 16 + [1] * 16, dtype=tf.float64)
         )
     assert np.all(_target["labels"] == np.ones(1, dtype=np.int64))
+
+
+@pytest.mark.parametrize(
+    "input_dtype,input_shape",
+    [
+        [tf.float32, (32, 32, 3)],
+        [tf.uint8, (32, 32, 3)],
+        [tf.float32, (64, 32, 3)],
+        [tf.uint8, (64, 32, 3)],
+    ]
+)
+def test_random_shadow(input_dtype, input_shape):
+    transform = T.RandomShadow((.2, .8))
+    input_t = tf.random.uniform(input_shape, dtype=tf.float32)
+    if input_dtype == tf.uint8:
+        input_t = tf.math.round((255 * input_t))
+    input_t = tf.cast(input_t, dtype=input_dtype)
+    transformed = transform(input_t)
+    assert isinstance(transformed, tf.Tensor)
+    assert transformed.shape == input_shape
+    assert transformed.dtype == input_dtype
+    # The shadow will darken the picture
+    assert tf.math.reduce_mean(input_t) > tf.math.reduce_mean(transformed)
+    assert tf.math.reduce_all(transformed >= 0)
+    if input_dtype == tf.uint8:
+        assert tf.reduce_all(transformed <= 255)
+    else:
+        assert tf.reduce_all(transformed <= 1.)


### PR DESCRIPTION
Following up on #730, this PR introduces the following modifications:
- adds `RandomShadow` augmentation
- adds unittests
- adds documentation

The following snippet:
```python
import matplotlib.pyplot as plt
from doctr.io.image import read_img_as_tensor
from doctr.transforms import RandomShadow

transform = RandomShadow((.2, .8))
img = read_img_as_tensor("path/to/your/image.jpg")
plt.imshow(transform(img).numpy()); plt/axis('off'); plt.show()
```
yields:
![shadow_sample](https://user-images.githubusercontent.com/76527547/150395391-a4213945-f0b6-4d1d-b20b-93302158e6d4.png)

Briefly:
- this first creates a 4-point polygon with 1 side on the top edge of the image
- the polygon is rotated & expanded
- the polygon is filled with 1s
- we apply an intensity gradient (so that the shadow fades as we go further from the source)
- with TF or PyTorch we overlay this after applying gaussian blur (a sharp shadow is not very believable)

Apart from filling the polygons, everything is in pure numpy until we overlay with the tensor image!

Any feedback is welcome!
