### PR TITLE
[ONNX/Tests] Part2 add ONNX tests for TF and PT detection models

### DIFF
--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -95,6 +95,18 @@ class FeaturePyramidNetwork(nn.Module):
 
 
 class DBNet(_DBNet, nn.Module):
+    """DBNet as described in `"Real-time Scene Text Detection with Differentiable Binarization"
+    <https://arxiv.org/pdf/1911.08947.pdf>`_.
+
+    Args:
+        feature extractor: the backbone serving as feature extractor
+        head_chans: the number of channels in the head
+        deform_conv: whether to use deformable convolution
+        num_classes: number of output channels in the segmentation map
+        assume_straight_pages: if True, fit straight bounding boxes only
+        exportable: onnx exportable returns only logits
+        cfg: the configuration dict of the model
+    """
 
     def __init__(
         self,

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -103,6 +103,7 @@ class DBNet(_DBNet, nn.Module):
         deform_conv: bool = False,
         num_classes: int = 1,
         assume_straight_pages: bool = True,
+        exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
 
@@ -111,6 +112,7 @@ class DBNet(_DBNet, nn.Module):
 
         conv_layer = DeformConv2d if deform_conv else nn.Conv2d
 
+        self.exportable = exportable
         self.assume_straight_pages = assume_straight_pages
 
         self.feat_extractor = feat_extractor
@@ -175,6 +177,10 @@ class DBNet(_DBNet, nn.Module):
         logits = self.prob_head(feat_concat)
 
         out: Dict[str, Any] = {}
+        if self.exportable:
+            out['logits'] = logits
+            return out
+
         if return_model_output or target is None or return_preds:
             prob_map = torch.sigmoid(logits)
 

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -111,6 +111,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         fpn_channels: number of channels each extracted feature maps is mapped to
         num_classes: number of output channels in the segmentation map
         assume_straight_pages: if True, fit straight bounding boxes only
+        exportable: onnx exportable returns only logits
         cfg: the configuration dict of the model
     """
 

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -122,6 +122,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         fpn_channels: int = 128,  # to be set to 256 to represent the author's initial idea
         num_classes: int = 1,
         assume_straight_pages: bool = True,
+        exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
 
@@ -129,6 +130,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         self.cfg = cfg
 
         self.feat_extractor = feature_extractor
+        self.exportable = exportable
         self.assume_straight_pages = assume_straight_pages
 
         self.fpn = FeaturePyramidNetwork(channels=fpn_channels)
@@ -228,6 +230,10 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         logits = self.probability_head(feat_concat, **kwargs)
 
         out: Dict[str, tf.Tensor] = {}
+        if self.exportable:
+            out['logits'] = logits
+            return out
+
         if return_model_output or target is None or return_preds:
             prob_map = tf.math.sigmoid(logits)
 

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -86,6 +86,17 @@ class LinkNetFPN(nn.Module):
 
 
 class LinkNet(nn.Module, _LinkNet):
+    """LinkNet as described in `"LinkNet: Exploiting Encoder Representations for Efficient Semantic Segmentation"
+    <https://arxiv.org/pdf/1707.03718.pdf>`_.
+
+    Args:
+        feature extractor: the backbone serving as feature extractor
+        num_classes: number of output channels in the segmentation map
+        head_chans: number of channels in the head layers
+        assume_straight_pages: if True, fit straight bounding boxes only
+        exportable: onnx exportable returns only logits
+        cfg: the configuration dict of the model
+    """
 
     def __init__(
         self,

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -93,11 +93,13 @@ class LinkNet(nn.Module, _LinkNet):
         num_classes: int = 1,
         head_chans: int = 32,
         assume_straight_pages: bool = True,
+        exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
 
         super().__init__()
         self.cfg = cfg
+        self.exportable = exportable
         self.assume_straight_pages = assume_straight_pages
 
         self.feat_extractor = feat_extractor
@@ -153,6 +155,10 @@ class LinkNet(nn.Module, _LinkNet):
         logits = self.classifier(logits)
 
         out: Dict[str, Any] = {}
+        if self.exportable:
+            out['logits'] = logits
+            return out
+
         if return_model_output or target is None or return_preds:
             prob_map = torch.sigmoid(logits)
         if return_model_output:

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -106,7 +106,12 @@ class LinkNet(_LinkNet, keras.Model):
     <https://arxiv.org/pdf/1707.03718.pdf>`_.
 
     Args:
-        num_classes: number of channels for the output
+        feature extractor: the backbone serving as feature extractor
+        fpn_channels: number of channels each extracted feature maps is mapped to
+        num_classes: number of output channels in the segmentation map
+        assume_straight_pages: if True, fit straight bounding boxes only
+        exportable: onnx exportable returns only logits
+        cfg: the configuration dict of the model
     """
 
     _children_names: List[str] = ['feat_extractor', 'fpn', 'classifier', 'postprocessor']

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -117,10 +117,12 @@ class LinkNet(_LinkNet, keras.Model):
         fpn_channels: int = 64,
         num_classes: int = 1,
         assume_straight_pages: bool = True,
+        exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(cfg=cfg)
 
+        self.exportable = exportable
         self.assume_straight_pages = assume_straight_pages
 
         self.feat_extractor = feat_extractor
@@ -214,6 +216,10 @@ class LinkNet(_LinkNet, keras.Model):
         logits = self.classifier(logits, **kwargs)
 
         out: Dict[str, tf.Tensor] = {}
+        if self.exportable:
+            out['logits'] = logits
+            return out
+
         if return_model_output or target is None or return_preds:
             prob_map = tf.math.sigmoid(logits)
         if return_model_output:


### PR DESCRIPTION
This PR:

- adds test cases to ensure all detection models can be exported into ONNX format in both frameworks
- update missing docstrings

Any feedback is welcome :hugs: 

NOTE: Part2 is splitted in detection and recognition
slow tests will be introduced with the recognition test PR 

Issues:
#789 #790 