### PR TITLE
Restore remap boxes

### DIFF
--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -95,8 +95,8 @@ class OCRPredictor(nn.Module, _OCRPredictor):
                                   angle,
                                   orig_shape=page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:],
                                   target_shape=mask) for
-                                page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations,
-                                                                     origin_page_shapes)]
+                     page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations,
+                                                          origin_page_shapes)]
 
         out = self.doc_builder(
             boxes,

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -93,8 +93,8 @@ class OCRPredictor(NestedObject, _OCRPredictor):
                                   angle,
                                   orig_shape=page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:],
                                   target_shape=mask) for
-                                page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations,
-                                                                     origin_page_shapes)]
+                     page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations,
+                                                          origin_page_shapes)]
 
         out = self.doc_builder(boxes, text_preds, origin_page_shapes)  # type: ignore[misc]
         return out

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -89,8 +89,12 @@ class OCRPredictor(NestedObject, _OCRPredictor):
 
         # Rotate back pages and boxes while keeping original image size
         if self.straighten_pages:
-            boxes = [rotate_boxes(page_boxes, angle, orig_shape=page.shape[:2]) for
-                     page_boxes, page, angle in zip(boxes, pages, origin_page_orientations)]
+            boxes = [rotate_boxes(page_boxes,
+                                  angle,
+                                  orig_shape=page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:],
+                                  target_shape=mask) for
+                                page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations,
+                                                                     origin_page_shapes)]
 
         out = self.doc_builder(boxes, text_preds, origin_page_shapes)  # type: ignore[misc]
         return out

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -132,7 +132,7 @@ def remap_boxes(
     orig_shape: Tuple[int, int],
     dest_shape: Tuple[int, int]
 ) -> np.ndarray:
-    """ Remaps a batch of rotated locpred (x, y, w, h, alpha, c) expressed for an origin_shape to a destination_shape.
+    """ Remaps a batch of rotated locpred (N, 4, 2) expressed for an origin_shape to a destination_shape.
     This does not impact the absolute shape of the boxes, but allow to calculate the new relative RotatedBbox
     coordinates after a resizing of the image.
     Args:

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -150,13 +150,6 @@ def remap_boxes(
     orig_height, orig_width = orig_shape
     dest_height, dest_width = dest_shape
     mboxes = loc_preds.copy()
-    # # remaps position of the box center for the destination image shape
-    # mboxes[:, 0] = ((loc_preds[:, 0] * orig_width) + (dest_width - orig_width) / 2) / dest_width
-    # mboxes[:, 1] = ((loc_preds[:, 1] * orig_height) + (dest_height - orig_height) / 2) / dest_height
-    # # remaps box dimension for the destination image shape
-    # mboxes[:, 2] = loc_preds[:, 2] * orig_width / dest_width
-    # mboxes[:, 3] = loc_preds[:, 3] * orig_height / dest_height
-
     mboxes[:, :, 0] = ((loc_preds[:, :, 0] * orig_width) + (dest_width - orig_width) / 2) / dest_width
     mboxes[:, :, 1] = ((loc_preds[:, :, 1] * orig_height) + (dest_height - orig_height) / 2) / dest_height
 

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from math import ceil
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional
 
 import cv2
 import numpy as np
@@ -127,11 +127,48 @@ def rotate_abs_geoms(
     return rotated_polys
 
 
+def remap_boxes(
+    loc_preds: np.ndarray,
+    orig_shape: Tuple[int, int],
+    dest_shape: Tuple[int, int]
+) -> np.ndarray:
+    """ Remaps a batch of rotated locpred (x, y, w, h, alpha, c) expressed for an origin_shape to a destination_shape.
+    This does not impact the absolute shape of the boxes, but allow to calculate the new relative RotatedBbox
+    coordinates after a resizing of the image.
+    Args:
+        loc_preds: (N, 6) array of RELATIVE locpred (x, y, w, h, alpha, c)
+        orig_shape: shape of the origin image
+        dest_shape: shape of the destination image
+    Returns:
+        A batch of rotated loc_preds (N, 6): (x, y, w, h, alpha, c) expressed in the destination referencial
+    """
+
+    if len(dest_shape) != 2:
+        raise ValueError(f"Mask length should be 2, was found at: {len(dest_shape)}")
+    if len(orig_shape) != 2:
+        raise ValueError(f"Image_shape length should be 2, was found at: {len(orig_shape)}")
+    orig_height, orig_width = orig_shape
+    dest_height, dest_width = dest_shape
+    mboxes = loc_preds.copy()
+    # # remaps position of the box center for the destination image shape
+    # mboxes[:, 0] = ((loc_preds[:, 0] * orig_width) + (dest_width - orig_width) / 2) / dest_width
+    # mboxes[:, 1] = ((loc_preds[:, 1] * orig_height) + (dest_height - orig_height) / 2) / dest_height
+    # # remaps box dimension for the destination image shape
+    # mboxes[:, 2] = loc_preds[:, 2] * orig_width / dest_width
+    # mboxes[:, 3] = loc_preds[:, 3] * orig_height / dest_height
+
+    mboxes[:, :, 0] = ((loc_preds[:, :, 0] * orig_width) + (dest_width - orig_width) / 2) / dest_width
+    mboxes[:, :, 1] = ((loc_preds[:, :, 1] * orig_height) + (dest_height - orig_height) / 2) / dest_height
+
+    return mboxes
+
+
 def rotate_boxes(
     loc_preds: np.ndarray,
     angle: float,
     orig_shape: Tuple[int, int],
     min_angle: float = 1.,
+    target_shape: Optional[Tuple[int, int]] = None,
 ) -> np.ndarray:
     """Rotate a batch of straight bounding boxes (xmin, ymin, xmax, ymax, c) or rotated bounding boxes
     (4, 2) of an angle, if angle > min_angle, around the center of the page.
@@ -176,6 +213,11 @@ def rotate_boxes(
     rotated_boxes = np.stack(
         (rotated_points[:, :, 0] / orig_shape[1], rotated_points[:, :, 1] / orig_shape[0]), axis=-1
     )
+
+    # Apply a mask if requested
+    if target_shape is not None:
+        rotated_boxes = remap_boxes(rotated_boxes, orig_shape=orig_shape, dest_shape=target_shape)
+
     return rotated_boxes
 
 

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -136,11 +136,11 @@ def remap_boxes(
     This does not impact the absolute shape of the boxes, but allow to calculate the new relative RotatedBbox
     coordinates after a resizing of the image.
     Args:
-        loc_preds: (N, 6) array of RELATIVE locpred (x, y, w, h, alpha, c)
+        loc_preds: (N, 4, 2) array of RELATIVE loc_preds
         orig_shape: shape of the origin image
         dest_shape: shape of the destination image
     Returns:
-        A batch of rotated loc_preds (N, 6): (x, y, w, h, alpha, c) expressed in the destination referencial
+        A batch of rotated loc_preds (N, 4, 2) expressed in the destination referencial
     """
 
     if len(dest_shape) != 2:

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from math import ceil
-from typing import List, Tuple, Union, Optional
+from typing import List, Optional, Tuple, Union
 
 import cv2
 import numpy as np

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -83,19 +83,6 @@ def mock_image(tmpdir_factory):
     return image
 
 
-@pytest.fixture(scope="session")
-def mock_tilted_payslip(tmpdir_factory):
-    url = 'https://3.bp.blogspot.com/-Es0oHTCrVEk/UnYA-iW9rYI/AAAAAAAAAFI/hWExrXFbo9U/s1600/003.jpg'
-    file = BytesIO(requests.get(url).content)
-    folder = tmpdir_factory.mktemp("images")
-    fn = str(folder.join("mock_payslip.jpeg"))
-    with open(fn, 'wb') as f:
-        f.write(file.getbuffer())
-    image = reader.read_img_as_numpy(fn)
-    image = geometry.rotate_image(image, 30, expand=True)
-    return image
-
-
 @pytest.fixture(scope="function")
 def mock_bitmap(mock_image):
     bitmap = np.squeeze(cv2.cvtColor(mock_image, cv2.COLOR_BGR2GRAY) / 255.)
@@ -107,7 +94,7 @@ def test_get_bitmap_angle(mock_bitmap):
     assert abs(angle - 30.) < 1.
 
 
-def test_estimate_orientation(mock_image):
+def test_estimate_orientation(mock_image, mock_tilted_payslip):
     assert estimate_orientation(mock_image * 0) == 0
 
     angle = estimate_orientation(mock_image)
@@ -117,8 +104,7 @@ def test_estimate_orientation(mock_image):
     angle_rotated = estimate_orientation(rotated)
     assert abs(angle_rotated) < 1.
 
-
-def test_estimate_orientation(mock_tilted_payslip):
+    mock_tilted_payslip = reader.read_img_as_numpy(mock_tilted_payslip)
     assert (estimate_orientation(mock_tilted_payslip) - 30.) < 1.
 
     rotated = geometry.rotate_image(mock_tilted_payslip, -30, expand=True)

--- a/tests/common/test_utils_geometry.py
+++ b/tests/common/test_utils_geometry.py
@@ -1,5 +1,9 @@
+from math import hypot
+
+import cv2
 import numpy as np
 import pytest
+
 
 from doctr.utils import geometry
 
@@ -26,6 +30,50 @@ def test_resolve_enclosing_rbbox():
     target1 = np.asarray([[.55, .65], [.05, .15], [.1, .1], [.6, .6]])
     target2 = np.asarray([[.05, .15], [.1, .1], [.6, .6], [.55, .65]])
     assert np.all(target1 - pred <= 1e-3) or np.all(target2 - pred <= 1e-3)
+
+
+def test_remap_boxes():
+    pred = geometry.remap_boxes(np.asarray([[[.25, .25], [.25, .75], [.75, .25], [.75, .75]]]), (10, 10), (20, 20))
+    target = np.asarray([[[.375, .375], [.375, .625], [.625, .375], [.625, .625]]])
+    assert np.all(pred == target)
+
+    pred = geometry.remap_boxes(np.asarray([[[.25, .25], [.25, .75], [.75, .25], [.75, .75]]]), (10, 10), (20, 10))
+    target = np.asarray([[[0.25, 0.375],
+                          [0.25, 0.625],
+                          [0.75, 0.375],
+                          [0.75, 0.625]]])
+    assert np.all(pred == target)
+
+    with pytest.raises(ValueError):
+        geometry.remap_boxes(np.asarray([[[.25, .25], [.25, .75], [.75, .25], [.75, .75]]]), (80, 40, 150), (160, 40))
+
+    with pytest.raises(ValueError):
+        geometry.remap_boxes(np.asarray([[[.25, .25], [.25, .75], [.75, .25], [.75, .75]]]), (80, 40), (160,))
+
+    orig_dimension = (100, 100)
+    dest_dimensions = (200, 100)
+    # Unpack dimensions
+    height_o, width_o = orig_dimension
+    height_d, width_d = dest_dimensions
+
+    orig_box = np.asarray([[[0.25, 0.25],
+                            [0.25, 0.25],
+                            [0.75, 0.75],
+                            [0.75, 0.75]]])
+
+    pred = geometry.remap_boxes(orig_box, orig_dimension, dest_dimensions)
+
+    # Switch to absolute coords
+    orig = np.stack((orig_box[:, :, 0] * width_o, orig_box[:, :, 1] * height_o), axis=2)[0]
+    dest = np.stack((pred[:, :, 0] * width_d, pred[:, :, 1] * height_d), axis=2)[0]
+
+    len_orig = hypot(orig[0][0] - orig[2][0], orig[0][1] - orig[2][1])
+    len_dest = hypot(dest[0][0] - dest[2][0], dest[0][1] - dest[2][1])
+    assert len_orig == len_dest
+
+    alpha_orig = np.rad2deg(np.arctan((orig[0][1] - orig[2][1]) / (orig[0][0] - orig[2][0])))
+    alpha_dest = np.rad2deg(np.arctan((dest[0][1] - dest[2][1]) / (dest[0][0] - dest[2][0])))
+    assert alpha_orig == alpha_dest
 
 
 def test_rotate_boxes():

--- a/tests/common/test_utils_geometry.py
+++ b/tests/common/test_utils_geometry.py
@@ -1,9 +1,7 @@
 from math import hypot
 
-import cv2
 import numpy as np
 import pytest
-
 
 from doctr.utils import geometry
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,16 @@ import shutil
 import tempfile
 from io import BytesIO
 
+import cv2
 import fitz
 import hdf5storage
 import numpy as np
 import pytest
 import requests
 import scipy.io as sio
+
+from doctr.io import reader
+from doctr.utils import geometry
 
 
 @pytest.fixture(scope="session")
@@ -33,6 +37,26 @@ def mock_pdf(tmpdir_factory):
         doc.save(f)
 
     return str(fn)
+
+
+@pytest.fixture(scope="session")
+def mock_payslip(tmpdir_factory):
+    url = 'https://3.bp.blogspot.com/-Es0oHTCrVEk/UnYA-iW9rYI/AAAAAAAAAFI/hWExrXFbo9U/s1600/003.jpg'
+    file = BytesIO(requests.get(url).content)
+    folder = tmpdir_factory.mktemp("data")
+    fn = str(folder.join("mock_payslip.jpeg"))
+    with open(fn, 'wb') as f:
+        f.write(file.getbuffer())
+    return fn
+
+
+@pytest.fixture(scope="session")
+def mock_tilted_payslip(mock_payslip, tmpdir_factory):
+    image = reader.read_img_as_numpy(mock_payslip)
+    image = geometry.rotate_image(image, 30, expand=True)
+    tmp_path = str(tmpdir_factory.mktemp("data").join("mock_tilted_payslip.jpg"))
+    cv2.imwrite(tmp_path, image)
+    return tmp_path
 
 
 @pytest.fixture(scope="session")

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -5,9 +5,11 @@ from doctr import models
 from doctr.io import Document, DocumentFile
 from doctr.models import detection, recognition
 from doctr.models.detection.predictor import DetectionPredictor
+from doctr.models.detection.zoo import detection_predictor
 from doctr.models.predictor import OCRPredictor
 from doctr.models.preprocessor import PreProcessor
 from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.models.recognition.zoo import recognition_predictor
 
 
 @pytest.mark.parametrize(
@@ -52,6 +54,36 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
     with pytest.raises(ValueError):
         input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
         _ = predictor([input_page])
+
+
+def test_trained_ocr_predictor(mock_tilted_payslip):
+    doc = DocumentFile.from_images(mock_tilted_payslip)
+
+    det_predictor = detection_predictor('db_resnet50', pretrained=True, batch_size=2, assume_straight_pages=True)
+    reco_predictor = recognition_predictor('crnn_vgg16_bn', pretrained=True, batch_size=128)
+
+    predictor = OCRPredictor(
+        det_predictor,
+        reco_predictor,
+        assume_straight_pages=True,
+        straighten_pages=True,
+    )
+
+    out = predictor(doc)
+
+    assert out.pages[0].blocks[0].lines[0].words[0].value == 'Mr.'
+    geometry_mr = np.array([[0.08844472, 0.35763523],
+                            [0.11625107, 0.34320644],
+                            [0.12588427, 0.35771032],
+                            [0.09807791, 0.37213911]])
+    assert np.allclose(np.array(out.pages[0].blocks[0].lines[0].words[0].geometry), geometry_mr)
+
+    assert out.pages[0].blocks[1].lines[0].words[-1].value == 'revised'
+    geometry_revised = np.array([[0.50422498, 0.19551784],
+                                 [0.55741975, 0.16791493],
+                                 [0.56705294, 0.18241881],
+                                 [0.51385817, 0.21002172]])
+    assert np.allclose(np.array(out.pages[0].blocks[1].lines[0].words[-1].geometry), geometry_revised)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is to address #800 as part of #788. 

It restores the function `remap_boxes` from #488 and adds a new functionality test to verify the output of a pretrained predictor on a rotated document. 