### PR TITLE
docs: Fixed HTML title

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ html_theme_options = {
 
 html_logo = '_static/images/Logo-docTR-white.png'
 html_favicon = '_static/images/favicon.ico'
-
+html_title = 'docTR documentation'
 
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
With the new documentation theme, the HTML page title (the one appearing on tabs) is now "docTR 0.5.0a0-git documentation" which isn't very user-friendly. This PR sets it as "docTR documentation" (on the former theme, we had "docTR: Document Text Recognition documentation - v0.5.0a0-git")

Any feedback is welcome!