### PR TITLE
add ViT as classification model TF and PT

### DIFF
--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -29,6 +29,8 @@ doctr.models.classification
 
 .. autofunction:: doctr.models.classification.magc_resnet31
 
+.. autofunction:: doctr.models.classification.vit
+
 .. autofunction:: doctr.models.classification.crop_orientation_predictor
 
 

--- a/doctr/models/classification/__init__.py
+++ b/doctr/models/classification/__init__.py
@@ -2,4 +2,5 @@ from .mobilenet import *
 from .resnet import *
 from .vgg import *
 from .magc_resnet import *
+from .vit import *
 from .zoo import *

--- a/doctr/models/classification/vit/__init__.py
+++ b/doctr/models/classification/vit/__init__.py
@@ -1,0 +1,6 @@
+from doctr.file_utils import is_tf_available, is_torch_available
+
+if is_tf_available():
+    from .tensorflow import *
+elif is_torch_available():
+    from .pytorch import *

--- a/doctr/models/classification/vit/__init__.py
+++ b/doctr/models/classification/vit/__init__.py
@@ -3,4 +3,4 @@ from doctr.file_utils import is_tf_available, is_torch_available
 if is_tf_available():
     from .tensorflow import *
 elif is_torch_available():
-    from .pytorch import *
+    from .pytorch import *  # type: ignore[misc]

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -11,7 +11,7 @@ from torch import nn
 
 from doctr.datasets import VOCABS
 from doctr.models.modules.transformer import EncoderBlock
-from doctr.models.modules.vision_transformer import PatchEmbedding
+from doctr.models.modules.vision_transformer.pytorch import PatchEmbedding
 
 from ...utils.pytorch import load_pretrained_params
 

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -10,9 +10,9 @@ import torch
 from torch import nn
 
 from doctr.datasets import VOCABS
-from doctr.models.modules.transformer import MultiHeadAttention, PositionwiseFeedForward
 
 from ...utils.pytorch import load_pretrained_params
+from doctr.models.modules.transformer import MultiHeadAttention, PositionwiseFeedForward
 
 __all__ = ["vit"]
 
@@ -119,6 +119,7 @@ class VisionTransformer(nn.Module):
         # (batch_size, seq_len + cls token, d_model)
         output = self.layer_norm(output)
         if self.include_top:
+            # (batch_size, num_classes) cls token
             output = self.head(output[:, 0])
 
         return output

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -10,9 +10,10 @@ import torch
 from torch import nn
 
 from doctr.datasets import VOCABS
+from doctr.models.modules.transformer import EncoderBlock
+from doctr.models.modules.vision_transformer import PatchEmbedding
 
 from ...utils.pytorch import load_pretrained_params
-from doctr.models.modules.transformer import MultiHeadAttention, PositionwiseFeedForward
 
 __all__ = ["vit"]
 
@@ -28,33 +29,6 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
 }
 
 
-class PatchEmbedding(nn.Module):
-    """Compute 2D patch embedding"""
-
-    # Inpired by: https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/patch_embed.py
-
-    def __init__(
-        self,
-        img_size: Tuple[int, int],
-        patch_size: Tuple[int, int],
-        channels: int,
-        embed_dim: int,
-    ) -> None:
-
-        super().__init__()
-        self.img_size = img_size
-        self.patch_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
-        self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
-        self.proj = nn.Conv2d(channels, embed_dim, kernel_size=patch_size, stride=patch_size)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        B, C, H, W = x.shape
-        assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
-        assert W % self.patch_size[1] == 0, "Image width must be divisible by patch width"
-
-        return self.proj(x)  # BCHW
-
-
 class VisionTransformer(nn.Module):
     """VisionTransformer architecture as described in
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
@@ -64,65 +38,35 @@ class VisionTransformer(nn.Module):
         self,
         img_size: Tuple[int, int],
         patch_size: Tuple[int, int],
-        channels: int = 3,
-        d_model: int = 768,
-        num_layers: int = 12,
-        num_heads: int = 12,
-        dropout: float = 0.1,
+        channels: int,
+        d_model: int,
+        num_layers: int,
+        num_heads: int,
+        dropout: float = 0.0,
         num_classes: int = 1000,
         include_top: bool = True,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
 
         super().__init__()
-        self.img_size = img_size
-        self.patch_size = patch_size
-        self.num_layers = num_layers
         self.include_top = include_top
 
-        self.patch_embedding = PatchEmbedding(self.img_size, self.patch_size, channels, d_model)
-        self.num_patches = self.patch_embedding.num_patches
-        self.cls_token = nn.Parameter(torch.randn(1, 1, d_model))  # type: ignore[attr-defined]
-        self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, d_model))  # type: ignore[attr-defined]
+        self.patch_embedding = PatchEmbedding(img_size, patch_size, channels, d_model)
+        self.encoder = EncoderBlock(num_layers, num_heads, d_model, dropout, use_gelu=True)
 
-        self.layer_norm = nn.LayerNorm(d_model, eps=1e-5)
-        self.dropout = nn.Dropout(dropout)
-
-        self.attention = nn.ModuleList(
-            [MultiHeadAttention(num_heads, d_model, dropout) for _ in range(self.num_layers)]
-        )
-        self.position_feed_forward = nn.ModuleList(
-            [PositionwiseFeedForward(d_model, d_model, dropout, use_gelu=True) for _ in range(self.num_layers)]
-        )
         if self.include_top:
             self.head = nn.Linear(d_model, num_classes)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        patches = self.patch_embedding(x)
 
-        B, C, H, W = patches.shape
-        patches = patches.view(B, C, -1).permute(0, 2, 1)  # (batch_size, num_patches, d_model)
-        cls_tokens = self.cls_token.repeat(B, 1, 1)  # (batch_size, 1, d_model)
-        # concate cls_tokens to patches
-        embeddings = torch.cat([cls_tokens, patches], dim=1)  # (batch_size, num_patches + 1, d_model)
-        # add positions to embeddings
-        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
+        embeddings = self.patch_embedding(x)
+        encoded = self.encoder(embeddings)
 
-        output = embeddings
-
-        for i in range(self.num_layers):
-            normed_output = self.layer_norm(output)
-            output = output + self.dropout(self.attention[i](normed_output, normed_output, normed_output))
-            normed_output = self.layer_norm(output)
-            output = output + self.dropout(self.position_feed_forward[i](normed_output))
-
-        # (batch_size, seq_len + cls token, d_model)
-        output = self.layer_norm(output)
         if self.include_top:
             # (batch_size, num_classes) cls token
-            output = self.head(output[:, 0])
+            return self.head(encoded[:, 0])
 
-        return output
+        return encoded
 
 
 def _vit(
@@ -130,10 +74,10 @@ def _vit(
     pretrained: bool,
     img_size: Tuple[int, int],
     patch_size: Tuple[int, int],
-    channels: int = 3,
-    embed_dim: int = 768,
-    num_layers: int = 12,
-    num_heads: int = 12,
+    channels: int,
+    embed_dim: int,
+    num_layers: int,
+    num_heads: int,
     dropout: float = 0.0,
     include_top: bool = True,
     ignore_keys: Optional[List[str]] = None,
@@ -191,8 +135,12 @@ def vit(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     return _vit(
         "vit",
         pretrained,
-        img_size=[32, 32],
-        patch_size=[4, 4],
+        img_size=(32, 32),
+        patch_size=(4, 4),
+        channels=3,
+        embed_dim=768,
+        num_layers=12,
+        num_heads=12,
         ignore_keys=["head.weight", "head.bias"],
         **kwargs,
     )

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -61,7 +61,7 @@ class VisionTransformer(nn.Module):
         super().__init__()
         self.include_top = include_top
 
-        self.patch_embedding = PatchEmbedding(input_shape[1:], patch_size, input_shape[0], d_model)
+        self.patch_embedding = PatchEmbedding(input_shape, patch_size, d_model)
         self.encoder = EncoderBlock(num_layers, num_heads, d_model, dropout, nn.GELU())
 
         if self.include_top:

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -1,0 +1,197 @@
+# Copyright (C) 2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+from torch import nn
+
+from doctr.datasets import VOCABS
+from doctr.models.modules.transformer import MultiHeadAttention, PositionwiseFeedForward
+
+from ...utils.pytorch import load_pretrained_params
+
+__all__ = ["vit"]
+
+
+default_cfgs: Dict[str, Dict[str, Any]] = {
+    "vit": {
+        "mean": (0.694, 0.695, 0.693),
+        "std": (0.299, 0.296, 0.301),
+        "input_shape": (3, 32, 32),
+        "classes": list(VOCABS["french"]),
+        "url": None,
+    },
+}
+
+
+class PatchEmbedding(nn.Module):
+    """Compute 2D patch embedding"""
+
+    # Inpired by: https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/patch_embed.py
+
+    def __init__(
+        self,
+        img_size: Tuple[int, int],
+        patch_size: Tuple[int, int],
+        channels: int,
+        embed_dim: int,
+    ) -> None:
+
+        super().__init__()
+        self.img_size = img_size
+        self.patch_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
+        self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
+        self.proj = nn.Conv2d(channels, embed_dim, kernel_size=patch_size, stride=patch_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, C, H, W = x.shape
+        assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
+        assert W % self.patch_size[1] == 0, "Image width must be divisible by patch width"
+
+        return self.proj(x)  # BCHW
+
+
+class VisionTransformer(nn.Module):
+    """VisionTransformer architecture as described in
+    `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    <https://arxiv.org/pdf/2010.11929.pdf>`_."""
+
+    def __init__(
+        self,
+        img_size: Tuple[int, int],
+        patch_size: Tuple[int, int],
+        channels: int = 3,
+        d_model: int = 768,
+        num_layers: int = 12,
+        num_heads: int = 12,
+        dropout: float = 0.1,
+        num_classes: int = 1000,
+        include_top: bool = True,
+        cfg: Optional[Dict[str, Any]] = None,
+    ) -> None:
+
+        super().__init__()
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.num_layers = num_layers
+        self.include_top = include_top
+
+        self.patch_embedding = PatchEmbedding(self.img_size, self.patch_size, channels, d_model)
+        self.num_patches = self.patch_embedding.num_patches
+        self.cls_token = nn.Parameter(torch.randn(1, 1, d_model))  # type: ignore[attr-defined]
+        self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, d_model))  # type: ignore[attr-defined]
+
+        self.layer_norm = nn.LayerNorm(d_model, eps=1e-5)
+        self.dropout = nn.Dropout(dropout)
+
+        self.attention = nn.ModuleList(
+            [MultiHeadAttention(num_heads, d_model, dropout) for _ in range(self.num_layers)]
+        )
+        self.position_feed_forward = nn.ModuleList(
+            [PositionwiseFeedForward(d_model, d_model, dropout, use_gelu=True) for _ in range(self.num_layers)]
+        )
+        if self.include_top:
+            self.head = nn.Linear(d_model, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        patches = self.patch_embedding(x)
+
+        B, C, H, W = patches.shape
+        patches = patches.view(B, C, -1).permute(0, 2, 1)  # (batch_size, num_patches, d_model)
+        cls_tokens = self.cls_token.repeat(B, 1, 1)  # (batch_size, 1, d_model)
+        # concate cls_tokens to patches
+        embeddings = torch.cat([cls_tokens, patches], dim=1)  # (batch_size, num_patches + 1, d_model)
+        # add positions to embeddings
+        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
+
+        output = embeddings
+
+        for i in range(self.num_layers):
+            normed_output = self.layer_norm(output)
+            output = output + self.dropout(self.attention[i](normed_output, normed_output, normed_output))
+            normed_output = self.layer_norm(output)
+            output = output + self.dropout(self.position_feed_forward[i](normed_output))
+
+        # (batch_size, seq_len + cls token, d_model)
+        output = self.layer_norm(output)
+        if self.include_top:
+            output = self.head(output[:, 0])
+
+        return output
+
+
+def _vit(
+    arch: str,
+    pretrained: bool,
+    img_size: Tuple[int, int],
+    patch_size: Tuple[int, int],
+    channels: int = 3,
+    embed_dim: int = 768,
+    num_layers: int = 12,
+    num_heads: int = 12,
+    dropout: float = 0.0,
+    include_top: bool = True,
+    ignore_keys: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> VisionTransformer:
+
+    kwargs["num_classes"] = kwargs.get("num_classes", len(default_cfgs[arch]["classes"]))
+    kwargs["classes"] = kwargs.get("classes", default_cfgs[arch]["classes"])
+
+    _cfg = deepcopy(default_cfgs[arch])
+    _cfg["num_classes"] = kwargs["num_classes"]
+    _cfg["classes"] = kwargs["classes"]
+    kwargs.pop("classes")
+
+    # Build the model
+    model = VisionTransformer(
+        img_size=img_size,
+        patch_size=patch_size,
+        channels=channels,
+        d_model=embed_dim,
+        num_layers=num_layers,
+        num_heads=num_heads,
+        dropout=dropout,
+        cfg=_cfg,
+        **kwargs,
+    )
+    # Load pretrained parameters
+    if pretrained:
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) else None
+        load_pretrained_params(model, default_cfgs[arch]["url"], ignore_keys=_ignore_keys)
+
+    return model
+
+
+def vit(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
+    """VisionTransformer architecture as described in
+    `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+
+    >>> import torch
+    >>> from doctr.models import vit
+    >>> model = vit(pretrained=False)
+    >>> input_tensor = torch.rand((1, 3, 32, 32), dtype=tf.float32)
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained: boolean, True if model is pretrained
+
+    Returns:
+        A feature extractor model
+    """
+
+    return _vit(
+        "vit",
+        pretrained,
+        img_size=[32, 32],
+        patch_size=[4, 4],
+        ignore_keys=["head.weight", "head.bias"],
+        **kwargs,
+    )

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -32,7 +32,19 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
 class VisionTransformer(nn.Module):
     """VisionTransformer architecture as described in
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
-    <https://arxiv.org/pdf/2010.11929.pdf>`_."""
+    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+
+    Args:
+        img_size: size of the input image
+        patch_size: size of the patches to be extracted from the input
+        channels: number of channels in the input image
+        d_model: dimension of the transformer layers
+        num_layers: number of transformer layers
+        num_heads: number of attention heads
+        dropout: dropout rate
+        num_classes: number of output classes
+        include_top: whether the classifier head should be instantiated
+    """
 
     def __init__(
         self,

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -37,7 +37,6 @@ class VisionTransformer(nn.Module):
     Args:
         input_shape: size of the input image
         patch_size: size of the patches to be extracted from the input
-        channels: number of channels in the input image
         d_model: dimension of the transformer layers
         num_layers: number of transformer layers
         num_heads: number of attention heads
@@ -50,7 +49,6 @@ class VisionTransformer(nn.Module):
         self,
         input_shape: Tuple[int, int, int],
         patch_size: Tuple[int, int] = (4, 4),
-        channels: int = 3,
         d_model: int = 768,
         num_layers: int = 12,
         num_heads: int = 12,
@@ -63,8 +61,8 @@ class VisionTransformer(nn.Module):
         super().__init__()
         self.include_top = include_top
 
-        self.patch_embedding = PatchEmbedding(input_shape[1:], patch_size, channels, d_model)
-        self.encoder = EncoderBlock(num_layers, num_heads, d_model, dropout, use_gelu=True)
+        self.patch_embedding = PatchEmbedding(input_shape[1:], patch_size, input_shape[0], d_model)
+        self.encoder = EncoderBlock(num_layers, num_heads, d_model, dropout, nn.GELU())
 
         if self.include_top:
             self.head = nn.Linear(d_model, num_classes)

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
 import tensorflow as tf
-from tensorflow.keras import layers
+from tensorflow.keras import layers, Sequential
 
 from doctr.datasets import VOCABS
 from doctr.models.modules.transformer import MultiHeadAttention, PositionwiseFeedForward
@@ -61,7 +61,7 @@ class PatchEmbedding(layers.Layer, NestedObject):
         return self.proj(x, **kwargs)  # BHWC
 
 
-class VisionTransformer(layers.Layer, NestedObject):
+class VisionTransformer(Sequential):
     """VisionTransformer architecture as described in
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
     <https://arxiv.org/pdf/2010.11929.pdf>`_."""

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -11,7 +11,8 @@ from tensorflow.keras import Sequential, layers
 
 from doctr.datasets import VOCABS
 from doctr.models.modules.transformer import EncoderBlock
-from doctr.models.modules.vision_transformer import PatchEmbedding
+from doctr.models.modules.vision_transformer.tensorflow import PatchEmbedding
+from doctr.utils.repr import NestedObject
 
 from ...utils import load_pretrained_params
 
@@ -44,6 +45,40 @@ class VisionTransformer(Sequential):
         num_classes: number of output classes
         include_top: whether the classifier head should be instantiated
     """
+
+    def __init__(
+        self,
+        input_shape: Tuple[int, int, int],
+        patch_size: Tuple[int, int] = (4, 4),
+        d_model: int = 768,
+        num_layers: int = 12,
+        num_heads: int = 12,
+        dropout: float = 0.0,
+        num_classes: int = 1000,
+        include_top: bool = True,
+        cfg: Optional[Dict[str, Any]] = None,
+    ) -> None:
+
+        _layers = []
+        _layers.append(
+            _VisionTransformer(
+                input_shape,
+                patch_size,
+                d_model,
+                num_layers,
+                num_heads,
+                dropout,
+                num_classes,
+                include_top,
+            )
+        )
+        super().__init__(_layers)
+        self.cfg = cfg
+
+
+class _VisionTransformer(layers.Layer, NestedObject):
+
+    # Note: fix for onnx export
 
     def __init__(
         self,

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -1,0 +1,201 @@
+# Copyright (C) 2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Tuple
+
+import tensorflow as tf
+from tensorflow.keras import layers
+
+from doctr.datasets import VOCABS
+from doctr.models.modules.transformer import MultiHeadAttention, PositionwiseFeedForward
+from doctr.utils.repr import NestedObject
+
+from ...utils import load_pretrained_params
+
+__all__ = ["vit"]
+
+
+default_cfgs: Dict[str, Dict[str, Any]] = {
+    "vit": {
+        "mean": (0.694, 0.695, 0.693),
+        "std": (0.299, 0.296, 0.301),
+        "input_shape": (32, 32, 3),
+        "classes": list(VOCABS["french"]),
+        "url": None,
+    },
+}
+
+tf.config.run_functions_eagerly(True)
+
+
+class PatchEmbedding(layers.Layer, NestedObject):
+    """Compute 2D patch embedding"""
+
+    def __init__(
+        self,
+        img_size: Tuple[int, int],
+        patch_size: Tuple[int, int],
+        embed_dim: int,
+    ) -> None:
+
+        super().__init__()
+        self.img_size = img_size
+        self.patch_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
+        self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
+        self.proj = layers.Conv2D(
+            embed_dim,
+            kernel_size=patch_size,
+            strides=patch_size,
+            padding="valid",
+            kernel_initializer="he_normal",
+        )
+
+    def call(self, x: tf.Tensor, **kwargs: Any) -> tf.Tensor:
+        B, W, H, C = x.shape
+        assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
+        assert W % self.patch_size[1] == 0, "Image width must be divisible by patch width"
+
+        return self.proj(x, **kwargs)  # BHWC
+
+
+class VisionTransformer(layers.Layer, NestedObject):
+    """VisionTransformer architecture as described in
+    `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    <https://arxiv.org/pdf/2010.11929.pdf>`_."""
+
+    def __init__(
+        self,
+        patch_size: Tuple[int, int],
+        input_shape: Tuple[int, int, int] = (32, 32, 3),
+        d_model: int = 768,
+        num_layers: int = 12,
+        num_heads: int = 12,
+        dropout: float = 0.1,
+        num_classes: int = 1000,
+        include_top: bool = True,
+        cfg: Optional[Dict[str, Any]] = None,
+    ) -> None:
+
+        super().__init__()
+        self.patch_size = patch_size
+        self.num_layers = num_layers
+        self.include_top = include_top
+
+        self.patch_embedding = PatchEmbedding(input_shape[:-1], self.patch_size, d_model)
+        self.num_patches = self.patch_embedding.num_patches
+        self.cls_token = self.add_weight(shape=(1, 1, d_model), initializer="zeros", trainable=True, name="cls_token")
+        self.positions = self.add_weight(
+            shape=(1, self.num_patches + 1, d_model), initializer="zeros", trainable=True, name="positions"
+        )
+
+        self.layer_norm = layers.LayerNormalization(epsilon=1e-5)
+        self.dropout = layers.Dropout(rate=dropout)
+
+        self.attention = [MultiHeadAttention(num_heads, d_model, dropout) for _ in range(self.num_layers)]
+        self.position_feed_forward = [
+            PositionwiseFeedForward(d_model, d_model, dropout, use_gelu=True) for _ in range(self.num_layers)
+        ]
+
+        if self.include_top:
+            self.head = layers.Dense(num_classes, kernel_initializer="he_normal")
+
+    def __call__(self, x: tf.Tensor, **kwargs: Any) -> tf.Tensor:
+        patches = self.patch_embedding(x)
+
+        B, C, H, W = patches.shape
+        patches = tf.reshape(patches, (B, (C * H), W))  # (batch_size, num_patches, d_model)
+
+        cls_tokens = tf.repeat(self.cls_token, B, axis=0)  # (batch_size, num_patches, d_model)
+        # concate cls_tokens to patches
+        embeddings = tf.concat([cls_tokens, patches], axis=1)  # (batch_size, num_patches + 1, d_model)
+        # add positions to embeddings
+        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
+
+        output = embeddings
+
+        for i in range(self.num_layers):
+            normed_output = self.layer_norm(output, **kwargs)
+            output = output + self.dropout(
+                self.attention[i](normed_output, normed_output, normed_output, **kwargs),
+                **kwargs,
+            )
+            normed_output = self.layer_norm(output, **kwargs)
+            output = output + self.dropout(self.position_feed_forward[i](normed_output, **kwargs), **kwargs)
+
+        # (batch_size, seq_len + cls token, d_model)
+        output = self.layer_norm(output, **kwargs)
+        if self.include_top:
+            # (batch_size, num_classes) cls token
+            output = self.head(output[:, 0], **kwargs)
+
+        return output
+
+
+def _vit(
+    arch: str,
+    pretrained: bool,
+    patch_size: Tuple[int, int],
+    embed_dim: int = 768,
+    num_layers: int = 12,
+    num_heads: int = 12,
+    dropout: float = 0.0,
+    include_top: bool = True,
+    ignore_keys: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> VisionTransformer:
+
+    kwargs["num_classes"] = kwargs.get("num_classes", len(default_cfgs[arch]["classes"]))
+    kwargs["input_shape"] = kwargs.get("input_shape", default_cfgs[arch]["input_shape"])
+    kwargs["classes"] = kwargs.get("classes", default_cfgs[arch]["classes"])
+
+    _cfg = deepcopy(default_cfgs[arch])
+    _cfg["num_classes"] = kwargs["num_classes"]
+    _cfg["classes"] = kwargs["classes"]
+    _cfg["input_shape"] = kwargs["input_shape"]
+    kwargs.pop("classes")
+
+    # Build the model
+    model = VisionTransformer(
+        patch_size=patch_size,
+        d_model=embed_dim,
+        num_layers=num_layers,
+        num_heads=num_heads,
+        dropout=dropout,
+        include_top=include_top,
+        cfg=_cfg,
+        **kwargs,
+    )
+    # Load pretrained parameters
+    if pretrained:
+        load_pretrained_params(model, default_cfgs[arch]["url"])
+
+    return model
+
+
+def vit(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
+    """VisionTransformer architecture as described in
+    `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+
+    >>> import tensorflow as tf
+    >>> from doctr.models import vit
+    >>> model = vit(pretrained=False)
+    >>> input_tensor = tf.random.uniform(shape=[1, 32, 32, 3], maxval=1, dtype=tf.float32)
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained: boolean, True if model is pretrained
+
+    Returns:
+        A feature extractor model
+    """
+
+    return _vit(
+        "vit",
+        pretrained,
+        patch_size=[4, 4],
+        **kwargs,
+    )

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import tensorflow as tf
 from tensorflow.keras import Sequential, layers
+from tensorflow_addons.layers import GELU
 
 from doctr.datasets import VOCABS
 from doctr.models.modules.transformer import EncoderBlock
@@ -59,20 +60,17 @@ class VisionTransformer(Sequential):
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
 
-        _layers = []
-        _layers.append(
-            _VisionTransformer(
-                input_shape,
-                patch_size,
-                d_model,
-                num_layers,
-                num_heads,
-                dropout,
-                num_classes,
-                include_top,
-            )
+        _vit = _VisionTransformer(
+            input_shape,
+            patch_size,
+            d_model,
+            num_layers,
+            num_heads,
+            dropout,
+            num_classes,
+            include_top,
         )
-        super().__init__(_layers)
+        super().__init__(_vit)
         self.cfg = cfg
 
 
@@ -97,7 +95,7 @@ class _VisionTransformer(layers.Layer, NestedObject):
         self.include_top = include_top
 
         self.patch_embedding = PatchEmbedding(input_shape[:-1], patch_size, d_model)
-        self.encoder = EncoderBlock(num_layers, num_heads, d_model, dropout, use_gelu=True)
+        self.encoder = EncoderBlock(num_layers, num_heads, d_model, dropout, activation_fct=GELU())
 
         if self.include_top:
             self.head = layers.Dense(num_classes, kernel_initializer="he_normal")

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -60,6 +60,7 @@ class VisionTransformer(Sequential):
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
 
+        # Note: fix for onnx export
         _vit = _VisionTransformer(
             input_shape,
             patch_size,
@@ -75,9 +76,6 @@ class VisionTransformer(Sequential):
 
 
 class _VisionTransformer(layers.Layer, NestedObject):
-
-    # Note: fix for onnx export
-
     def __init__(
         self,
         input_shape: Tuple[int, int, int],
@@ -94,7 +92,7 @@ class _VisionTransformer(layers.Layer, NestedObject):
         super().__init__()
         self.include_top = include_top
 
-        self.patch_embedding = PatchEmbedding(input_shape[:-1], patch_size, d_model)
+        self.patch_embedding = PatchEmbedding(input_shape, patch_size, d_model)
         self.encoder = EncoderBlock(num_layers, num_heads, d_model, dropout, activation_fct=GELU())
 
         if self.include_top:

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -7,11 +7,11 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
 import tensorflow as tf
-from tensorflow.keras import layers, Sequential
+from tensorflow.keras import Sequential, layers
 
 from doctr.datasets import VOCABS
-from doctr.models.modules.transformer import MultiHeadAttention, PositionwiseFeedForward
-from doctr.utils.repr import NestedObject
+from doctr.models.modules.transformer import EncoderBlock
+from doctr.models.modules.vision_transformer import PatchEmbedding
 
 from ...utils import load_pretrained_params
 
@@ -28,38 +28,6 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
     },
 }
 
-tf.config.run_functions_eagerly(True)
-
-
-class PatchEmbedding(layers.Layer, NestedObject):
-    """Compute 2D patch embedding"""
-
-    def __init__(
-        self,
-        img_size: Tuple[int, int],
-        patch_size: Tuple[int, int],
-        embed_dim: int,
-    ) -> None:
-
-        super().__init__()
-        self.img_size = img_size
-        self.patch_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
-        self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
-        self.proj = layers.Conv2D(
-            embed_dim,
-            kernel_size=patch_size,
-            strides=patch_size,
-            padding="valid",
-            kernel_initializer="he_normal",
-        )
-
-    def call(self, x: tf.Tensor, **kwargs: Any) -> tf.Tensor:
-        B, W, H, C = x.shape
-        assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
-        assert W % self.patch_size[1] == 0, "Image width must be divisible by patch width"
-
-        return self.proj(x, **kwargs)  # BHWC
-
 
 class VisionTransformer(Sequential):
     """VisionTransformer architecture as described in
@@ -68,79 +36,47 @@ class VisionTransformer(Sequential):
 
     def __init__(
         self,
+        img_size: Tuple[int, int],
         patch_size: Tuple[int, int],
-        input_shape: Tuple[int, int, int] = (32, 32, 3),
-        d_model: int = 768,
-        num_layers: int = 12,
-        num_heads: int = 12,
-        dropout: float = 0.1,
+        input_shape: Tuple[int, int, int],
+        d_model: int,
+        num_layers: int,
+        num_heads: int,
+        dropout: float = 0.0,
         num_classes: int = 1000,
         include_top: bool = True,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
 
         super().__init__()
-        self.patch_size = patch_size
-        self.num_layers = num_layers
         self.include_top = include_top
 
-        self.patch_embedding = PatchEmbedding(input_shape[:-1], self.patch_size, d_model)
-        self.num_patches = self.patch_embedding.num_patches
-        self.cls_token = self.add_weight(shape=(1, 1, d_model), initializer="zeros", trainable=True, name="cls_token")
-        self.positions = self.add_weight(
-            shape=(1, self.num_patches + 1, d_model), initializer="zeros", trainable=True, name="positions"
-        )
-
-        self.layer_norm = layers.LayerNormalization(epsilon=1e-5)
-        self.dropout = layers.Dropout(rate=dropout)
-
-        self.attention = [MultiHeadAttention(num_heads, d_model, dropout) for _ in range(self.num_layers)]
-        self.position_feed_forward = [
-            PositionwiseFeedForward(d_model, d_model, dropout, use_gelu=True) for _ in range(self.num_layers)
-        ]
+        self.patch_embedding = PatchEmbedding(img_size, patch_size, d_model)
+        self.encoder = EncoderBlock(num_layers, num_heads, d_model, dropout, use_gelu=True)
 
         if self.include_top:
             self.head = layers.Dense(num_classes, kernel_initializer="he_normal")
 
     def __call__(self, x: tf.Tensor, **kwargs: Any) -> tf.Tensor:
-        patches = self.patch_embedding(x)
 
-        B, C, H, W = patches.shape
-        patches = tf.reshape(patches, (B, (C * H), W))  # (batch_size, num_patches, d_model)
+        embeddings = self.patch_embedding(x, **kwargs)
+        encoded = self.encoder(embeddings, **kwargs)
 
-        cls_tokens = tf.repeat(self.cls_token, B, axis=0)  # (batch_size, num_patches, d_model)
-        # concate cls_tokens to patches
-        embeddings = tf.concat([cls_tokens, patches], axis=1)  # (batch_size, num_patches + 1, d_model)
-        # add positions to embeddings
-        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
-
-        output = embeddings
-
-        for i in range(self.num_layers):
-            normed_output = self.layer_norm(output, **kwargs)
-            output = output + self.dropout(
-                self.attention[i](normed_output, normed_output, normed_output, **kwargs),
-                **kwargs,
-            )
-            normed_output = self.layer_norm(output, **kwargs)
-            output = output + self.dropout(self.position_feed_forward[i](normed_output, **kwargs), **kwargs)
-
-        # (batch_size, seq_len + cls token, d_model)
-        output = self.layer_norm(output, **kwargs)
         if self.include_top:
             # (batch_size, num_classes) cls token
-            output = self.head(output[:, 0], **kwargs)
+            return self.head(encoded[:, 0], **kwargs)
 
-        return output
+        return encoded
 
 
 def _vit(
     arch: str,
     pretrained: bool,
+    img_size: Tuple[int, int],
     patch_size: Tuple[int, int],
-    embed_dim: int = 768,
-    num_layers: int = 12,
-    num_heads: int = 12,
+    embed_dim: int,
+    num_layers: int,
+    num_heads: int,
     dropout: float = 0.0,
     include_top: bool = True,
     ignore_keys: Optional[List[str]] = None,
@@ -148,17 +84,16 @@ def _vit(
 ) -> VisionTransformer:
 
     kwargs["num_classes"] = kwargs.get("num_classes", len(default_cfgs[arch]["classes"]))
-    kwargs["input_shape"] = kwargs.get("input_shape", default_cfgs[arch]["input_shape"])
     kwargs["classes"] = kwargs.get("classes", default_cfgs[arch]["classes"])
 
     _cfg = deepcopy(default_cfgs[arch])
     _cfg["num_classes"] = kwargs["num_classes"]
     _cfg["classes"] = kwargs["classes"]
-    _cfg["input_shape"] = kwargs["input_shape"]
     kwargs.pop("classes")
 
     # Build the model
     model = VisionTransformer(
+        img_size=img_size,
         patch_size=patch_size,
         d_model=embed_dim,
         num_layers=num_layers,
@@ -196,6 +131,10 @@ def vit(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     return _vit(
         "vit",
         pretrained,
-        patch_size=[4, 4],
+        img_size=(32, 32),
+        patch_size=(4, 4),
+        embed_dim=768,
+        num_layers=12,
+        num_heads=12,
         **kwargs,
     )

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import tensorflow as tf
 from tensorflow.keras import Sequential, layers
@@ -48,10 +48,10 @@ class VisionTransformer(Sequential):
     def __init__(
         self,
         input_shape: Tuple[int, int, int],
-        patch_size: Tuple[int, int],
-        d_model: int,
-        num_layers: int,
-        num_heads: int,
+        patch_size: Tuple[int, int] = (4, 4),
+        d_model: int = 768,
+        num_layers: int = 12,
+        num_heads: int = 12,
         dropout: float = 0.0,
         num_classes: int = 1000,
         include_top: bool = True,
@@ -82,13 +82,6 @@ class VisionTransformer(Sequential):
 def _vit(
     arch: str,
     pretrained: bool,
-    patch_size: Tuple[int, int],
-    embed_dim: int,
-    num_layers: int,
-    num_heads: int,
-    dropout: float = 0.0,
-    include_top: bool = True,
-    ignore_keys: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> VisionTransformer:
 
@@ -103,16 +96,7 @@ def _vit(
     kwargs.pop("classes")
 
     # Build the model
-    model = VisionTransformer(
-        patch_size=patch_size,
-        d_model=embed_dim,
-        num_layers=num_layers,
-        num_heads=num_heads,
-        dropout=dropout,
-        include_top=include_top,
-        cfg=_cfg,
-        **kwargs,
-    )
+    model = VisionTransformer(cfg=_cfg, **kwargs)
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, default_cfgs[arch]["url"])
@@ -141,9 +125,5 @@ def vit(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     return _vit(
         "vit",
         pretrained,
-        patch_size=(4, 4),
-        embed_dim=768,
-        num_layers=12,
-        num_heads=12,
         **kwargs,
     )

--- a/doctr/models/classification/zoo.py
+++ b/doctr/models/classification/zoo.py
@@ -25,6 +25,7 @@ ARCHS: List[str] = [
     "resnet50",
     "resnet34_wide",
     "vgg16_bn_r",
+    "vit",
 ]
 ORIENTATION_ARCHS: List[str] = ["mobilenet_v3_small_orientation"]
 

--- a/doctr/models/modules/__init__.py
+++ b/doctr/models/modules/__init__.py
@@ -1,1 +1,2 @@
 from .transformer import *
+from .vision_transformer import *

--- a/doctr/models/modules/transformer/pytorch.py
+++ b/doctr/models/modules/transformer/pytorch.py
@@ -60,7 +60,7 @@ class PositionwiseFeedForward(nn.Sequential):
     def __init__(
         self, d_model: int, ffd: int, dropout: float = 0.1, activation_fct: Callable[[Any], Any] = nn.ReLU()
     ) -> None:
-        super().__init__(
+        super().__init__(  # type: ignore[call-overload]
             nn.Linear(d_model, ffd),
             activation_fct,
             nn.Dropout(p=dropout),

--- a/doctr/models/modules/transformer/pytorch.py
+++ b/doctr/models/modules/transformer/pytorch.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple
 import torch
 from torch import nn
 
-__all__ = ["Decoder", "PositionalEncoding"]
+__all__ = ["Decoder", "PositionalEncoding", "MultiHeadAttention", "PositionwiseFeedForward"]
 
 
 class PositionalEncoding(nn.Module):
@@ -57,10 +57,10 @@ def scaled_dot_product_attention(
 class PositionwiseFeedForward(nn.Sequential):
     """Position-wise Feed-Forward Network"""
 
-    def __init__(self, d_model: int, ffd: int, dropout: float = 0.1) -> None:
+    def __init__(self, d_model: int, ffd: int, dropout: float = 0.1, use_gelu: bool = False) -> None:
         super().__init__(
             nn.Linear(d_model, ffd),
-            nn.ReLU(),
+            nn.ReLU() if not use_gelu else nn.GELU(),  # Gelu for ViT
             nn.Dropout(p=dropout),
             nn.Linear(ffd, d_model),
         )

--- a/doctr/models/modules/vision_transformer/__init__.py
+++ b/doctr/models/modules/vision_transformer/__init__.py
@@ -1,0 +1,6 @@
+from doctr.file_utils import is_tf_available, is_torch_available
+
+if is_tf_available():
+    from .tensorflow import *
+elif is_torch_available():
+    from .pytorch import *  # type: ignore[misc]

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -32,7 +32,7 @@ class PatchEmbedding(nn.Module):
         self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
 
         self.cls_token = nn.Parameter(torch.randn(1, 1, embed_dim))  # type: ignore[attr-defined]
-        self.positions = nn.Parameter(torch.zeros(1, self.num_patches + 1, embed_dim))
+        self.positions = nn.Parameter(torch.zeros(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]
         self.proj = nn.Conv2d(channels, embed_dim, kernel_size=self.patch_size, stride=self.patch_size)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -33,9 +33,8 @@ class PatchEmbedding(nn.Module):
         self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
 
         self.cls_token = nn.Parameter(torch.randn(1, 1, embed_dim))  # type: ignore[attr-defined]
-        # self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]
         self.positional_encoding = PositionalEncoding(embed_dim, max_len=self.num_patches + 1)
-        self.proj = nn.Conv2d(channels, embed_dim, kernel_size=patch_size, stride=patch_size)
+        self.proj = nn.Conv2d(channels, embed_dim, kernel_size=self.patch_size, stride=self.patch_size)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         B, C, H, W = x.shape

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+from typing import Tuple
+
+import torch
+from torch import nn
+
+__all__ = ["PatchEmbedding"]
+
+
+class PatchEmbedding(nn.Module):
+    """Compute 2D patch embeddings with cls token and positional encoding"""
+
+    # Inpired by: https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/patch_embed.py
+
+    def __init__(
+        self,
+        img_size: Tuple[int, int],
+        patch_size: Tuple[int, int],
+        channels: int,
+        embed_dim: int,
+    ) -> None:
+
+        super().__init__()
+        self.img_size = img_size
+        self.patch_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
+        self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
+
+        self.cls_token = nn.Parameter(torch.randn(1, 1, embed_dim))  # type: ignore[attr-defined]
+        self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]
+        self.proj = nn.Conv2d(channels, embed_dim, kernel_size=patch_size, stride=patch_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, C, H, W = x.shape
+        assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
+        assert W % self.patch_size[1] == 0, "Image width must be divisible by patch width"
+
+        patches = self.proj(x)  # BCHW
+
+        B, C, H, W = patches.size()
+        patches = patches.view(B, C, -1).permute(0, 2, 1)  # (batch_size, num_patches, d_model)
+        cls_tokens = self.cls_token.expand(B, -1, -1)  # (batch_size, 1, d_model)
+        # concate cls_tokens to patches
+        embeddings = torch.cat([cls_tokens, patches], dim=1)  # (batch_size, num_patches + 1, d_model)
+        # add positions to embeddings
+        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
+
+        return embeddings

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -9,6 +9,8 @@ from typing import Tuple
 import torch
 from torch import nn
 
+from ..transformer.pytorch import PositionalEncoding
+
 __all__ = ["PatchEmbedding"]
 
 
@@ -31,7 +33,8 @@ class PatchEmbedding(nn.Module):
         self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
 
         self.cls_token = nn.Parameter(torch.randn(1, 1, embed_dim))  # type: ignore[attr-defined]
-        self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]
+        # self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]
+        self.positional_encoding = PositionalEncoding(embed_dim, max_len=self.num_patches + 1)
         self.proj = nn.Conv2d(channels, embed_dim, kernel_size=patch_size, stride=patch_size)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -47,6 +50,6 @@ class PatchEmbedding(nn.Module):
         # concate cls_tokens to patches
         embeddings = torch.cat([cls_tokens, patches], dim=1)  # (batch_size, num_patches + 1, d_model)
         # add positions to embeddings
-        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
+        embeddings = self.positional_encoding(embeddings)  # (batch_size, num_patches + 1, d_model)
 
         return embeddings

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -19,17 +19,16 @@ class PatchEmbedding(nn.Module):
 
     def __init__(
         self,
-        img_size: Tuple[int, int],
+        input_shape: Tuple[int, int, int],
         patch_size: Tuple[int, int],
-        channels: int,
         embed_dim: int,
     ) -> None:
 
         super().__init__()
-        self.img_size = img_size
+        channels, height, width = input_shape
         self.patch_size = patch_size
-        self.grid_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
-        self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
+        self.grid_size = (height // patch_size[0], width // patch_size[1])
+        self.num_patches = (height // patch_size[0]) * (width // patch_size[1])
 
         self.cls_token = nn.Parameter(torch.randn(1, 1, embed_dim))  # type: ignore[attr-defined]
         self.positions = nn.Parameter(torch.zeros(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -18,16 +18,16 @@ class PatchEmbedding(layers.Layer, NestedObject):
 
     def __init__(
         self,
-        img_size: Tuple[int, int],
+        input_shape: Tuple[int, int, int],
         patch_size: Tuple[int, int],
         embed_dim: int,
     ) -> None:
 
         super().__init__()
-        self.img_size = img_size
+        height, width, _ = input_shape
         self.patch_size = patch_size
-        self.grid_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
-        self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
+        self.grid_size = (height // patch_size[0], width // patch_size[1])
+        self.num_patches = (height // patch_size[0]) * (width // patch_size[1])
 
         self.cls_token = self.add_weight(shape=(1, 1, embed_dim), initializer="zeros", trainable=True, name="cls_token")
         self.positions = self.add_weight(
@@ -57,7 +57,7 @@ class PatchEmbedding(layers.Layer, NestedObject):
         B, H, W, C = patches.shape
         patches = tf.reshape(patches, (B, (H * W), C))  # (batch_size, num_patches, d_model)
 
-        cls_tokens = tf.repeat(self.cls_token, B, axis=0)  # (batch_size, num_patches, d_model)
+        cls_tokens = tf.repeat(self.cls_token, B, axis=0)  # (batch_size, 1, d_model)
         # concate cls_tokens to patches
         embeddings = tf.concat([cls_tokens, patches], axis=1)  # (batch_size, num_patches + 1, d_model)
         # add positions to embeddings

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -10,12 +10,7 @@ from tensorflow.keras import layers
 
 from doctr.utils.repr import NestedObject
 
-from ..transformer.tensorflow import PositionalEncoding
-
 __all__ = ["PatchEmbedding"]
-
-
-tf.config.run_functions_eagerly(True)
 
 
 class PatchEmbedding(layers.Layer, NestedObject):
@@ -30,12 +25,17 @@ class PatchEmbedding(layers.Layer, NestedObject):
 
         super().__init__()
         self.img_size = img_size
-        print(self.img_size)
-        self.patch_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
+        self.patch_size = patch_size
+        self.grid_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
         self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
 
         self.cls_token = self.add_weight(shape=(1, 1, embed_dim), initializer="zeros", trainable=True, name="cls_token")
-        self.positional_encoding = PositionalEncoding(embed_dim, max_len=self.num_patches + 1)
+        self.positions = self.add_weight(
+            shape=(1, self.num_patches + 1, embed_dim),
+            initializer="zeros",
+            trainable=True,
+            name="positions",
+        )
         self.proj = layers.Conv2D(
             filters=embed_dim,
             kernel_size=self.patch_size,
@@ -48,12 +48,11 @@ class PatchEmbedding(layers.Layer, NestedObject):
         )
 
     def call(self, x: tf.Tensor, **kwargs: Any) -> tf.Tensor:
-        B, W, H, C = x.shape
+        B, H, W, C = x.shape
         assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
         assert W % self.patch_size[1] == 0, "Image width must be divisible by patch width"
 
         patches = self.proj(x, **kwargs)  # BHWC
-        print(patches.shape)
 
         B, H, W, C = patches.shape
         patches = tf.reshape(patches, (B, (H * W), C))  # (batch_size, num_patches, d_model)
@@ -62,7 +61,6 @@ class PatchEmbedding(layers.Layer, NestedObject):
         # concate cls_tokens to patches
         embeddings = tf.concat([cls_tokens, patches], axis=1)  # (batch_size, num_patches + 1, d_model)
         # add positions to embeddings
-        embeddings = self.positional_encoding(embeddings, **kwargs)  # (batch_size, num_patches + 1, d_model)
-        print(embeddings.shape)
+        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
 
         return embeddings

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from typing import Any, Tuple
+
+import tensorflow as tf
+from tensorflow.keras import layers
+
+from doctr.utils.repr import NestedObject
+
+__all__ = ["PatchEmbedding"]
+
+
+tf.config.run_functions_eagerly(True)
+
+
+class PatchEmbedding(layers.Layer, NestedObject):
+    """Compute 2D patch embeddings with cls token and positional encoding"""
+
+    def __init__(
+        self,
+        img_size: Tuple[int, int],
+        patch_size: Tuple[int, int],
+        embed_dim: int,
+    ) -> None:
+
+        super().__init__()
+        self.img_size = img_size
+        self.patch_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
+        self.num_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
+
+        self.cls_token = self.add_weight(shape=(1, 1, embed_dim), initializer="zeros", trainable=True, name="cls_token")
+        self.positions = self.add_weight(
+            shape=(1, self.num_patches + 1, embed_dim), initializer="zeros", trainable=True, name="positions"
+        )
+        self.proj = layers.Conv2D(
+            embed_dim,
+            kernel_size=patch_size,
+            strides=patch_size,
+            padding="valid",
+            kernel_initializer="he_normal",
+        )
+
+    def call(self, x: tf.Tensor, **kwargs: Any) -> tf.Tensor:
+        B, W, H, C = x.shape
+        assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
+        assert W % self.patch_size[1] == 0, "Image width must be divisible by patch width"
+
+        patches = self.proj(x, **kwargs)  # BHWC
+
+        B, H, W, C = patches.shape
+        patches = tf.reshape(patches, (B, (H * W), C))  # (batch_size, num_patches, d_model)
+
+        cls_tokens = tf.repeat(self.cls_token, B, axis=0)  # (batch_size, num_patches, d_model)
+        # concate cls_tokens to patches
+        embeddings = tf.concat([cls_tokens, patches], axis=1)  # (batch_size, num_patches + 1, d_model)
+        # add positions to embeddings
+        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
+
+        return embeddings

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -321,7 +321,12 @@ def main(args):
 
     if args.export_onnx:
         print("Exporting model to ONNX...")
-        dummy_input = [tf.TensorSpec([None, args.input_size, args.input_size, 3], tf.float32, name="input")]
+        if args.arch == "vit":
+            # fixed batch size for vit
+            dummy_input = [tf.TensorSpec([1, args.input_size, args.input_size, 3], tf.float32, name="input")]
+        else:
+            # dynamic batch size
+            dummy_input = [tf.TensorSpec([None, args.input_size, args.input_size, 3], tf.float32, name="input")]
         model_path, _ = export_model_to_onnx(model, exp_name, dummy_input)
         print(f"Exported model saved in {model_path}")
 

--- a/tests/pytorch/test_models_classification_pt.py
+++ b/tests/pytorch/test_models_classification_pt.py
@@ -40,6 +40,7 @@ def _test_classification(model, input_shape, output_size, batch_size=2):
         ["magc_resnet31", (3, 32, 32), (126,)],
         ["mobilenet_v3_small", (3, 32, 32), (126,)],
         ["mobilenet_v3_large", (3, 32, 32), (126,)],
+        ["vit", (3, 32, 32), (126,)],
     ],
 )
 def test_classification_architectures(arch_name, input_shape, output_size):
@@ -120,6 +121,7 @@ def test_crop_orientation_model(mock_text_box):
         ["mobilenet_v3_small", (3, 32, 32), (126,)],
         ["mobilenet_v3_large", (3, 32, 32), (126,)],
         ["mobilenet_v3_small_orientation", (3, 128, 128), (4,)],
+        ["vit", (3, 32, 32), (126,)],
     ],
 )
 def test_models_onnx_export(arch_name, input_shape, output_size):

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -111,7 +111,7 @@ def test_models_onnx_export(arch_name, input_shape, output_size):
         model = classification.__dict__[arch_name](pretrained=True, input_shape=input_shape)
     else:
         model = classification.__dict__[arch_name](pretrained=True, include_top=True, input_shape=input_shape)
-    # batch_size = None for dynamic batch size
+
     if arch_name == "vit":
         # vit model needs a fixed batch size
         # TODO : patches = tf.reshape(patches, (B, (C * H), W))  # (batch_size, num_patches, d_model)
@@ -119,6 +119,7 @@ def test_models_onnx_export(arch_name, input_shape, output_size):
     else:
         # batch_size = None for dynamic batch size
         dummy_input = [tf.TensorSpec([None, *input_shape], tf.float32, name="input")]
+
     np_dummy_input = np.random.rand(batch_size, *input_shape).astype(np.float32)
     with tempfile.TemporaryDirectory() as tmpdir:
         # Export

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -112,7 +112,13 @@ def test_models_onnx_export(arch_name, input_shape, output_size):
     else:
         model = classification.__dict__[arch_name](pretrained=True, include_top=True, input_shape=input_shape)
     # batch_size = None for dynamic batch size
-    dummy_input = [tf.TensorSpec([None, *input_shape], tf.float32, name="input")]
+    if arch_name == "vit":
+        # vit model needs a fixed batch size
+        # TODO : patches = tf.reshape(patches, (B, (C * H), W))  # (batch_size, num_patches, d_model)
+        dummy_input = [tf.TensorSpec([2, *input_shape], tf.float32, name="input")]
+    else:
+        # batch_size = None for dynamic batch size
+        dummy_input = [tf.TensorSpec([None, *input_shape], tf.float32, name="input")]
     np_dummy_input = np.random.rand(batch_size, *input_shape).astype(np.float32)
     with tempfile.TemporaryDirectory() as tmpdir:
         # Export

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -24,6 +24,7 @@ from doctr.models.utils import export_model_to_onnx
         ["magc_resnet31", (32, 32, 3), (126,)],
         ["mobilenet_v3_small", (32, 32, 3), (126,)],
         ["mobilenet_v3_large", (32, 32, 3), (126,)],
+        ["vit", (32, 32, 3), (126,)],
     ],
 )
 def test_classification_architectures(arch_name, input_shape, output_size):
@@ -95,6 +96,7 @@ def test_crop_orientation_model(mock_text_box):
         ["resnet34_wide", (32, 32, 3), (126,)],
         ["resnet50", (32, 32, 3), (126,)],
         ["magc_resnet31", (32, 32, 3), (126,)],
+        ["vit", (32, 32, 3), (126,)],
         # Disabled for now
         # ["mobilenet_v3_small", (512, 512, 3), (126,)],
         # ["mobilenet_v3_large", (512, 512, 3), (126,)],

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -114,7 +114,6 @@ def test_models_onnx_export(arch_name, input_shape, output_size):
 
     if arch_name == "vit":
         # vit model needs a fixed batch size
-        # TODO : patches = tf.reshape(patches, (B, (C * H), W))  # (batch_size, num_patches, d_model)
         dummy_input = [tf.TensorSpec([2, *input_shape], tf.float32, name="input")]
     else:
         # batch_size = None for dynamic batch size


### PR DESCRIPTION
This PR:

- adds ViT as classification model, which can be used as backbone for ViTSTR/ParSeq

Any feedback or ideas for improvements are very welcome :hugs: 

validated via test runs both models trains well 