### PR TITLE
docs: Fixed typo in installation instructions

### DIFF
--- a/docs/source/getting_started/installing.rst
+++ b/docs/source/getting_started/installing.rst
@@ -43,13 +43,13 @@ We strive towards reducing framework-specific dependencies to a minimum, but som
 
         .. code:: bash
 
-            pip install python-doctr[tensorflow]
+            pip install "python-doctr[tf]"
 
     .. tab:: PyTorch
 
         .. code:: bash
 
-            pip install python-doctr[pytorch]
+            pip install "python-doctr[torch]"
 
 
 Via Git


### PR DESCRIPTION
Hey there 👋 

I noticed a small typo introduced in #862 for installation instructions. This PR simply fixes that for both tabs.

Any feedback is welcome!