### PR TITLE
fix: Fixed load_pretrained_params in PyTorch when ignoring keys

### DIFF
--- a/doctr/models/classification/magc_resnet/pytorch.py
+++ b/doctr/models/classification/magc_resnet/pytorch.py
@@ -137,7 +137,7 @@ def _magc_resnet(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        _ignore_keys = ignore_keys if kwargs['num_classes'] != len(default_cfgs[arch]['classes']) else None
         load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     return model

--- a/doctr/models/classification/magc_resnet/pytorch.py
+++ b/doctr/models/classification/magc_resnet/pytorch.py
@@ -110,6 +110,7 @@ def _magc_resnet(
     stage_stride: List[int],
     stage_conv: List[bool],
     stage_pooling: List[Optional[Tuple[int, int]]],
+    ignore_keys: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> ResNet:
 
@@ -134,12 +135,13 @@ def _magc_resnet(
     )
     # Load pretrained parameters
     if pretrained:
+        _kwargs = {}
         if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
             # The number of classes is not the same as the number of classes in the pretrained model =>
             # remove the last layer weights
-            load_pretrained_params(model, default_cfgs[arch]['url'], pop_entrys=['13.weight', '13.bias'])
-        else:
-            load_pretrained_params(model, default_cfgs[arch]['url'])
+            _kwargs = {"ignore_keys": ignore_keys}
+
+        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
 
     return model
 
@@ -172,5 +174,6 @@ def magc_resnet31(pretrained: bool = False, **kwargs: Any) -> ResNet:
         [(2, 2), (2, 1), None, None],
         origin_stem=False,
         stem_channels=128,
+        ignore_keys=['13.weight', '13.bias'],
         **kwargs,
     )

--- a/doctr/models/classification/magc_resnet/pytorch.py
+++ b/doctr/models/classification/magc_resnet/pytorch.py
@@ -135,13 +135,10 @@ def _magc_resnet(
     )
     # Load pretrained parameters
     if pretrained:
-        _kwargs = {}
-        if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
-            # The number of classes is not the same as the number of classes in the pretrained model =>
-            # remove the last layer weights
-            _kwargs = {"ignore_keys": ignore_keys}
-
-        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     return model
 

--- a/doctr/models/classification/mobilenet/pytorch.py
+++ b/doctr/models/classification/mobilenet/pytorch.py
@@ -87,12 +87,10 @@ def _mobilenet_v3(
 
     # Load pretrained parameters
     if pretrained:
-        _kwargs = {}
-        if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
-            # The number of classes is not the same as the number of classes in the pretrained model =>
-            # remove the last layer weights
-            _kwargs = {"ignore_keys": ignore_keys}
-        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     model.cfg = _cfg
 

--- a/doctr/models/classification/mobilenet/pytorch.py
+++ b/doctr/models/classification/mobilenet/pytorch.py
@@ -89,7 +89,7 @@ def _mobilenet_v3(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        _ignore_keys = ignore_keys if kwargs['num_classes'] != len(default_cfgs[arch]['classes']) else None
         load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     model.cfg = _cfg

--- a/doctr/models/classification/mobilenet/pytorch.py
+++ b/doctr/models/classification/mobilenet/pytorch.py
@@ -60,6 +60,7 @@ def _mobilenet_v3(
     arch: str,
     pretrained: bool,
     rect_strides: Optional[List[str]] = None,
+    ignore_keys: Optional[List[str]] = None,
     **kwargs: Any
 ) -> mobilenetv3.MobileNetV3:
 
@@ -86,13 +87,12 @@ def _mobilenet_v3(
 
     # Load pretrained parameters
     if pretrained:
+        _kwargs = {}
         if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
             # The number of classes is not the same as the number of classes in the pretrained model =>
             # remove the last layer weights
-            load_pretrained_params(model, default_cfgs[arch]['url'],
-                                   pop_entrys=['classifier.3.weight', 'classifier.3.bias'])
-        else:
-            load_pretrained_params(model, default_cfgs[arch]['url'])
+            _kwargs = {"ignore_keys": ignore_keys}
+        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
 
     model.cfg = _cfg
 
@@ -117,7 +117,12 @@ def mobilenet_v3_small(pretrained: bool = False, **kwargs: Any) -> mobilenetv3.M
         a torch.nn.Module
     """
 
-    return _mobilenet_v3('mobilenet_v3_small', pretrained, **kwargs)
+    return _mobilenet_v3(
+        'mobilenet_v3_small',
+        pretrained,
+        ignore_keys=['classifier.3.weight', 'classifier.3.bias'],
+        **kwargs
+    )
 
 
 def mobilenet_v3_small_r(pretrained: bool = False, **kwargs: Any) -> mobilenetv3.MobileNetV3:
@@ -142,6 +147,7 @@ def mobilenet_v3_small_r(pretrained: bool = False, **kwargs: Any) -> mobilenetv3
         'mobilenet_v3_small_r',
         pretrained,
         ['features.2.block.1.0', 'features.4.block.1.0', 'features.9.block.1.0'],
+        ignore_keys=['classifier.3.weight', 'classifier.3.bias'],
         **kwargs
     )
 
@@ -163,7 +169,12 @@ def mobilenet_v3_large(pretrained: bool = False, **kwargs: Any) -> mobilenetv3.M
     Returns:
         a torch.nn.Module
     """
-    return _mobilenet_v3('mobilenet_v3_large', pretrained, **kwargs)
+    return _mobilenet_v3(
+        'mobilenet_v3_large',
+        pretrained,
+        ignore_keys=['classifier.3.weight', 'classifier.3.bias'],
+        **kwargs,
+    )
 
 
 def mobilenet_v3_large_r(pretrained: bool = False, **kwargs: Any) -> mobilenetv3.MobileNetV3:
@@ -187,6 +198,7 @@ def mobilenet_v3_large_r(pretrained: bool = False, **kwargs: Any) -> mobilenetv3
         'mobilenet_v3_large_r',
         pretrained,
         ['features.4.block.1.0', 'features.7.block.1.0', 'features.13.block.1.0'],
+        ignore_keys=['classifier.3.weight', 'classifier.3.bias'],
         **kwargs
     )
 
@@ -209,4 +221,9 @@ def mobilenet_v3_small_orientation(pretrained: bool = False, **kwargs: Any) -> m
         a torch.nn.Module
     """
 
-    return _mobilenet_v3('mobilenet_v3_small_orientation', pretrained, **kwargs)
+    return _mobilenet_v3(
+        'mobilenet_v3_small_orientation',
+        pretrained,
+        ignore_keys=['classifier.3.weight', 'classifier.3.bias'],
+        **kwargs,
+    )

--- a/doctr/models/classification/resnet/pytorch.py
+++ b/doctr/models/classification/resnet/pytorch.py
@@ -177,7 +177,7 @@ def _resnet(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        _ignore_keys = ignore_keys if kwargs['num_classes'] != len(default_cfgs[arch]['classes']) else None
         load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     return model
@@ -205,7 +205,7 @@ def _tv_resnet(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        _ignore_keys = ignore_keys if kwargs['num_classes'] != len(default_cfgs[arch]['classes']) else None
         load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     model.cfg = _cfg

--- a/doctr/models/classification/resnet/pytorch.py
+++ b/doctr/models/classification/resnet/pytorch.py
@@ -159,6 +159,7 @@ def _resnet(
     stage_stride: List[int],
     stage_conv: List[bool],
     stage_pooling: List[Optional[Tuple[int, int]]],
+    ignore_keys: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> ResNet:
 
@@ -174,12 +175,13 @@ def _resnet(
     model = ResNet(num_blocks, output_channels, stage_stride, stage_conv, stage_pooling, cfg=_cfg, **kwargs)
     # Load pretrained parameters
     if pretrained:
+        _kwargs = {}
         if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
             # The number of classes is not the same as the number of classes in the pretrained model =>
             # remove the last layer weights
-            load_pretrained_params(model, default_cfgs[arch]['url'], pop_entrys=['13.weight', '13.bias'])
-        else:
-            load_pretrained_params(model, default_cfgs[arch]['url'])
+            _kwargs = {"ignore_keys": ignore_keys}
+            _kwargs = {"ignore_keys": ['13.weight', '13.bias']}
+        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
 
     return model
 
@@ -188,6 +190,7 @@ def _tv_resnet(
     arch: str,
     pretrained: bool,
     arch_fn,
+    ignore_keys: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> TVResNet:
 
@@ -203,12 +206,13 @@ def _tv_resnet(
     model = arch_fn(**kwargs)
     # Load pretrained parameters
     if pretrained:
+        _kwargs = {}
         if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
             # The number of classes is not the same as the number of classes in the pretrained model =>
             # remove the last layer weights
-            load_pretrained_params(model, default_cfgs[arch]['url'], pop_entrys=['fc.weight', 'fc.bias'])
-        else:
-            load_pretrained_params(model, default_cfgs[arch]['url'])
+            _kwargs = {"ignore_keys": ignore_keys}
+            _kwargs = {"ignore_keys": ['fc.weight', 'fc.bias']}
+        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
 
     model.cfg = _cfg
 
@@ -232,7 +236,13 @@ def resnet18(pretrained: bool = False, **kwargs: Any) -> TVResNet:
         A resnet18 model
     """
 
-    return _tv_resnet('resnet18', pretrained, tv_resnet18, **kwargs)
+    return _tv_resnet(
+        'resnet18',
+        pretrained,
+        tv_resnet18,
+        ignore_keys=['fc.weight', 'fc.bias'],
+        **kwargs,
+    )
 
 
 def resnet31(pretrained: bool = False, **kwargs: Any) -> ResNet:
@@ -263,6 +273,7 @@ def resnet31(pretrained: bool = False, **kwargs: Any) -> ResNet:
         [(2, 2), (2, 1), None, None],
         origin_stem=False,
         stem_channels=128,
+        ignore_keys=['13.weight', '13.bias'],
         **kwargs,
     )
 
@@ -284,7 +295,13 @@ def resnet34(pretrained: bool = False, **kwargs: Any) -> TVResNet:
         A resnet34 model
     """
 
-    return _tv_resnet('resnet34', pretrained, tv_resnet34, **kwargs)
+    return _tv_resnet(
+        'resnet34',
+        pretrained,
+        tv_resnet34,
+        ignore_keys=['fc.weight', 'fc.bias'],
+        **kwargs,
+    )
 
 
 def resnet34_wide(pretrained: bool = False, **kwargs: Any) -> ResNet:
@@ -314,6 +331,7 @@ def resnet34_wide(pretrained: bool = False, **kwargs: Any) -> ResNet:
         [None] * 4,
         origin_stem=True,
         stem_channels=128,
+        ignore_keys=['10.weight', '10.bias'],
         **kwargs,
     )
 
@@ -335,4 +353,10 @@ def resnet50(pretrained: bool = False, **kwargs: Any) -> TVResNet:
         A resnet50 model
     """
 
-    return _tv_resnet('resnet50', pretrained, tv_resnet50, **kwargs)
+    return _tv_resnet(
+        'resnet50',
+        pretrained,
+        tv_resnet50,
+        ignore_keys=['fc.weight', 'fc.bias'],
+        **kwargs,
+    )

--- a/doctr/models/classification/resnet/pytorch.py
+++ b/doctr/models/classification/resnet/pytorch.py
@@ -206,13 +206,10 @@ def _tv_resnet(
     model = arch_fn(**kwargs)
     # Load pretrained parameters
     if pretrained:
-        _kwargs = {}
-        if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
-            # The number of classes is not the same as the number of classes in the pretrained model =>
-            # remove the last layer weights
-            _kwargs = {"ignore_keys": ignore_keys}
-            _kwargs = {"ignore_keys": ['fc.weight', 'fc.bias']}
-        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     model.cfg = _cfg
 

--- a/doctr/models/classification/resnet/pytorch.py
+++ b/doctr/models/classification/resnet/pytorch.py
@@ -175,13 +175,10 @@ def _resnet(
     model = ResNet(num_blocks, output_channels, stage_stride, stage_conv, stage_pooling, cfg=_cfg, **kwargs)
     # Load pretrained parameters
     if pretrained:
-        _kwargs = {}
-        if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
-            # The number of classes is not the same as the number of classes in the pretrained model =>
-            # remove the last layer weights
-            _kwargs = {"ignore_keys": ignore_keys}
-            _kwargs = {"ignore_keys": ['13.weight', '13.bias']}
-        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     return model
 

--- a/doctr/models/classification/vgg/pytorch.py
+++ b/doctr/models/classification/vgg/pytorch.py
@@ -58,7 +58,7 @@ def _vgg(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        _ignore_keys = ignore_keys if kwargs['num_classes'] != len(default_cfgs[arch]['classes']) else None
         load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     model.cfg = _cfg

--- a/doctr/models/classification/vgg/pytorch.py
+++ b/doctr/models/classification/vgg/pytorch.py
@@ -32,6 +32,7 @@ def _vgg(
     pretrained: bool,
     tv_arch: str,
     num_rect_pools: int = 3,
+    ignore_keys: Optional[List[str]] = None,
     **kwargs: Any
 ) -> tv_vgg.VGG:
 
@@ -55,13 +56,12 @@ def _vgg(
     model.classifier = nn.Linear(512, kwargs['num_classes'])
     # Load pretrained parameters
     if pretrained:
+        _kwargs = {}
         if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
             # The number of classes is not the same as the number of classes in the pretrained model =>
             # remove the last layer weights
-            load_pretrained_params(model, default_cfgs[arch]['url'],
-                                   pop_entrys=['classifier.weight', 'classifier.bias'])
-        else:
-            load_pretrained_params(model, default_cfgs[arch]['url'])
+            _kwargs = {"ignore_keys": ignore_keys}
+        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
 
     model.cfg = _cfg
 
@@ -86,4 +86,11 @@ def vgg16_bn_r(pretrained: bool = False, **kwargs: Any) -> tv_vgg.VGG:
         VGG feature extractor
     """
 
-    return _vgg('vgg16_bn_r', pretrained, 'vgg16_bn', 3, **kwargs)
+    return _vgg(
+        'vgg16_bn_r',
+        pretrained,
+        'vgg16_bn',
+        3,
+        ignore_keys=['classifier.weight', 'classifier.bias'],
+        **kwargs,
+    )

--- a/doctr/models/classification/vgg/pytorch.py
+++ b/doctr/models/classification/vgg/pytorch.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from torch import nn
 from torchvision.models import vgg as tv_vgg

--- a/doctr/models/classification/vgg/pytorch.py
+++ b/doctr/models/classification/vgg/pytorch.py
@@ -56,12 +56,10 @@ def _vgg(
     model.classifier = nn.Linear(512, kwargs['num_classes'])
     # Load pretrained parameters
     if pretrained:
-        _kwargs = {}
-        if kwargs['num_classes'] != len(default_cfgs[arch]['classes']):
-            # The number of classes is not the same as the number of classes in the pretrained model =>
-            # remove the last layer weights
-            _kwargs = {"ignore_keys": ignore_keys}
-        load_pretrained_params(model, default_cfgs[arch]['url'], **_kwargs)
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        load_pretrained_params(model, default_cfgs[arch]['url'], ignore_keys=_ignore_keys)
 
     model.cfg = _cfg
 

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -221,6 +221,7 @@ def _crnn(
     pretrained: bool,
     backbone_fn: Callable[[Any], nn.Module],
     pretrained_backbone: bool = True,
+    ignore_keys: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> CRNN:
 
@@ -240,12 +241,10 @@ def _crnn(
     model = CRNN(feat_extractor, cfg=_cfg, **kwargs)  # type: ignore[arg-type]
     # Load pretrained parameters
     if pretrained:
-        if _cfg['vocab'] != default_cfgs[arch]['vocab']:
-            # The number of classes is not the same as the number of classes in the pretrained model =>
-            # remove the last layer weights
-            load_pretrained_params(model, _cfg['url'], pop_entrys=['linear.weight', 'linear.bias'])
-        else:
-            load_pretrained_params(model, _cfg['url'])
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        load_pretrained_params(model, _cfg['url'], ignore_keys=_ignore_keys)
 
     return model
 
@@ -267,7 +266,7 @@ def crnn_vgg16_bn(pretrained: bool = False, **kwargs: Any) -> CRNN:
         text recognition architecture
     """
 
-    return _crnn('crnn_vgg16_bn', pretrained, vgg16_bn_r, **kwargs)
+    return _crnn('crnn_vgg16_bn', pretrained, vgg16_bn_r, ignore_keys=['linear.weight', 'linear.bias'], **kwargs)
 
 
 def crnn_mobilenet_v3_small(pretrained: bool = False, **kwargs: Any) -> CRNN:
@@ -287,7 +286,13 @@ def crnn_mobilenet_v3_small(pretrained: bool = False, **kwargs: Any) -> CRNN:
         text recognition architecture
     """
 
-    return _crnn('crnn_mobilenet_v3_small', pretrained, mobilenet_v3_small_r, **kwargs)
+    return _crnn(
+        'crnn_mobilenet_v3_small',
+        pretrained,
+        mobilenet_v3_small_r,
+        ignore_keys=['linear.weight', 'linear.bias'],
+        **kwargs,
+    )
 
 
 def crnn_mobilenet_v3_large(pretrained: bool = False, **kwargs: Any) -> CRNN:
@@ -307,4 +312,10 @@ def crnn_mobilenet_v3_large(pretrained: bool = False, **kwargs: Any) -> CRNN:
         text recognition architecture
     """
 
-    return _crnn('crnn_mobilenet_v3_large', pretrained, mobilenet_v3_large_r, **kwargs)
+    return _crnn(
+        'crnn_mobilenet_v3_large',
+        pretrained,
+        mobilenet_v3_large_r,
+        ignore_keys=['linear.weight', 'linear.bias'],
+        **kwargs,
+    )

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -243,7 +243,7 @@ def _crnn(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs['num_classes'] == len(default_cfgs[arch]['classes']) else None
+        _ignore_keys = ignore_keys if _cfg['vocab'] == default_cfgs[arch]['vocab'] else None
         load_pretrained_params(model, _cfg['url'], ignore_keys=_ignore_keys)
 
     return model

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -243,7 +243,7 @@ def _crnn(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if _cfg['vocab'] == default_cfgs[arch]['vocab'] else None
+        _ignore_keys = ignore_keys if _cfg['vocab'] != default_cfgs[arch]['vocab'] else None
         load_pretrained_params(model, _cfg['url'], ignore_keys=_ignore_keys)
 
     return model

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -28,7 +28,7 @@ def load_pretrained_params(
     >>> load_pretrained_params(model, "https://yoursource.com/yourcheckpoint-yourhash.zip")
 
     Args:
-        model: the keras model to be loaded
+        model: the PyTorch model to be loaded
         url: URL of the zipped set of parameters
         hash_prefix: first characters of SHA256 expected hash
         overwrite: should the zip extraction be enforced if the archive has already been extracted

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -48,8 +48,8 @@ def load_pretrained_params(
             for key in ignore_keys:
                 state_dict.pop(key)
             missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
-            if len(missing_keys) != len(ignore_keys) or len(unexpected_keys) > 0:
-                raise AssertionError("unable to load state_dict")
+            if set(missing_keys) != set(ignore_keys) or len(unexpected_keys) > 0:
+                raise ValueError("unable to load state_dict, due to non-matching keys.")
         else:
             # Load weights
             model.load_state_dict(state_dict)

--- a/tests/pytorch/test_models_classification_pt.py
+++ b/tests/pytorch/test_models_classification_pt.py
@@ -46,9 +46,8 @@ def test_classification_architectures(arch_name, input_shape, output_size):
     # Model
     model = classification.__dict__[arch_name](pretrained=True).eval()
     _test_classification(model, input_shape, output_size)
-    # test pretrained model with different num_classes
-    model = classification.__dict__[arch_name](pretrained=True, num_classes=108).eval()
-    _test_classification(model, input_shape, output_size=(108,))
+    # Check that you can pretrained everything up until the last layer
+    classification.__dict__[arch_name](pretrained=True, num_classes=10)
 
 
 @pytest.mark.parametrize(

--- a/tests/pytorch/test_models_utils_pt.py
+++ b/tests/pytorch/test_models_utils_pt.py
@@ -16,10 +16,16 @@ def test_load_pretrained_params(tmpdir_factory):
     # Pass an incorrect hash
     with pytest.raises(ValueError):
         load_pretrained_params(model, url, "mywronghash", cache_dir=str(cache_dir))
-    # Let tit resolve the hash from the file name
+    # Let it resolve the hash from the file name
     load_pretrained_params(model, url, cache_dir=str(cache_dir))
     # Check that the file was downloaded & the archive extracted
     assert os.path.exists(cache_dir.join('models').join(url.rpartition("/")[-1]))
+    # Check ignore keys
+    load_pretrained_params(model, url, cache_dir=str(cache_dir), ignore_keys=["2.weight"])
+    # non matching keys
+    model = nn.Sequential(nn.Linear(8, 8), nn.ReLU(), nn.Linear(8, 4), nn.ReLU(), nn.Linear(4, 1))
+    with pytest.raises(ValueError):
+        load_pretrained_params(model, url, cache_dir=str(cache_dir), ignore_keys=["2.weight"])
 
 
 def test_conv_sequence():


### PR DESCRIPTION
Following up on #874, this PR introduces the following modifications:
- renamed "pop_entrys" to "ignore_keys"
- updated `load_pretrained_params` to avoid non-strict loading of wrongly sized state_dict
- fixed classification models `ignore_keys` mechanism (the keys to ignore were hardcoded in the factory function, while this function is used to build models of different size, and thus with Linear layers being named differently)
- added dedicated unittest for `ignore_keys`

Any feedback is welcome!