### PR TITLE
feat: add rotated linknet_resnet18 tensorflow ckpts

### DIFF
--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -119,7 +119,6 @@ class _LinkNet(BaseModel):
 
         if self.assume_straight_pages:
             seg_target = np.zeros(target_shape, dtype=bool)
-            edge_mask = np.zeros(target_shape, dtype=bool)
         else:
             seg_target = np.zeros(target_shape, dtype=np.uint8)
 
@@ -159,19 +158,10 @@ class _LinkNet(BaseModel):
                     if box.shape == (4, 2):
                         box = [np.min(box[:, 0]), np.min(box[:, 1]), np.max(box[:, 0]), np.max(box[:, 1])]
                     seg_target[idx, box[1]: box[3] + 1, box[0]: box[2] + 1] = True
-                    # top edge
-                    edge_mask[idx, box[1], box[0]: min(box[2] + 1, w)] = True
-                    # bot edge
-                    edge_mask[idx, min(box[3], h - 1), box[0]: min(box[2] + 1, w)] = True
-                    # left edge
-                    edge_mask[idx, box[1]: min(box[3] + 1, h), box[0]] = True
-                    # right edge
-                    edge_mask[idx, box[1]: min(box[3] + 1, h), min(box[2], w - 1)] = True
 
         # Don't forget to switch back to channel first if PyTorch is used
         if not is_tf_available():
             seg_target = seg_target.transpose(0, 3, 1, 2)
             seg_mask = seg_mask.transpose(0, 3, 1, 2)
-            edge_mask = edge_mask.transpose(0, 3, 1, 2)
 
-        return seg_target, seg_mask, edge_mask
+        return seg_target, seg_mask

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -107,7 +107,7 @@ class _LinkNet(BaseModel):
         self,
         target: List[np.ndarray],
         output_shape: Tuple[int, int],
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray]:
 
         if any(t.dtype != np.float32 for t in target):
             raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
@@ -143,7 +143,12 @@ class _LinkNet(BaseModel):
                 abs_boxes[:, [0, 2]] *= w
                 abs_boxes[:, [1, 3]] *= h
                 abs_boxes = abs_boxes.round().astype(np.int32)
-                polys = [None] * abs_boxes.shape[0]  # Unused
+                polys = np.stack([
+                    abs_boxes[:, [0, 1]],
+                    abs_boxes[:, [0, 3]],
+                    abs_boxes[:, [2, 3]],
+                    abs_boxes[:, [2, 1]],
+                ], axis=1)
                 boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
 
             for poly, box, box_size in zip(polys, abs_boxes, boxes_size):

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -158,7 +158,6 @@ class LinkNet(nn.Module, _LinkNet):
         self,
         out_map: torch.Tensor,
         target: List[np.ndarray],
-        edge_factor: float = 2.,
     ) -> torch.Tensor:
         """Compute linknet loss, BCE with boosted box edges or focal loss. Focal loss implementation based on
         <https://github.com/tensorflow/addons/>`_.
@@ -166,26 +165,26 @@ class LinkNet(nn.Module, _LinkNet):
         Args:
             out_map: output feature map of the model of shape (N, 1, H, W)
             target: list of dictionary where each dict has a `boxes` and a `flags` entry
-            edge_factor: boost factor for box edges (in case of BCE)
 
         Returns:
             A loss tensor
         """
-        seg_target, seg_mask, edge_mask = self.build_target(target, out_map.shape[-2:])  # type: ignore[arg-type]
+        seg_target, seg_mask = self.build_target(target, out_map.shape[-2:])  # type: ignore[arg-type]
 
         seg_target, seg_mask = torch.from_numpy(seg_target).to(dtype=out_map.dtype), torch.from_numpy(seg_mask)
         seg_target, seg_mask = seg_target.to(out_map.device), seg_mask.to(out_map.device)
-        if edge_factor > 0:
-            edge_mask = torch.from_numpy(edge_mask).to(dtype=out_map.dtype, device=out_map.device)
 
-        # Get the cross_entropy for each entry
-        loss = F.binary_cross_entropy_with_logits(out_map, seg_target, reduction='none')
+        # BCE loss
+        bce_loss = F.binary_cross_entropy_with_logits(out_map, seg_target, reduction='none')
 
-        # Compute BCE loss with highlighted edges
-        if edge_factor > 0:
-            loss = ((1 + (edge_factor - 1) * edge_mask) * loss)
+        # Dice loss
+        prob_map = torch.nn.functional.sigmoid(out_map)
+        inter = (prob_map[seg_mask] * target[seg_mask]).sum()
+        cardinality = (prob_map[seg_mask] + target[seg_mask]).sum()
+        dice_loss = 1 - 2 * inter / (cardinality + 1e-8)
+
         # Only consider contributions overlaping the mask
-        return loss[seg_mask].mean()
+        return bce_loss[seg_mask].mean() + dice_loss.mean()
 
 
 def _linknet(

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -179,8 +179,8 @@ class LinkNet(nn.Module, _LinkNet):
 
         # Dice loss
         prob_map = torch.nn.functional.sigmoid(out_map)
-        inter = (prob_map[seg_mask] * target[seg_mask]).sum()
-        cardinality = (prob_map[seg_mask] + target[seg_mask]).sum()
+        inter = (prob_map[seg_mask] * seg_target[seg_mask]).sum()
+        cardinality = (prob_map[seg_mask] + seg_target[seg_mask]).sum()
         dice_loss = 1 - 2 * inter / (cardinality + 1e-8)
 
         # Only consider contributions overlaping the mask

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -160,8 +160,8 @@ class LinkNet(_LinkNet, keras.Model):
 
         # Dice loss
         prob_map = tf.math.sigmoid(out_map)
-        inter = tf.math.reduce_sum(prob_map[seg_mask] * target[seg_mask])
-        cardinality = tf.math.reduce_sum(prob_map[seg_mask] + target[seg_mask])
+        inter = tf.math.reduce_sum(prob_map[seg_mask] * seg_target[seg_mask])
+        cardinality = tf.math.reduce_sum(prob_map[seg_mask] + seg_target[seg_mask])
         dice_loss = 1 - 2 * inter / (cardinality + 1e-8)
 
         return tf.math.reduce_mean(bce_loss[seg_mask]) + tf.math.reduce_mean(dice_loss)

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -19,7 +19,7 @@ from doctr.utils.repr import NestedObject
 
 from .base import LinkNetPostProcessor, _LinkNet
 
-__all__ = ['LinkNet', 'linknet_resnet18']
+__all__ = ['LinkNet', 'linknet_resnet18', 'linknet_resnet18_rotation']
 
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
@@ -28,6 +28,12 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         'std': (0.264, 0.2749, 0.287),
         'input_shape': (1024, 1024, 3),
         'url': None,
+    },
+    'linknet_resnet18_rotation': {
+        'mean': (0.798, 0.785, 0.772),
+        'std': (0.264, 0.2749, 0.287),
+        'input_shape': (1024, 1024, 3),
+        'url': 'https://github.com/mindee/doctr/releases/download/v0.5.0/linknet_resnet18_rotation-1d4795e4.zip',
     },
 }
 
@@ -251,6 +257,33 @@ def linknet_resnet18(pretrained: bool = False, **kwargs: Any) -> LinkNet:
 
     return _linknet(
         'linknet_resnet18',
+        pretrained,
+        resnet18,
+        ['resnet_block_1', 'resnet_block_3', 'resnet_block_5', 'resnet_block_7'],
+        **kwargs,
+    )
+
+
+def linknet_resnet18_rotation(pretrained: bool = False, **kwargs: Any) -> LinkNet:
+    """LinkNet as described in `"LinkNet: Exploiting Encoder Representations for Efficient Semantic Segmentation"
+    <https://arxiv.org/pdf/1707.03718.pdf>`_.
+
+    Example::
+        >>> import tensorflow as tf
+        >>> from doctr.models import linknet_resnet18
+        >>> model = linknet_resnet18_rotation(pretrained=True)
+        >>> input_tensor = tf.random.uniform(shape=[1, 1024, 1024, 3], maxval=1, dtype=tf.float32)
+        >>> out = model(input_tensor)
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on our text detection dataset
+
+    Returns:
+        text detection architecture
+    """
+
+    return _linknet(
+        'linknet_resnet18_rotation',
         pretrained,
         resnet18,
         ['resnet_block_1', 'resnet_block_3', 'resnet_block_5', 'resnet_block_7'],

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -139,7 +139,6 @@ class LinkNet(_LinkNet, keras.Model):
         self,
         out_map: tf.Tensor,
         target: List[np.ndarray],
-        edge_factor: float = 2.,
     ) -> tf.Tensor:
         """Compute linknet loss, BCE with boosted box edges or focal loss. Focal loss implementation based on
         <https://github.com/tensorflow/addons/>`_.
@@ -147,29 +146,25 @@ class LinkNet(_LinkNet, keras.Model):
         Args:
             out_map: output feature map of the model of shape N x H x W x 1
             target: list of dictionary where each dict has a `boxes` and a `flags` entry
-            edge_factor: boost factor for box edges (in case of BCE)
 
         Returns:
             A loss tensor
         """
-        seg_target, seg_mask, edge_mask = self.build_target(target, out_map.shape[1:3])
+        seg_target, seg_mask = self.build_target(target, out_map.shape[1:3])
 
         seg_target = tf.convert_to_tensor(seg_target, dtype=out_map.dtype)
         seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
-        if edge_factor > 0:
-            edge_mask = tf.convert_to_tensor(edge_mask, dtype=tf.bool)
 
-        # Get the cross_entropy for each entry
-        loss = tf.keras.losses.binary_crossentropy(seg_target, out_map, from_logits=True)[..., None]
+        # BCE loss
+        bce_loss = tf.keras.losses.binary_crossentropy(seg_target, out_map, from_logits=True)[..., None]
 
-        # Compute BCE loss with highlighted edges
-        if edge_factor > 0:
-            loss = tf.math.multiply(
-                1 + (edge_factor - 1) * tf.cast(edge_mask, out_map.dtype),
-                loss
-            )
+        # Dice loss
+        prob_map = tf.math.sigmoid(out_map)
+        inter = tf.math.reduce_sum(prob_map[seg_mask] * target[seg_mask])
+        cardinality = tf.math.reduce_sum(prob_map[seg_mask] + target[seg_mask])
+        dice_loss = 1 - 2 * inter / (cardinality + 1e-8)
 
-        return tf.reduce_mean(loss[seg_mask])
+        return tf.math.reduce_mean(bce_loss[seg_mask]) + tf.math.reduce_mean(dice_loss)
 
     def call(
         self,

--- a/doctr/models/detection/zoo.py
+++ b/doctr/models/detection/zoo.py
@@ -15,8 +15,8 @@ __all__ = ["detection_predictor"]
 
 
 if is_tf_available():
-    ARCHS = ['db_resnet50', 'db_mobilenet_v3_large', 'linknet_resnet18']
-    ROT_ARCHS = []
+    ARCHS = ['db_resnet50', 'db_mobilenet_v3_large', 'linknet_resnet18', 'linknet_resnet18_rotation']
+    ROT_ARCHS = ['linknet_resnet18_rotation']
 elif is_torch_available():
     ARCHS = ['db_resnet34', 'db_resnet50', 'db_mobilenet_v3_large', 'linknet_resnet18', 'db_resnet50_rotation']
     ROT_ARCHS = ['db_resnet50_rotation']


### PR DESCRIPTION
Following #816, this PR adds the checkpoints of the trained linket_resnet18 on rotated samples.
Any feedback is welcome!