### PR TITLE
Changes needed to be able to use doctr on AWS Lambda

### DIFF
--- a/doctr/utils/data.py
+++ b/doctr/utils/data.py
@@ -70,7 +70,10 @@ def download_from_url(
         file_name = url.rpartition('/')[-1]
 
     if not isinstance(cache_dir, str):
-        cache_dir = os.path.join(os.path.expanduser('~'), '.cache', 'doctr')
+        if os.environ['DOCTR_CACHE_DIR']:
+            cache_dir = os.environ['DOCTR_CACHE_DIR']
+        else:
+            cache_dir = os.path.join(os.path.expanduser('~'), '.cache', 'doctr')
 
     # Check hash in file name
     if hash_prefix is None:

--- a/doctr/utils/multithreading.py
+++ b/doctr/utils/multithreading.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 
+import os
 import multiprocessing as mp
 from multiprocessing.pool import ThreadPool
 from typing import Any, Callable, Iterable, Optional
@@ -29,8 +30,8 @@ def multithread_exec(func: Callable[[Any], Any], seq: Iterable[Any], threads: Op
 
     threads = threads if isinstance(threads, int) else min(16, mp.cpu_count())
     # Single-thread
-    if threads < 2:
-        results = map(func, seq)
+    if threads < 2 or os.environ['DOCTR_CONCURRENCY_DISABLE'] == 'true':
+        results = list(map(func, seq))
     # Multi-threading
     else:
         with ThreadPool(threads) as tp:


### PR DESCRIPTION
I want to use `doctr` on `AWS Lambda`, but there is a restriction: it gives a function write access only under `/tmp` folder.
I have found two places where `doctr` claims write access outside this folder:
1. While caching downloaded models.
2. By using `ThreadPool` from python's `multiprocessing` package: it uses `/dev/shm` folder for shared memory which is not present on `AWS Lambda`.

That's why I think it would be nice to add an option for user to decide where models should be cached and whether to use `multiprocessing` or not.