### PR TITLE
[models]: update master PT add checks for each reco model and xorresponding test

### DIFF
--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -194,6 +194,9 @@ class CRNN(RecognitionModel, nn.Module):
         return_preds: bool = False,
     ) -> Dict[str, Any]:
 
+        if self.training and target is None:
+            raise ValueError('Need to provide labels during training for teacher forcing')
+
         features = self.feat_extractor(x)
         # B x C x H x W --> B x C*H x W --> B x W x C*H
         c, h, w = features.shape[1], features.shape[2], features.shape[3]

--- a/doctr/models/recognition/crnn/tensorflow.py
+++ b/doctr/models/recognition/crnn/tensorflow.py
@@ -195,6 +195,9 @@ class CRNN(RecognitionModel, Model):
         **kwargs: Any,
     ) -> Dict[str, Any]:
 
+        if kwargs.get('training', False) and target is None:
+            raise ValueError('Need to provide labels during training for teacher forcing')
+
         features = self.feat_extractor(x, **kwargs)
         # B x H x W x C --> B x W x H x C
         transposed_feat = tf.transpose(features, perm=[0, 2, 1, 3])

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -176,6 +176,9 @@ class MASTER(_MASTER, nn.Module):
 
         out: Dict[str, Any] = {}
 
+        if self.training and target is None:
+            raise ValueError('Need to provide labels during training for teacher forcing')
+
         if target is not None:
             # Compute target: tensor of gts and sequence lengths
             _gt, _seq_len = self.build_target(target)
@@ -213,7 +216,7 @@ class MASTER(_MASTER, nn.Module):
         b = encoded.size(0)
 
         # Padding symbol + SOS at the beginning
-        ys = torch.zeros((b, self.max_length), dtype=torch.long, device=encoded.device) * (self.vocab_size + 2)  # pad
+        ys = torch.ones((b, self.max_length), dtype=torch.long, device=encoded.device) * (self.vocab_size + 2)  # pad
         ys[:, 0] = self.vocab_size + 1  # sos
 
         # Final dimension include EOS/SOS/PAD

--- a/doctr/models/recognition/master/tensorflow.py
+++ b/doctr/models/recognition/master/tensorflow.py
@@ -159,7 +159,7 @@ class MASTER(_MASTER, Model):
 
         if kwargs.get('training', False):
             if target is None:
-                raise AssertionError("In training mode, you need to pass a value to 'target'")
+                raise ValueError("In training mode, you need to pass a value to 'target'")
             tgt_mask = self.make_mask(gt)
             # Compute logits
             output = self.decoder(gt, encoded, tgt_mask, None, **kwargs)

--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -239,6 +239,10 @@ class SAR(nn.Module, RecognitionModel):
             _gt, _seq_len = self.build_target(target)
             gt, seq_len = torch.from_numpy(_gt).to(dtype=torch.long), torch.tensor(_seq_len)  # type: ignore[assignment]
             gt, seq_len = gt.to(x.device), seq_len.to(x.device)
+
+        if self.training and target is None:
+            raise ValueError('Need to provide labels during training for teacher forcing')
+
         decoded_features = self.decoder(features, encoded, gt=None if target is None else gt)
 
         out: Dict[str, Any] = {}

--- a/doctr/models/recognition/sar/tensorflow.py
+++ b/doctr/models/recognition/sar/tensorflow.py
@@ -299,7 +299,7 @@ class SAR(Model, RecognitionModel):
             gt, seq_len = self.build_target(target)
             seq_len = tf.cast(seq_len, tf.int32)
 
-        if kwargs.get('training', False) and gt is None:
+        if kwargs.get('training', False) and target is None:
             raise ValueError('Need to provide labels during training for teacher forcing')
 
         decoded_features = self.decoder(features, encoded, gt=None if target is None else gt, **kwargs)

--- a/doctr/models/recognition/transformer/pytorch.py
+++ b/doctr/models/recognition/transformer/pytorch.py
@@ -59,17 +59,17 @@ def scaled_dot_product_attention(
 class PositionwiseFeedForward(nn.Module):
     """ Position-wise Feed-Forward Network """
 
-    def __init__(self, d_model: int, ffd: int, dropout=0.1) -> None:
+    def __init__(self, d_model: int, ffd: int, dropout: float = 0.1) -> None:
         super(PositionwiseFeedForward, self).__init__()
-        self.first_linear = nn.Linear(d_model, ffd)
-        self.sec_linear = nn.Linear(ffd, d_model)
-        self.dropout = nn.Dropout(p=dropout)
+        self.feed_forward = nn.Sequential(
+            nn.Linear(d_model, ffd),
+            nn.ReLU(),
+            nn.Dropout(p=dropout),
+            nn.Linear(ffd, d_model),
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = torch.relu(self.first_linear(x))
-        x = self.dropout(x)
-        x = self.sec_linear(x)
-        return x
+        return self.feed_forward(x)
 
 
 class MultiHeadAttention(nn.Module):
@@ -77,7 +77,7 @@ class MultiHeadAttention(nn.Module):
 
     def __init__(self, num_heads: int, d_model: int, dropout: float = 0.1) -> None:
         super().__init__()
-        assert d_model % num_heads == 0
+        assert d_model % num_heads == 0, "d_model must be divisible by num_heads"
 
         self.d_k = d_model // num_heads
         self.num_heads = num_heads

--- a/tests/pytorch/test_models_recognition_pt.py
+++ b/tests/pytorch/test_models_recognition_pt.py
@@ -14,7 +14,7 @@ from doctr.models.recognition.predictor import RecognitionPredictor
         ["crnn_mobilenet_v3_small", (3, 32, 128), True],
         ["crnn_mobilenet_v3_large", (3, 32, 128), True],
         ["sar_resnet31", (3, 32, 128), False],
-        ["master", (3, 48, 160), False],
+        ["master", (3, 32, 128), False],
     ],
 )
 def test_recognition_models(arch_name, input_shape, pretrained, mock_vocab):
@@ -36,6 +36,10 @@ def test_recognition_models(arch_name, input_shape, pretrained, mock_vocab):
     assert isinstance(out['out_map'], torch.Tensor)
     assert out['out_map'].dtype == torch.float32
     assert isinstance(out['loss'], torch.Tensor)
+    # test model in train mode needs targets
+    with pytest.raises(ValueError):
+        model.train()
+        model(input_tensor, None)
 
 
 @pytest.mark.parametrize(

--- a/tests/tensorflow/test_models_recognition_tf.py
+++ b/tests/tensorflow/test_models_recognition_tf.py
@@ -38,6 +38,9 @@ def test_recognition_models(arch_name, input_shape):
     assert len(out['preds']) == batch_size
     assert all(isinstance(word, str) and isinstance(conf, float) and 0 <= conf <= 1 for word, conf in out['preds'])
     assert isinstance(out['loss'], tf.Tensor)
+    # test model in train mode needs targets
+    with pytest.raises(ValueError):
+        reco_model(input_tensor, None, training=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR:

- apply suggestions for MASTER PT @frgfm 
- add check each recognition model if train mode that targets != None and corresponding test

Any feedback is welcome :hugs: 

Inference again evaluated pipe and single word crop:

```
Line(
            (words): [
              Word(value='des', confidence=0.86),
              Word(value='Hausanschus', confidence=0.47),
              Word(value='und', confidence=0.83),
              Word(value='Keleraumes', confidence=0.39),
              Word(value='erhalten', confidence=0.75),
            ]
          ),
```
results are really impressive :+1: 
