### PR TITLE
[tests] add missing hf model tests

### DIFF
--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -59,6 +59,7 @@ class VisionTransformer(nn.Module):
     ) -> None:
 
         super().__init__()
+        self.cfg = cfg
         self.include_top = include_top
 
         self.patch_embedding = PatchEmbedding(input_shape, patch_size, d_model)

--- a/tests/pytorch/test_models_factory.py
+++ b/tests/pytorch/test_models_factory.py
@@ -33,6 +33,7 @@ def test_push_to_hf_hub():
         ["magc_resnet31", "classification", "Felix92/doctr-dummy-torch-magc-resnet31"],
         ["mobilenet_v3_small", "classification", "Felix92/doctr-dummy-torch-mobilenet-v3-small"],
         ["mobilenet_v3_large", "classification", "Felix92/doctr-dummy-torch-mobilenet-v3-large"],
+        ["vit", "classification", "Felix92/doctr-dummy-torch-vit"],
         ["db_resnet34", "detection", "Felix92/doctr-dummy-torch-db-resnet34"],
         ["db_resnet50", "detection", "Felix92/doctr-dummy-torch-db-resnet50"],
         ["db_mobilenet_v3_large", "detection", "Felix92/doctr-dummy-torch-db-mobilenet-v3-large"],
@@ -43,8 +44,8 @@ def test_push_to_hf_hub():
         ["crnn_vgg16_bn", "recognition", "Felix92/doctr-dummy-torch-crnn-vgg16-bn"],
         ["crnn_mobilenet_v3_small", "recognition", "Felix92/doctr-dummy-torch-crnn-mobilenet-v3-small"],
         ["crnn_mobilenet_v3_large", "recognition", "Felix92/doctr-dummy-torch-crnn-mobilenet-v3-large"],
-        #  ["sar_resnet31", "recognition", ""],  enable after model is fixed !
-        #  ["master", "recognition", ""],  enable after model is fixed !
+        ["sar_resnet31", "recognition", "Felix92/doctr-dummy-torch-sar-resnet31"],
+        ["master", "recognition", "Felix92/doctr-dummy-torch-master"],
         [
             "fasterrcnn_mobilenet_v3_large_fpn",
             "obj_detection",

--- a/tests/tensorflow/test_models_factory.py
+++ b/tests/tensorflow/test_models_factory.py
@@ -33,6 +33,7 @@ def test_push_to_hf_hub():
         ["resnet50", "classification", "Felix92/doctr-dummy-tf-resnet50"],
         ["magc_resnet31", "classification", "Felix92/doctr-dummy-tf-magc-resnet31"],
         ["mobilenet_v3_large", "classification", "Felix92/doctr-dummy-tf-mobilenet-v3-large"],
+        ["vit", "classification", "Felix92/doctr-dummy-tf-vit"],
         ["db_resnet50", "detection", "Felix92/doctr-dummy-tf-db-resnet50"],
         ["db_mobilenet_v3_large", "detection", "Felix92/doctr-dummy-tf-db-mobilenet-v3-large"],
         ["linknet_resnet18", "detection", "Felix92/doctr-dummy-tf-linknet-resnet18"],


### PR DESCRIPTION
This PR:

- adds missing model tests hf hub
- fix missing cfg in pytorch vit  / fixes also upload pytorch vit to hub 

