### PR TITLE
docs: Improved error message of encode_string

### DIFF
--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -72,7 +72,10 @@ def encode_string(
     Returns:
         A list encoding the input_string"""
 
-    return list(map(vocab.index, input_string))  # type: ignore[arg-type]
+    try:
+        return list(map(vocab.index, input_string))  # type: ignore[arg-type]
+    except ValueError:
+        raise ValueError("some characters cannot be found in 'vocab'")
 
 
 def decode_sequence(


### PR DESCRIPTION
This PR improves the error message of `encode_string` when a character is not to be found in the vocab.

Closes #927

Any feedback is welcome!