### PR TITLE
[Fix] rotation classifier input move to model device

### DIFF
--- a/doctr/models/classification/predictor/pytorch.py
+++ b/doctr/models/classification/predictor/pytorch.py
@@ -44,7 +44,8 @@ class CropOrientationPredictor(nn.Module):
             raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")
 
         processed_batches = self.pre_processor(crops)
-        predicted_batches = [self.model(batch) for batch in processed_batches]
+        _device = next(self.model.parameters()).device
+        predicted_batches = [self.model(batch).to(device=_device) for batch in processed_batches]
 
         # Postprocess predictions
         predicted_batches = [out_batch.argmax(dim=1).cpu().detach().numpy() for out_batch in predicted_batches]


### PR DESCRIPTION
This PR:

- fix moving rotation classifier input to cuda device if given

Closes:
#1020 