### PR TITLE
feat: replace PyMuPDF  by pdf2image, for license compatibility

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -52,7 +52,7 @@ def main():
     uploaded_file = st.sidebar.file_uploader("Upload files", type=['pdf', 'png', 'jpeg', 'jpg'])
     if uploaded_file is not None:
         if uploaded_file.name.endswith('.pdf'):
-            doc = DocumentFile.from_pdf(uploaded_file.read()).as_images()
+            doc = DocumentFile.from_pdf(uploaded_file.read())
         else:
             doc = DocumentFile.from_images(uploaded_file.read())
         page_idx = st.sidebar.selectbox("Page selection", [idx + 1 for idx in range(len(doc))]) - 1

--- a/doctr/io/pdf.py
+++ b/doctr/io/pdf.py
@@ -4,13 +4,12 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List
 
-import cv2
 import pdf2image
 import numpy as np
 
-from doctr.utils.common_types import AbstractFile, Bbox
+from doctr.utils.common_types import AbstractFile
 
 __all__ = ['read_pdf_as_numpy']
 
@@ -20,7 +19,7 @@ def read_pdf_as_numpy(file: AbstractFile) -> List[np.ndarray]:
 
     Example::
         >>> from doctr.documents import read_pdf
-        >>> doc = read_pdf("path/to/your/doc.pdf")
+        >>> doc = read_pdf_as_numpy("path/to/your/doc.pdf")
 
     Args:
         file: the path to the PDF file

--- a/doctr/io/pdf.py
+++ b/doctr/io/pdf.py
@@ -7,15 +7,15 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import cv2
-import fitz
+import pdf2image
 import numpy as np
 
 from doctr.utils.common_types import AbstractFile, Bbox
 
-__all__ = ['read_pdf', 'PDF']
+__all__ = ['read_pdf_as_numpy']
 
 
-def read_pdf(file: AbstractFile, **kwargs: Any) -> fitz.Document:
+def read_pdf_as_numpy(file: AbstractFile) -> List[np.ndarray]:
     """Read a PDF file and convert it into an image in numpy format
 
     Example::
@@ -31,154 +31,18 @@ def read_pdf(file: AbstractFile, **kwargs: Any) -> fitz.Document:
     if isinstance(file, (str, Path)) and not Path(file).is_file():
         raise FileNotFoundError(f"unable to access {file}")
 
-    fitz_args: Dict[str, AbstractFile] = {}
-
     if isinstance(file, (str, Path)):
-        fitz_args['filename'] = file
+        pil_images = pdf2image.convert_from_path(
+            file,
+            dpi=144,  # To keep the same behaviour than before with fitz
+        )
     elif isinstance(file, bytes):
-        fitz_args['stream'] = file
+        pil_images = pdf2image.convert_from_bytes(
+            file,
+            dpi=144,
+        )
     else:
         raise TypeError("unsupported object type for argument 'file'")
 
-    # Read pages with fitz and convert them to numpy ndarrays
-    return fitz.open(**fitz_args, filetype="pdf", **kwargs)
-
-
-def convert_page_to_numpy(
-    page: fitz.fitz.Page,
-    output_size: Optional[Tuple[int, int]] = None,
-    bgr_output: bool = False,
-    default_scales: Tuple[float, float] = (2, 2),
-) -> np.ndarray:
-    """Convert a fitz page to a numpy-formatted image
-
-    Args:
-        page: the page of a file read with PyMuPDF
-        output_size: the expected output size of each page in format H x W. Default goes to 840 x 595 for A4 pdf,
-        if you want to increase the resolution while preserving the original A4 aspect ratio can pass (1024, 726)
-        rgb_output: whether the output ndarray channel order should be RGB instead of BGR.
-        default_scales: spatial scaling to be applied when output_size is not specified where (1, 1)
-            corresponds to 72 dpi rendering.
-
-    Returns:
-        the rendered image in numpy format
-    """
-
-    # If no output size is specified, keep the origin one
-    if output_size is not None:
-        scales = (output_size[1] / page.MediaBox[2], output_size[0] / page.MediaBox[3])
-    else:
-        # Default 72 DPI (scales of (1, 1)) is unnecessarily low
-        scales = default_scales
-
-    transform_matrix = fitz.Matrix(*scales)
-
-    # Generate the pixel map using the transformation matrix
-    pixmap = page.get_pixmap(matrix=transform_matrix)
-    # Decode it into a numpy
-    img = np.frombuffer(pixmap.samples, dtype=np.uint8).reshape(pixmap.height, pixmap.width, 3)
-
-    # Switch the channel order
-    if bgr_output:
-        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
-
-    return img
-
-
-class PDF:
-    """PDF document template
-
-    Args:
-        doc: input PDF document
-    """
-    def __init__(self, doc: fitz.Document) -> None:
-        self.doc = doc
-
-    def as_images(self, **kwargs) -> List[np.ndarray]:
-        """Convert all document pages to images
-
-        Example::
-            >>> from doctr.documents import DocumentFile
-            >>> pages = DocumentFile.from_pdf("path/to/your/doc.pdf").as_images()
-
-        Args:
-            kwargs: keyword arguments of `convert_page_to_numpy`
-        Returns:
-            the list of pages decoded as numpy ndarray of shape H x W x 3
-        """
-        return [convert_page_to_numpy(page, **kwargs) for page in self.doc]
-
-    def get_page_lines(self, idx, **kwargs) -> List[Tuple[Bbox, str]]:
-        """Get the annotations for all lines of a given page"""
-        lines: List[Tuple[Bbox, str]] = []
-        prev_block, prev_line = -1, -1
-        current_line = []
-        xmin, ymin, xmax, ymax = 0, 0, 0, 0
-        # xmin, ymin, xmax, ymax, value, block_idx, line_idx, word_idx
-        for info in self.doc[idx].get_text_words(**kwargs):
-            if prev_block == info[-3] and prev_line == info[-2]:
-                current_line.append(info[4])
-                xmin, ymin = min(xmin, info[0]), min(ymin, info[1])
-                xmax, ymax = max(xmax, info[2]), max(ymax, info[3])
-            else:
-                if len(current_line) > 0:
-                    lines.append(((xmin, ymin, xmax, ymax), " ".join(current_line)))
-                current_line = [info[4]]
-                prev_block, prev_line = info[-3], info[-2]
-                xmin, ymin, xmax, ymax = info[:4]
-
-        if len(current_line) > 0:
-            lines.append(((xmin, ymin, xmax, ymax), " ".join(current_line)))
-
-        return lines
-
-    def get_lines(self, **kwargs) -> List[List[Tuple[Bbox, str]]]:
-        """Get the annotations for all lines in the document
-
-        Example::
-            >>> from doctr.documents import DocumentFile
-            >>> lines = DocumentFile.from_pdf("path/to/your/doc.pdf").get_lines()
-
-        Args:
-            kwargs: keyword arguments of `fitz.Page.get_text_words`
-        Returns:
-            the list of pages annotations, represented as a list of tuple (bounding box, value)
-        """
-        return [self.get_page_lines(idx, **kwargs) for idx in range(len(self.doc))]
-
-    def get_page_words(self, idx, **kwargs) -> List[Tuple[Bbox, str]]:
-        """Get the annotations for all words of a given page"""
-
-        # xmin, ymin, xmax, ymax, value, block_idx, line_idx, word_idx
-        return [(info[:4], info[4]) for info in self.doc[idx].get_text_words(**kwargs)]
-
-    def get_words(self, **kwargs) -> List[List[Tuple[Bbox, str]]]:
-        """Get the annotations for all words in the document
-
-        Example::
-            >>> from doctr.documents import DocumentFile
-            >>> words = DocumentFile.from_pdf("path/to/your/doc.pdf").get_words()
-
-        Args:
-            kwargs: keyword arguments of `fitz.Page.get_text_words`
-        Returns:
-            the list of pages annotations, represented as a list of tuple (bounding box, value)
-        """
-        return [self.get_page_words(idx, **kwargs) for idx in range(len(self.doc))]
-
-    def get_page_artefacts(self, idx) -> List[Tuple[float, float, float, float]]:
-        return [tuple(self.doc[idx].get_image_bbox(artefact))  # type: ignore[misc]
-                for artefact in self.doc[idx].get_images(full=True)]
-
-    def get_artefacts(self) -> List[List[Tuple[float, float, float, float]]]:
-        """Get the artefacts for the entire document
-
-        Example::
-            >>> from doctr.documents import DocumentFile
-            >>> artefacts = DocumentFile.from_pdf("path/to/your/doc.pdf").get_artefacts()
-
-        Returns:
-            the list of pages artefacts, represented as a list of bounding boxes
-        """
-
-        return [self.get_page_artefacts(idx) for idx in range(len(self.doc))]
+    # Convert pages to numpy ndarrays
+    return [np.array(pil_img, np.uint8, copy=True) for pil_img in pil_images]

--- a/doctr/io/reader.py
+++ b/doctr/io/reader.py
@@ -12,7 +12,7 @@ from doctr.utils.common_types import AbstractFile
 
 from .html import read_html
 from .image import read_img_as_numpy
-from .pdf import PDF, read_pdf
+from .pdf import read_pdf_as_numpy
 
 __all__ = ['DocumentFile']
 
@@ -21,7 +21,7 @@ class DocumentFile:
     """Read a document from multiple extensions"""
 
     @classmethod
-    def from_pdf(cls, file: AbstractFile, **kwargs) -> PDF:
+    def from_pdf(cls, file: AbstractFile) -> List[np.ndarray]:
         """Read a PDF file
 
         Example::
@@ -31,15 +31,13 @@ class DocumentFile:
         Args:
             file: the path to the PDF file or a binary stream
         Returns:
-            a PDF document
+            a list of numpy pages
         """
 
-        doc = read_pdf(file, **kwargs)
-
-        return PDF(doc)
+        return read_pdf_as_numpy(file)
 
     @classmethod
-    def from_url(cls, url: str, **kwargs) -> PDF:
+    def from_url(cls, url: str) -> List[np.ndarray]:
         """Interpret a web page as a PDF document
 
         Example::
@@ -49,10 +47,10 @@ class DocumentFile:
         Args:
             url: the URL of the target web page
         Returns:
-            a PDF document
+            a list of numpy pages
         """
         pdf_stream = read_html(url)
-        return cls.from_pdf(pdf_stream, **kwargs)
+        return cls.from_pdf(pdf_stream)
 
     @classmethod
     def from_images(cls, files: Union[Sequence[AbstractFile], AbstractFile], **kwargs) -> List[np.ndarray]:

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,7 @@ ignore_missing_imports = True
 
 ignore_missing_imports = True
 
-[mypy-fitz.*]
+[mypy-pdf2image.*]
 
 ignore_missing_imports = True
 

--- a/requirements-pt.txt
+++ b/requirements-pt.txt
@@ -2,7 +2,7 @@ numpy>=1.16.0
 scipy>=1.4.0
 h5py>=3.1.0
 opencv-python>=3.4.5.20
-PyMuPDF>=1.16.0,!=1.18.11,!=1.18.12
+pdf2image>=1.16.0
 pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0,<3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16.0
 scipy>=1.4.0
 h5py>=3.1.0
 opencv-python>=3.4.5.20
-PyMuPDF>=1.16.0,!=1.18.11,!=1.18.12
+pdf2image>=1.16.0
 pyclipper>=1.2.0
 shapely>=1.6.0
 matplotlib>=3.1.0,<3.4.3

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ _deps = [
     "h5py>=3.1.0",
     "opencv-python>=3.4.5.20",
     "tensorflow>=2.4.0",
-    "PyMuPDF>=1.16.0,!=1.18.11,!=1.18.12",  # 18.11 and 18.12 fail (issue #222)
+    "pdf2image>=1.16.0",
     "pyclipper>=1.2.0",
     "shapely>=1.6.0",
     "matplotlib>=3.1.0,<3.4.3",
@@ -94,7 +94,7 @@ install_requires = [
     deps["scipy"],
     deps["h5py"],
     deps["opencv-python"],
-    deps["PyMuPDF"],
+    deps["pdf2image"],
     deps["pyclipper"],
     deps["shapely"],
     deps["matplotlib"],

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -4,8 +4,6 @@ import numpy as np
 import pytest
 import requests
 
-from typing import List
-
 from doctr import io
 
 
@@ -18,19 +16,21 @@ def _check_doc_content(doc_tensors, num_pages):
 
 def test_read_pdf_as_numpy(mock_pdf):
     doc = io.read_pdf_as_numpy(mock_pdf)
-    assert isinstance(doc, List[np.ndarray])
+    assert len(doc) == 1
+    assert isinstance(doc[0], np.ndarray)
 
     with open(mock_pdf, 'rb') as f:
-        doc = io.read_pdf(f.read())
-    assert isinstance(doc, List[np.ndarray])
+        doc = io.read_pdf_as_numpy(f.read())
+    assert len(doc) == 1
+    assert isinstance(doc[0], np.ndarray)
 
     # Wrong input type
     with pytest.raises(TypeError):
-        _ = io.read_pdf(123)
+        _ = io.read_pdf_as_numpy(123)
 
     # Wrong path
     with pytest.raises(FileNotFoundError):
-        _ = io.read_pdf("my_imaginary_file.pdf")
+        _ = io.read_pdf_as_numpy("my_imaginary_file.pdf")
 
 
 def test_read_img_as_numpy(tmpdir_factory, mock_pdf):
@@ -85,5 +85,6 @@ def test_document_file(mock_pdf, mock_image_stream):
     pages = io.DocumentFile.from_images(mock_image_stream)
     _check_doc_content(pages, 1)
 
-    assert isinstance(io.DocumentFile.from_pdf(mock_pdf), List[np.ndarray])
-    assert isinstance(io.DocumentFile.from_url("https://www.google.com"), List[np.ndarray])
+    assert len(io.DocumentFile.from_pdf(mock_pdf)) == 1
+    assert isinstance(io.DocumentFile.from_pdf(mock_pdf)[0], np.ndarray)
+    assert isinstance(io.DocumentFile.from_url("https://www.google.com")[0], np.ndarray)

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -12,7 +12,7 @@ from doctr.utils import geometry
 
 
 def test_extract_crops(mock_pdf):  # noqa: F811
-    doc_img = DocumentFile.from_pdf(mock_pdf).as_images()[0]
+    doc_img = DocumentFile.from_pdf(mock_pdf)[0]
     num_crops = 2
     rel_boxes = np.array([[idx / num_crops, idx / num_crops, (idx + 1) / num_crops, (idx + 1) / num_crops]
                           for idx in range(num_crops)], dtype=np.float32)
@@ -46,7 +46,7 @@ def test_extract_crops(mock_pdf):  # noqa: F811
 
 
 def test_extract_rcrops(mock_pdf):  # noqa: F811
-    doc_img = DocumentFile.from_pdf(mock_pdf).as_images()[0]
+    doc_img = DocumentFile.from_pdf(mock_pdf)[0]
     num_crops = 2
     rel_boxes = np.array([[[idx / num_crops, idx / num_crops],
                            [idx / num_crops + .1, idx / num_crops],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import tempfile
 from io import BytesIO
 
 import cv2
-import fitz
 import hdf5storage
 import numpy as np
 import pytest
@@ -24,19 +23,13 @@ def mock_vocab():
 @pytest.fixture(scope="session")
 def mock_pdf(tmpdir_factory):
 
-    doc = fitz.open()
-
-    page = doc.new_page()
-    page.insert_text(fitz.Point(50, 100), "I am a jedi!", fontsize=20)
-    page = doc.new_page()
-    page.insert_text(fitz.Point(50, 100), "No, I am your father.", fontsize=20)
-
+    url = "https://github.com/mindee/doctr/releases/download/v0.5.0/mock_pdf.pdf"
+    file = BytesIO(requests.get(url).content)
     # Save the PDF
     fn = tmpdir_factory.mktemp("data").join("mock_pdf_file.pdf")
     with open(fn, 'wb') as f:
-        doc.save(f)
-
-    return str(fn)
+        f.write(file.getbuffer())
+    return fn
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,11 +22,11 @@ def mock_vocab():
 
 @pytest.fixture(scope="session")
 def mock_pdf(tmpdir_factory):
-
     url = "https://github.com/mindee/doctr/releases/download/v0.5.0/mock_pdf.pdf"
     file = BytesIO(requests.get(url).content)
     # Save the PDF
-    fn = tmpdir_factory.mktemp("data").join("mock_pdf_file.pdf")
+    folder = tmpdir_factory.mktemp("data")
+    fn = str(folder.join("mock_pdf_file.pdf"))
     with open(fn, 'wb') as f:
         f.write(file.getbuffer())
     return fn

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -35,7 +35,7 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
 
     assert not reco_predictor.model.training
 
-    doc = DocumentFile.from_pdf(mock_pdf).as_images()
+    doc = DocumentFile.from_pdf(mock_pdf)
 
     predictor = OCRPredictor(
         det_predictor,

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -39,7 +39,7 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         recognition.crnn_vgg16_bn(pretrained=False, pretrained_backbone=False, vocab=mock_vocab)
     )
 
-    doc = DocumentFile.from_pdf(mock_pdf).as_images()
+    doc = DocumentFile.from_pdf(mock_pdf)
 
     predictor = OCRPredictor(
         det_predictor,


### PR DESCRIPTION
This PR replaces PyMuPDF by pdf2image, which is under MIT license.
This library allows to convert a pdf (from both path and stream) to a list of images.
We loose the text extraction feature for source pdf, but we didn't use it so far so it won't change anything.

Any feedback is welcome!
closes #486 
closes #113 