### PR TITLE
pytest-api test: fix ping server step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,15 +18,17 @@ jobs:
 
   pytest-api:
     runs-on: ubuntu-latest
+    env:
+        PORT=8002
     steps:
       - uses: actions/checkout@v2
       - name: Build & run docker
-        run: PORT=8002 docker-compose up -d --build
+        run: docker-compose up -d --build
       - name: Ping server
-        run: curl http://localhost:8002/docs
+        run: curl http://localhost:$PORT/docs
       - name: Install dependencies in docker
         run: |
-          PORT=8002 docker-compose exec -T web python -m pip install --upgrade pip
-          PORT=8002 docker-compose exec -T web pip install -r requirements-dev.txt
+          docker-compose exec -T web python -m pip install --upgrade pip
+          docker-compose exec -T web pip install -r requirements-dev.txt
       - name: Run docker test
-        run: PORT=8002 docker-compose exec -T web pytest .
+        run: docker-compose exec -T web pytest .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
     env:
         # Port for web container
         # See docker-compose.yml
-        PORT=8002
+        PORT: 8002
     steps:
       - uses: actions/checkout@v2
       - name: Build & run docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,8 @@ jobs:
   pytest-api:
     runs-on: ubuntu-latest
     env:
+        # Port for web container
+        # See docker-compose.yml
         PORT=8002
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build & run docker
         run: docker-compose up -d --build
       - name: Ping server
-        run: curl http://localhost:$PORT/docs
+        run: wget --spider --tries=12 http://localhost:$PORT/docs
       - name: Install dependencies in docker
         run: |
           docker-compose exec -T web python -m pip install --upgrade pip

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,6 @@
-fastapi>=0.73.0
+# Fastapi: minimum version required to avoid pydantic error
+# cf. https://github.com/tiangolo/fastapi/issues/4168
+fastapi>=0.73.0 
 uvicorn>=0.11.1
 python-multipart==0.0.5
 python-doctr>=0.2.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.65.2
+fastapi>=0.73.0
 uvicorn>=0.11.1
 python-multipart==0.0.5
 python-doctr>=0.2.0

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -3,26 +3,26 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-import pytest
+import pytest_asyncio
 import requests
 from httpx import AsyncClient
 
 from app.main import app
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 def mock_recognition_image(tmpdir_factory):
     url = 'https://user-images.githubusercontent.com/76527547/117133599-c073fa00-ada4-11eb-831b-412de4d28341.jpeg'
     return requests.get(url).content
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 def mock_detection_image(tmpdir_factory):
     url = 'https://user-images.githubusercontent.com/76527547/117319856-fc35bf00-ae8b-11eb-9b51-ca5aba673466.jpg'
     return requests.get(url).content
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def test_app_asyncio():
     # for httpx>=20, follow_redirects=True (cf. https://github.com/encode/httpx/releases/tag/0.20.0)
     async with AsyncClient(app=app, base_url="http://test") as ac:


### PR DESCRIPTION
This PR aims two solve problems:

* to fix this error on CI : https://github.com/mindee/doctr/runs/7517599231?check_suite_focus=true
`curl` command in CI is run but the API is not fully ready so the `Ping server` step often failed. There is an option `--retry-all-errors` since curl 7.71.0 but there is only curl 7.68.0 on `ubuntu-latest` (which is ubuntu 20.04) and that's not that simple to update curl to this version.
I replaced `curl` by `wget` with option `--spider`.
From man page:
```
--spider
When invoked with this option, Wget will behave as a Web spider, which means that it will not download the pages, just check that they are there.
```

* fix https://github.com/mindee/doctr/issues/847. The problem comes from Tuples on fastapi, see https://github.com/tiangolo/fastapi/issues/4168, https://github.com/tiangolo/fastapi/issues/3782 and https://github.com/tiangolo/fastapi/issues/3665#issuecomment-1019579214. Updating `fastapi` version should fix the problem.