### PR TITLE
[ONNX/Tests] Part2 add ONNX tests for TF and PT recognition models 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,17 @@ style:
 # Run tests for the library
 test:
 	coverage run -m pytest tests/common/
-	USE_TF='1' coverage run -m pytest tests/tensorflow/
-	USE_TORCH='1' coverage run -m pytest tests/pytorch/
+	USE_TF='1' SLOW='1' coverage run -m pytest tests/tensorflow/
+	USE_TORCH='1' SLOW='1' coverage run -m pytest tests/pytorch/
 
 test-common:
 	coverage run -m pytest tests/common/
 
 test-tf:
-	USE_TF='1' coverage run -m pytest tests/tensorflow/
+	USE_TF='1' SLOW='1' coverage run -m pytest tests/tensorflow/
 
 test-torch:
-	USE_TORCH='1' coverage run -m pytest tests/pytorch/
+	USE_TORCH='1' SLOW='1' coverage run -m pytest tests/pytorch/
 
 # Check that docs can build
 docs-single-version:

--- a/doctr/models/recognition/crnn/pytorch.py
+++ b/doctr/models/recognition/crnn/pytorch.py
@@ -106,6 +106,7 @@ class CRNN(RecognitionModel, nn.Module):
         feature_extractor: the backbone serving as feature extractor
         vocab: vocabulary used for encoding
         rnn_units: number of units in the LSTM layers
+        exportable: onnx exportable returns only logits
         cfg: configuration dictionary
     """
 
@@ -117,12 +118,14 @@ class CRNN(RecognitionModel, nn.Module):
         vocab: str,
         rnn_units: int = 128,
         input_shape: Tuple[int, int, int] = (3, 32, 128),
+        exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
         self.vocab = vocab
         self.cfg = cfg
         self.max_length = 32
+        self.exportable = exportable
         self.feat_extractor = feature_extractor
 
         # Resolve the input_size of the LSTM
@@ -206,6 +209,10 @@ class CRNN(RecognitionModel, nn.Module):
         logits = self.linear(logits)
 
         out: Dict[str, Any] = {}
+        if self.exportable:
+            out['logits'] = logits
+            return out
+
         if return_model_output:
             out["out_map"] = logits
 

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -46,6 +46,7 @@ class MASTER(_MASTER, nn.Module):
         max_length: maximum length of character sequence handled by the model
         dropout: dropout probability of the decoder
         input_shape: size of the image inputs
+        exportable: onnx exportable returns only logits
         cfg: dictionary containing information about the model
     """
 
@@ -60,10 +61,12 @@ class MASTER(_MASTER, nn.Module):
         max_length: int = 50,
         dropout: float = 0.2,
         input_shape: Tuple[int, int, int] = (3, 32, 128),  # different from the paper
+        exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
 
+        self.exportable = exportable
         self.max_length = max_length
         self.d_model = d_model
         self.vocab = vocab
@@ -192,6 +195,10 @@ class MASTER(_MASTER, nn.Module):
             logits = self.linear(output)
         else:
             logits = self.decode(encoded)
+
+        if self.exportable:
+            out['logits'] = logits
+            return out
 
         if target is not None:
             out['loss'] = self.compute_loss(logits, gt, seq_len)

--- a/doctr/models/recognition/master/tensorflow.py
+++ b/doctr/models/recognition/master/tensorflow.py
@@ -45,6 +45,7 @@ class MASTER(_MASTER, Model):
         max_length: maximum length of character sequence handled by the model
         dropout: dropout probability of the decoder
         input_shape: size of the image inputs
+        exportable: onnx exportable returns only logits
         cfg: dictionary containing information about the model
     """
 
@@ -59,10 +60,12 @@ class MASTER(_MASTER, Model):
         max_length: int = 50,
         dropout: float = 0.2,
         input_shape: Tuple[int, int, int] = (32, 128, 3),  # different from the paper
+        exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
 
+        self.exportable = exportable
         self.max_length = max_length
         self.d_model = d_model
         self.vocab = vocab
@@ -184,6 +187,10 @@ class MASTER(_MASTER, Model):
             logits = self.linear(output, **kwargs)
         else:
             logits = self.decode(encoded, **kwargs)
+
+        if self.exportable:
+            out['logits'] = logits
+            return out
 
         if target is not None:
             out['loss'] = self.compute_loss(logits, gt, seq_len)

--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -176,7 +176,8 @@ class SAR(nn.Module, RecognitionModel):
         attention_units: number of hidden units in attention module
         max_length: maximum word length handled by the model
         dropout_prob: dropout probability of the encoder LSTM
-        cfg: default setup dict of the model
+        exportable: onnx exportable returns only logits
+        cfg: dictionary containing information about the model
     """
 
     def __init__(
@@ -189,11 +190,13 @@ class SAR(nn.Module, RecognitionModel):
         max_length: int = 30,
         dropout_prob: float = 0.,
         input_shape: Tuple[int, int, int] = (3, 32, 128),
+        exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
 
         super().__init__()
         self.vocab = vocab
+        self.exportable = exportable
         self.cfg = cfg
 
         self.max_length = max_length + 1  # Add 1 timestep for EOS after the longest word
@@ -246,6 +249,10 @@ class SAR(nn.Module, RecognitionModel):
         decoded_features = self.decoder(features, encoded, gt=None if target is None else gt)
 
         out: Dict[str, Any] = {}
+        if self.exportable:
+            out['logits'] = decoded_features
+            return out
+
         if return_model_output:
             out["out_map"] = decoded_features
 

--- a/tests/pytorch/test_models_recognition_pt.py
+++ b/tests/pytorch/test_models_recognition_pt.py
@@ -1,3 +1,7 @@
+import os
+import tempfile
+
+import onnxruntime
 import pytest
 import torch
 
@@ -5,6 +9,7 @@ from doctr.models import recognition
 from doctr.models.recognition.crnn.pytorch import CTCPostProcessor
 from doctr.models.recognition.master.pytorch import MASTERPostProcessor
 from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.models.utils import export_model_to_onnx
 
 
 @pytest.mark.parametrize(
@@ -87,3 +92,31 @@ def test_recognition_zoo(arch_name):
     out = predictor(input_tensor)
     assert isinstance(out, list) and len(out) == batch_size
     assert all(isinstance(word, str) and isinstance(conf, float) for word, conf in out)
+
+
+@pytest.mark.skipif(os.getenv("SLOW", '0') == '0', reason="slow test")
+@pytest.mark.parametrize(
+    "arch_name, input_shape",
+    [
+        ["crnn_vgg16_bn", (3, 32, 128)],
+        ["crnn_mobilenet_v3_small", (3, 32, 128)],
+        ["crnn_mobilenet_v3_large", (3, 32, 128)],
+        ["sar_resnet31", (3, 32, 128)],
+        ["master", (3, 32, 128)],  # cf. https://github.com/microsoft/onnxruntime/issues/10994 onnxruntime issue
+    ],
+)
+def test_models_onnx_export(arch_name, input_shape):
+    # Model
+    batch_size = 2
+    model = recognition.__dict__[arch_name](pretrained=True, exportable=True).eval()
+    dummy_input = torch.rand((batch_size, *input_shape), dtype=torch.float32)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Export
+        model_path = export_model_to_onnx(model, model_name=os.path.join(tmpdir, "model"), dummy_input=dummy_input)
+        assert os.path.exists(model_path)
+        # Inference
+        ort_session = onnxruntime.InferenceSession(os.path.join(tmpdir, "model.onnx"),
+                                                   providers=["CPUExecutionProvider"])
+        ort_outs = ort_session.run(['logits'], {'input': dummy_input.numpy()})
+        assert isinstance(ort_outs, list) and len(ort_outs) == 1
+        assert ort_outs[0].shape[0] == batch_size

--- a/tests/tensorflow/test_models_recognition_tf.py
+++ b/tests/tensorflow/test_models_recognition_tf.py
@@ -1,4 +1,9 @@
+import os
+import shutil
+import tempfile
+
 import numpy as np
+import onnxruntime
 import pytest
 import tensorflow as tf
 
@@ -9,6 +14,7 @@ from doctr.models.recognition.crnn.tensorflow import CTCPostProcessor
 from doctr.models.recognition.master.tensorflow import MASTERPostProcessor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.models.recognition.sar.tensorflow import SARPostProcessor
+from doctr.models.utils import export_model_to_onnx
 from doctr.utils.geometry import extract_crops
 
 
@@ -139,3 +145,51 @@ def test_crnn_beam_search(arch_name):
 def test_recognition_zoo_error():
     with pytest.raises(ValueError):
         _ = recognition.zoo.recognition_predictor("my_fancy_model", pretrained=False)
+
+
+@pytest.mark.skipif(os.getenv("SLOW", '0') == '0', reason="slow test")
+@pytest.mark.parametrize(
+    "arch_name, input_shape",
+    [
+        ["crnn_vgg16_bn", (32, 128, 3)],
+        ["crnn_mobilenet_v3_small", (32, 128, 3)],
+        ["crnn_mobilenet_v3_large", (32, 128, 3)],
+        ["sar_resnet31", (32, 128, 3)],
+        ["master", (32, 128, 3)],
+    ],
+)
+def test_models_onnx_export(arch_name, input_shape):
+    # Model
+    batch_size = 2
+    tf.keras.backend.clear_session()
+    model = recognition.__dict__[arch_name](pretrained=True, exportable=True, input_shape=input_shape)
+    if arch_name == 'sar_resnet31':  # SAR export currently only available with constant batch size
+        dummy_input = [tf.TensorSpec([batch_size, *input_shape], tf.float32, name="input")]
+    elif arch_name == 'master':  # MASTER export currently only available with constant batch size
+        dummy_input = [tf.TensorSpec([batch_size, *input_shape], tf.float32, name="input")]
+    else:
+        # batch_size = None for dynamic batch size
+        dummy_input = [tf.TensorSpec([None, *input_shape], tf.float32, name="input")]
+    np_dummy_input = np.random.rand(batch_size, *input_shape).astype(np.float32)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Export
+        model_path, output = export_model_to_onnx(
+            model,
+            model_name=os.path.join(tmpdir, "model"),
+            dummy_input=dummy_input,
+            large_model=True if arch_name == 'master' else False,
+        )
+        assert os.path.exists(model_path)
+
+        if arch_name == 'master':
+            # large models are exported as zip archive
+            shutil.unpack_archive(model_path, tmpdir, 'zip')
+            model_path = os.path.join(tmpdir, '__MODEL_PROTO.onnx')
+        else:
+            model_path = os.path.join(tmpdir, 'model.onnx')
+
+        # Inference
+        ort_session = onnxruntime.InferenceSession(model_path, providers=["CPUExecutionProvider"])
+        ort_outs = ort_session.run(output, {'input': np_dummy_input})
+        assert isinstance(ort_outs, list) and len(ort_outs) == 1
+        assert ort_outs[0].shape[0] == batch_size


### PR DESCRIPTION
This PR:

- adds test cases to ensure all recognition models can be exported into ONNX format in both frameworks
Note: MASTER PT can be exported but not loaded with onnxruntime there is an internal ticket i have linked it in the test
- introduces slow tests which are only tested on local machine (to ensure CI instance will not be killed :sweat_smile: )

Any feedback is welcome :hugs: 

Issues:
#789 #790 