### PR TITLE
[datasets] revert whitespace filtering and fix svhn reco

### DIFF
--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -153,10 +153,10 @@ jobs:
           pip install -e .[torch] --upgrade
       - if: matrix.framework == 'tensorflow'
         name: Evaluate text recognition (TF)
-        run: python references/recognition/evaluate_tensorflow.py crnn_mobilenet_v3_small --dataset IIIT5K
+        run: python references/recognition/evaluate_tensorflow.py crnn_mobilenet_v3_small --dataset IIIT5K -b 32
       - if: matrix.framework == 'pytorch'
         name: Evaluate text recognition (PT)
-        run: python references/recognition/evaluate_pytorch.py crnn_mobilenet_v3_small --dataset IIIT5K
+        run: python references/recognition/evaluate_pytorch.py crnn_mobilenet_v3_small --dataset IIIT5K -b 32
 
   latency-text-recognition:
     runs-on: ${{ matrix.os }}

--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -97,9 +97,7 @@ class CORD(VisionDataset):
                 crops = crop_bboxes_from_image(img_path=os.path.join(tmp_root, img_path),
                                                geoms=np.asarray(box_targets, dtype=int).clip(min=0))
                 for crop, label in zip(crops, list(text_targets)):
-                    # filter labels with whitespaces
-                    if ' ' not in label:
-                        self.data.append((crop, dict(labels=[label])))
+                    self.data.append((crop, dict(labels=[label])))
             else:
                 self.data.append((
                     img_path,

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -91,8 +91,8 @@ class FUNSD(VisionDataset):
                 crops = crop_bboxes_from_image(img_path=os.path.join(tmp_root, img_path),
                                                geoms=np.asarray(box_targets, dtype=np_dtype))
                 for crop, label in zip(crops, list(text_targets)):
-                    # filter labels with non utf-8 characters and whitespaces
-                    if not any(char in label for char in [' ', '☑', '☐', '\uf703', '\uf702']):
+                    # filter labels with non utf-8 characters
+                    if not any(char in label for char in ['☑', '☐', '\uf703', '\uf702']):
                         self.data.append((crop, dict(labels=[label])))
             else:
                 self.data.append((

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -91,7 +91,7 @@ class FUNSD(VisionDataset):
                 crops = crop_bboxes_from_image(img_path=os.path.join(tmp_root, img_path),
                                                geoms=np.asarray(box_targets, dtype=np_dtype))
                 for crop, label in zip(crops, list(text_targets)):
-                    # filter labels with non utf-8 characters
+                    # filter labels with unknown characters
                     if not any(char in label for char in ['☑', '☐', '\uf703', '\uf702']):
                         self.data.append((crop, dict(labels=[label])))
             else:

--- a/doctr/datasets/svhn.py
+++ b/doctr/datasets/svhn.py
@@ -114,7 +114,8 @@ class SVHN(VisionDataset):
                 if recognition_task:
                     crops = crop_bboxes_from_image(img_path=os.path.join(tmp_root, img_name), geoms=box_targets)
                     for crop, label in zip(crops, label_targets):
-                        self.data.append((crop, dict(labels=[label])))
+                        if crop.shape[0] > 0 and crop.shape[1] > 0 and len(label) > 0:
+                            self.data.append((crop, dict(labels=[label])))
                 else:
                     self.data.append((img_name, dict(boxes=box_targets, labels=label_targets)))
 

--- a/references/recognition/evaluate_pytorch.py
+++ b/references/recognition/evaluate_pytorch.py
@@ -146,7 +146,7 @@ def parse_args():
     parser.add_argument('--vocab', type=str, default="french", help='Vocab to be used for evaluation')
     parser.add_argument('--dataset', type=str, default="FUNSD", help='Dataset to evaluate on')
     parser.add_argument('--device', default=None, type=int, help='device')
-    parser.add_argument('-b', '--batch_size', type=int, default=32, help='batch size for evaluation')
+    parser.add_argument('-b', '--batch_size', type=int, default=1, help='batch size for evaluation')
     parser.add_argument('--input_size', type=int, default=32, help='input size H for the model, W = 4*H')
     parser.add_argument('-j', '--workers', type=int, default=None, help='number of workers used for dataloading')
     parser.add_argument('--only_regular', dest='regular', action='store_true',

--- a/references/recognition/evaluate_tensorflow.py
+++ b/references/recognition/evaluate_tensorflow.py
@@ -124,7 +124,7 @@ def parse_args():
     parser.add_argument('arch', type=str, help='text-recognition model to evaluate')
     parser.add_argument('--vocab', type=str, default="french", help='Vocab to be used for evaluation')
     parser.add_argument('--dataset', type=str, default="FUNSD", help='Dataset to evaluate on')
-    parser.add_argument('-b', '--batch_size', type=int, default=32, help='batch size for evaluation')
+    parser.add_argument('-b', '--batch_size', type=int, default=1, help='batch size for evaluation')
     parser.add_argument('--input_size', type=int, default=32, help='input size H for the model, W = 4*H')
     parser.add_argument('-j', '--workers', type=int, default=None, help='number of workers used for dataloading')
     parser.add_argument('--only_regular', dest='regular', action='store_true',


### PR DESCRIPTION
This PR:

- reverts the whitespace filtering in FUNSD and CORD (is to much focused then to be used only inside docTR)
- update recognition eval scripts and corresponding CI job ( batch_size = 1 as default to ensure nothing is skipped in fact of whitespaces seperated labels)
- add fix for svhn dataset (recognition)

Any feddback is welcome :hugs: 
