### PR TITLE
fix: Fixes inplace target modifications for AbstractDatasets

### DIFF
--- a/doctr/datasets/datasets/pytorch.py
+++ b/doctr/datasets/datasets/pytorch.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
+from copy import deepcopy
 from typing import Any, List, Tuple
 
 import torch
@@ -22,7 +23,7 @@ class AbstractDataset(_AbstractDataset):
         # Read image
         img = read_img_as_tensor(os.path.join(self.root, img_name), dtype=torch.float32)
 
-        return img, target
+        return img, deepcopy(target)
 
     @staticmethod
     def collate_fn(samples: List[Tuple[torch.Tensor, Any]]) -> Tuple[torch.Tensor, List[Any]]:

--- a/doctr/datasets/datasets/tensorflow.py
+++ b/doctr/datasets/datasets/tensorflow.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import os
+from copy import deepcopy
 from typing import Any, List, Tuple
 
 import tensorflow as tf
@@ -22,7 +23,7 @@ class AbstractDataset(_AbstractDataset):
         # Read image
         img = read_img_as_tensor(os.path.join(self.root, img_name), dtype=tf.float32)
 
-        return img, target
+        return img, deepcopy(target)
 
     @staticmethod
     def collate_fn(samples: List[Tuple[tf.Tensor, Any]]) -> Tuple[tf.Tensor, List[Any]]:

--- a/tests/common/test_datasets.py
+++ b/tests/common/test_datasets.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
@@ -42,3 +43,13 @@ def test_abstractdataset(mock_image_path):
     ds.sample_transforms = lambda x, y: (x, y + 1)
     img3, target3 = ds[0]
     assert np.all(img3.numpy() == img.numpy()) and (target3 == (target + 1))
+
+    # Check inplace modifications
+    ds.data = [(ds.data[0][0], {"label": "A"})]
+    def inplace_transfo(x, target):
+        target["label"] += "B"
+        return x, target
+    ds.sample_transforms = inplace_transfo
+    _, t = ds[0]
+    _, t = ds[0]
+    assert t['label'] == "AB"

--- a/tests/common/test_datasets.py
+++ b/tests/common/test_datasets.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
@@ -46,6 +45,7 @@ def test_abstractdataset(mock_image_path):
 
     # Check inplace modifications
     ds.data = [(ds.data[0][0], {"label": "A"})]
+
     def inplace_transfo(x, target):
         target["label"] += "B"
         return x, target


### PR DESCRIPTION
This PR introduces the following modifications:
- updates `_read_sample` to return a deepcopy of the target to prevent inplace modifications
- adds a dedicated unittest (accessing several times a specific target will return the same value each time now, whether there are inplace transforms or not)

Closes #840

Any feedback is welcome!