### PR TITLE
ci: Add swagger ping in API CI job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build & run docker
         run: PORT=8002 docker-compose up -d --build
+      - name: Ping server
+        run: curl http://localhost:8002/docs
       - name: Install dependencies in docker
         run: |
           PORT=8002 docker-compose exec -T web python -m pip install --upgrade pip


### PR DESCRIPTION
Following up on #847, this PR introduces the following modification:
- adds a step in CI job for API, to ping the swagger before running the unittest

Presumably, if the behaviour described in #847, the CI should fail on this PR.

Any feedback is welcome!