### PR TITLE
[models] add ViTSTR TF and PT and update ViT to work as backbone

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Credits where it's due: this repository is implementing, among others, architect
 - CRNN: [An End-to-End Trainable Neural Network for Image-based Sequence Recognition and Its Application to Scene Text Recognition](https://arxiv.org/pdf/1507.05717.pdf).
 - SAR: [Show, Attend and Read:A Simple and Strong Baseline for Irregular Text Recognition](https://arxiv.org/pdf/1811.00751.pdf).
 - MASTER: [MASTER: Multi-Aspect Non-local Network for Scene Text Recognition](https://arxiv.org/pdf/1910.02562.pdf).
+- ViTSTR: [Vision Transformer for Fast and Efficient Scene Text Recognition](https://arxiv.org/pdf/2105.08582.pdf).
 
 
 ## More goodies

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,6 +48,7 @@ Text recognition models
 * SAR from `"Show, Attend and Read: A Simple and Strong Baseline for Irregular Text Recognition" <https://arxiv.org/pdf/1811.00751.pdf>`_
 * CRNN from `"An End-to-End Trainable Neural Network for Image-based Sequence Recognition and Its Application to Scene Text Recognition" <https://arxiv.org/pdf/1507.05717.pdf>`_
 * MASTER from `"MASTER: Multi-Aspect Non-local Network for Scene Text Recognition" <https://arxiv.org/pdf/1910.02562.pdf>`_
+* ViTSTR from `"Vision Transformer for Fast and Efficient Scene Text Recognition" <https://arxiv.org/pdf/2105.08582.pdf>`_
 
 
 Supported datasets

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -67,6 +67,8 @@ doctr.models.recognition
 
 .. autofunction:: doctr.models.recognition.master
 
+.. autofunction:: doctr.models.recognition.vitstr
+
 .. autofunction:: doctr.models.recognition.recognition_predictor
 
 

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -67,7 +67,7 @@ doctr.models.recognition
 
 .. autofunction:: doctr.models.recognition.master
 
-.. autofunction:: doctr.models.recognition.vitstr
+.. autofunction:: doctr.models.recognition.vitstr_small
 
 .. autofunction:: doctr.models.recognition.recognition_predictor
 

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -29,6 +29,8 @@ doctr.models.classification
 
 .. autofunction:: doctr.models.classification.magc_resnet31
 
+.. autofunction:: doctr.models.classification.vit_s
+
 .. autofunction:: doctr.models.classification.vit_b
 
 .. autofunction:: doctr.models.classification.crop_orientation_predictor

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -69,6 +69,8 @@ doctr.models.recognition
 
 .. autofunction:: doctr.models.recognition.vitstr_small
 
+.. autofunction:: doctr.models.recognition.vitstr_base
+
 .. autofunction:: doctr.models.recognition.recognition_predictor
 
 

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -128,8 +128,8 @@ def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     <https://arxiv.org/pdf/2010.11929.pdf>`_.
 
     >>> import torch
-    >>> from doctr.models import vit
-    >>> model = vit(pretrained=False)
+    >>> from doctr.models import vit_b
+    >>> model = vit_b(pretrained=False)
     >>> input_tensor = torch.rand((1, 3, 32, 32), dtype=tf.float32)
     >>> out = model(input_tensor)
 

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -19,7 +19,7 @@ __all__ = ["vit_b"]
 
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
-    "vit": {
+    "vit_b": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
@@ -141,7 +141,7 @@ def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     """
 
     return _vit(
-        "vit",
+        "vit_b",
         pretrained,
         ignore_keys=["head.weight", "head.bias"],
         **kwargs,

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -15,11 +15,18 @@ from doctr.models.modules.vision_transformer.pytorch import PatchEmbedding
 
 from ...utils.pytorch import load_pretrained_params
 
-__all__ = ["vit_b"]
+__all__ = ["vit_s", "vit_b"]
 
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
     "vit_b": {
+        "mean": (0.694, 0.695, 0.693),
+        "std": (0.299, 0.296, 0.301),
+        "input_shape": (3, 32, 32),
+        "classes": list(VOCABS["french"]),
+        "url": None,
+    },
+    "vit_s": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
@@ -57,12 +64,12 @@ class VisionTransformer(nn.Sequential):
     <https://arxiv.org/pdf/2010.11929.pdf>`_.
 
     Args:
-        input_shape: size of the input image
-        patch_size: size of the patches to be extracted from the input
         d_model: dimension of the transformer layers
         num_layers: number of transformer layers
         num_heads: number of attention heads
         ffd_ratio: multiplier for the hidden dimension of the feedforward layer
+        input_shape: size of the input image
+        patch_size: size of the patches to be extracted from the input
         dropout: dropout rate
         num_classes: number of output classes
         include_top: whether the classifier head should be instantiated
@@ -70,12 +77,12 @@ class VisionTransformer(nn.Sequential):
 
     def __init__(
         self,
+        d_model: int,
+        num_layers: int,
+        num_heads: int,
+        ffd_ratio: int,
         input_shape: Tuple[int, int, int] = (3, 32, 32),
         patch_size: Tuple[int, int] = (4, 4),
-        d_model: int = 768,
-        num_layers: int = 12,
-        num_heads: int = 12,
-        ffd_ratio: int = 4,
         dropout: float = 0.0,
         num_classes: int = 1000,
         include_top: bool = True,
@@ -143,6 +150,42 @@ def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     return _vit(
         "vit_b",
         pretrained,
+        d_model=768,
+        num_layers=12,
+        num_heads=12,
+        ffd_ratio=4,
+        ignore_keys=["head.weight", "head.bias"],
+        **kwargs,
+    )
+
+
+def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
+    """VisionTransformer-S architecture
+    `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+
+    NOTE: unofficial config used in ViTSTR and ParSeq
+
+    >>> import torch
+    >>> from doctr.models import vit_s
+    >>> model = vit_s(pretrained=False)
+    >>> input_tensor = torch.rand((1, 3, 32, 32), dtype=tf.float32)
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained: boolean, True if model is pretrained
+
+    Returns:
+        A feature extractor model
+    """
+
+    return _vit(
+        "vit_s",
+        pretrained,
+        d_model=384,
+        num_layers=12,
+        num_heads=6,
+        ffd_ratio=4,
         ignore_keys=["head.weight", "head.bias"],
         **kwargs,
     )

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -21,7 +21,7 @@ __all__ = ["vit_b"]
 
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
-    "vit": {
+    "vit_b": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (32, 32, 3),
@@ -134,7 +134,7 @@ def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     """
 
     return _vit(
-        "vit",
+        "vit_b",
         pretrained,
         **kwargs,
     )

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -17,10 +17,17 @@ from doctr.utils.repr import NestedObject
 
 from ...utils import load_pretrained_params
 
-__all__ = ["vit_b"]
+__all__ = ["vit_s", "vit_b"]
 
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
+    "vit_s": {
+        "mean": (0.694, 0.695, 0.693),
+        "std": (0.299, 0.296, 0.301),
+        "input_shape": (3, 32, 32),
+        "classes": list(VOCABS["french"]),
+        "url": None,
+    },
     "vit_b": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
@@ -54,12 +61,12 @@ class VisionTransformer(Sequential):
     <https://arxiv.org/pdf/2010.11929.pdf>`_.
 
     Args:
-        input_shape: size of the input image
-        patch_size: size of the patches to be extracted from the input
         d_model: dimension of the transformer layers
         num_layers: number of transformer layers
         num_heads: number of attention heads
         ffd_ratio: multiplier for the hidden dimension of the feedforward layer
+        input_shape: size of the input image
+        patch_size: size of the patches to be extracted from the input
         dropout: dropout rate
         num_classes: number of output classes
         include_top: whether the classifier head should be instantiated
@@ -67,12 +74,12 @@ class VisionTransformer(Sequential):
 
     def __init__(
         self,
+        d_model: int,
+        num_layers: int,
+        num_heads: int,
+        ffd_ratio: int,
         input_shape: Tuple[int, int, int] = (32, 32, 3),
         patch_size: Tuple[int, int] = (4, 4),
-        d_model: int = 768,
-        num_layers: int = 12,
-        num_heads: int = 12,
-        ffd_ratio: int = 4,
         dropout: float = 0.0,
         num_classes: int = 1000,
         include_top: bool = True,
@@ -115,6 +122,37 @@ def _vit(
     return model
 
 
+def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
+    """VisionTransformer-S architecture
+    `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+
+    NOTE: unofficial config used in ViTSTR and ParSeq
+
+    >>> import tf
+    >>> from doctr.models import vit_s
+    >>> model = vit_s(pretrained=False)
+    >>> input_tensor = tf.random.uniform(shape=[1, 32, 32, 3], maxval=1, dtype=tf.float32)
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained: boolean, True if model is pretrained
+
+    Returns:
+        A feature extractor model
+    """
+
+    return _vit(
+        "vit_s",
+        pretrained,
+        d_model=384,
+        num_layers=12,
+        num_heads=6,
+        ffd_ratio=4,
+        **kwargs,
+    )
+
+
 def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     """VisionTransformer-B architecture as described in
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
@@ -136,5 +174,9 @@ def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     return _vit(
         "vit_b",
         pretrained,
+        d_model=768,
+        num_layers=12,
+        num_heads=12,
+        ffd_ratio=4,
         **kwargs,
     )

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -121,8 +121,8 @@ def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     <https://arxiv.org/pdf/2010.11929.pdf>`_.
 
     >>> import tensorflow as tf
-    >>> from doctr.models import vit
-    >>> model = vit(pretrained=False)
+    >>> from doctr.models import vit_b
+    >>> model = vit_b(pretrained=False)
     >>> input_tensor = tf.random.uniform(shape=[1, 32, 32, 3], maxval=1, dtype=tf.float32)
     >>> out = model(input_tensor)
 

--- a/doctr/models/classification/zoo.py
+++ b/doctr/models/classification/zoo.py
@@ -25,6 +25,7 @@ ARCHS: List[str] = [
     "resnet50",
     "resnet34_wide",
     "vgg16_bn_r",
+    "vit_s",
     "vit_b",
 ]
 ORIENTATION_ARCHS: List[str] = ["mobilenet_v3_small_orientation"]

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -25,7 +25,7 @@ class PatchEmbedding(nn.Module):
 
         super().__init__()
         channels, height, width = input_shape
-        # fix patch size if recognition task
+        # fix patch size if recognition task with 32x128 input
         self.patch_size = (4, 8) if height != width else patch_size
         self.grid_size = (height // patch_size[0], width // patch_size[1])
         self.num_patches = (height // patch_size[0]) * (width // patch_size[1])

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -25,7 +25,8 @@ class PatchEmbedding(nn.Module):
 
         super().__init__()
         channels, height, width = input_shape
-        self.patch_size = patch_size
+        # fix patch size if recognition task
+        self.patch_size = (4, 8) if height != width else patch_size
         self.grid_size = (height // patch_size[0], width // patch_size[1])
         self.num_patches = (height // patch_size[0]) * (width // patch_size[1])
 

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 
+import math
 from typing import Tuple
 
 import torch
@@ -32,6 +33,42 @@ class PatchEmbedding(nn.Module):
         self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]
         self.proj = nn.Linear((channels * self.patch_size[0] * self.patch_size[1]), embed_dim)
 
+    def interpolate_pos_encoding(self, embeddings: torch.Tensor, height: int, width: int) -> torch.Tensor:
+        """
+        100 % borrowed from:
+        https://github.com/huggingface/transformers/blob/main/src/transformers/models/vit/modeling_vit.py
+
+        This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher
+        resolution images.
+
+        Source:
+        https://github.com/facebookresearch/dino/blob/de9ee3df6cf39fac952ab558447af1fa1365362a/vision_transformer.py
+        """
+
+        num_patches = embeddings.shape[1] - 1
+        num_positions = self.positions.shape[1] - 1
+        if num_patches == num_positions and height == width:
+            return self.positions
+        class_pos_embed = self.positions[:, 0]
+        patch_pos_embed = self.positions[:, 1:]
+        dim = embeddings.shape[-1]
+        h0 = float(height // self.patch_size[0])
+        w0 = float(width // self.patch_size[1])
+        # we add a small number to avoid floating point error in the interpolation
+        # see discussion at https://github.com/facebookresearch/dino/issues/8
+        h0, w0 = h0 + 0.1, w0 + 0.1
+        patch_pos_embed = patch_pos_embed.reshape(1, int(math.sqrt(num_positions)), int(math.sqrt(num_positions)), dim)
+        patch_pos_embed = patch_pos_embed.permute(0, 3, 1, 2)
+        patch_pos_embed = nn.functional.interpolate(
+            patch_pos_embed,
+            mode="bicubic",
+            align_corners=False,
+            scale_factor=(h0 / math.sqrt(num_positions), w0 / math.sqrt(num_positions)),
+        )
+        assert int(h0) == patch_pos_embed.shape[-2] and int(w0) == patch_pos_embed.shape[-1]
+        patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
+        return torch.cat((class_pos_embed.unsqueeze(0), patch_pos_embed), dim=1)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         B, C, H, W = x.shape
         assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
@@ -52,7 +89,7 @@ class PatchEmbedding(nn.Module):
         cls_tokens = self.cls_token.expand(B, -1, -1)  # (batch_size, 1, d_model)
         # concate cls_tokens to patches
         embeddings = torch.cat([cls_tokens, patches], dim=1)  # (batch_size, num_patches + 1, d_model)
-        # add positions to embeddings
-        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
+        # add positions to embeddings -> (batch_size, num_patches + 1, d_model)
+        embeddings = embeddings + self.interpolate_pos_encoding(embeddings, H, W)
 
         return embeddings

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -65,7 +65,9 @@ class PatchEmbedding(nn.Module):
             align_corners=False,
             scale_factor=(h0 / math.sqrt(num_positions), w0 / math.sqrt(num_positions)),
         )
-        assert int(h0) == patch_pos_embed.shape[-2] and int(w0) == patch_pos_embed.shape[-1]
+        assert int(h0) == patch_pos_embed.shape[-2], "height of interpolated patch embedding doesn't match"
+        assert int(w0) == patch_pos_embed.shape[-1], "width of interpolated patch embedding doesn't match"
+
         patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
         return torch.cat((class_pos_embed.unsqueeze(0), patch_pos_embed), dim=1)
 
@@ -89,7 +91,7 @@ class PatchEmbedding(nn.Module):
         cls_tokens = self.cls_token.expand(B, -1, -1)  # (batch_size, 1, d_model)
         # concate cls_tokens to patches
         embeddings = torch.cat([cls_tokens, patches], dim=1)  # (batch_size, num_patches + 1, d_model)
-        # add positions to embeddings -> (batch_size, num_patches + 1, d_model)
-        embeddings = embeddings + self.interpolate_pos_encoding(embeddings, H, W)
+        # add positions to embeddings
+        embeddings += self.interpolate_pos_encoding(embeddings, H, W)  # (batch_size, num_patches + 1, d_model)
 
         return embeddings

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -71,7 +71,9 @@ class PatchEmbedding(layers.Layer, NestedObject):
         )
 
         shape = patch_pos_embed.shape
-        assert h0 == shape[-3] and w0 == shape[-2]
+        assert h0 == shape[-3], "height of interpolated patch embedding doesn't match"
+        assert w0 == shape[-2], "width of interpolated patch embedding doesn't match"
+
         patch_pos_embed = tf.reshape(tensor=patch_pos_embed, shape=(1, -1, dim))
         return tf.concat(values=(class_pos_embed, patch_pos_embed), axis=1)
 
@@ -94,7 +96,7 @@ class PatchEmbedding(layers.Layer, NestedObject):
         cls_tokens = tf.repeat(self.cls_token, B, axis=0)  # (batch_size, 1, d_model)
         # concate cls_tokens to patches
         embeddings = tf.concat([cls_tokens, patches], axis=1)  # (batch_size, num_patches + 1, d_model)
-        # add positions to embeddings -> (batch_size, num_patches + 1, d_model)
-        embeddings = embeddings + self.interpolate_pos_encoding(embeddings, H, W)
+        # add positions to embeddings
+        embeddings += self.interpolate_pos_encoding(embeddings, H, W)  # (batch_size, num_patches + 1, d_model)
 
         return embeddings

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -52,7 +52,7 @@ class PatchEmbedding(layers.Layer, NestedObject):
         https://github.com/facebookresearch/dino/blob/de9ee3df6cf39fac952ab558447af1fa1365362a/vision_transformer.py
         """
 
-        batch_size, seq_len, dim = embeddings.shape
+        seq_len, dim = embeddings.shape[1:]
         num_patches = seq_len - 1
 
         num_positions = self.positions.shape[1] - 1

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -26,7 +26,7 @@ class PatchEmbedding(layers.Layer, NestedObject):
 
         super().__init__()
         height, width, _ = input_shape
-        # fix patch size if recognition task
+        # fix patch size if recognition task with 32x128 input
         self.patch_size = (4, 8) if height != width else patch_size
         self.grid_size = (height // patch_size[0], width // patch_size[1])
         self.num_patches = (height // patch_size[0]) * (width // patch_size[1])
@@ -85,7 +85,7 @@ class PatchEmbedding(layers.Layer, NestedObject):
         # patchify image without convolution
         # adapted from:
         # https://uvadlc-notebooks.readthedocs.io/en/latest/tutorial_notebooks/tutorial15/Vision_Transformer.html
-        # NOTE: tf.image.extract_patches has no ONNX support and Conv2D with padding=valid consumes too much memory
+        # NOTE: tf.image.extract_patches has no ONNX support and Conv2D with padding=valid consumes to much memory
         patches = tf.reshape(
             x, (B, H // self.patch_size[0], self.patch_size[0], W // self.patch_size[1], self.patch_size[1], C)
         )

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -3,6 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
+import math
 from typing import Any, Tuple
 
 import tensorflow as tf
@@ -36,31 +37,64 @@ class PatchEmbedding(layers.Layer, NestedObject):
             trainable=True,
             name="positions",
         )
-        self.proj = layers.Conv2D(
-            filters=embed_dim,
-            kernel_size=self.patch_size,
-            strides=self.patch_size,
-            padding="valid",
-            data_format="channels_last",
-            use_bias=True,
-            kernel_initializer="he_normal",
-            bias_initializer="zeros",
+        self.proj = layers.Dense(embed_dim, kernel_initializer="he_normal")
+
+    def interpolate_pos_encoding(self, embeddings: tf.Tensor, height: int, width: int) -> tf.Tensor:
+        """
+        100 % borrowed from:
+        https://github.com/huggingface/transformers/blob/main/src/transformers/models/vit/modeling_tf_vit.py
+
+        This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher
+        resolution images.
+
+        Source:
+        https://github.com/facebookresearch/dino/blob/de9ee3df6cf39fac952ab558447af1fa1365362a/vision_transformer.py
+        """
+
+        batch_size, seq_len, dim = embeddings.shape
+        num_patches = seq_len - 1
+
+        num_positions = self.positions.shape[1] - 1
+
+        if num_patches == num_positions and height == width:
+            return self.positions
+        class_pos_embed = self.positions[:, :1]
+        patch_pos_embed = self.positions[:, 1:]
+        h0 = height // self.patch_size[0]
+        w0 = width // self.patch_size[1]
+        patch_pos_embed = tf.image.resize(
+            images=tf.reshape(
+                patch_pos_embed, shape=(1, int(math.sqrt(num_positions)), int(math.sqrt(num_positions)), dim)
+            ),
+            size=(h0, w0),
+            method="bicubic",
         )
+
+        shape = patch_pos_embed.shape
+        assert h0 == shape[-3] and w0 == shape[-2]
+        patch_pos_embed = tf.reshape(tensor=patch_pos_embed, shape=(1, -1, dim))
+        return tf.concat(values=(class_pos_embed, patch_pos_embed), axis=1)
 
     def call(self, x: tf.Tensor, **kwargs: Any) -> tf.Tensor:
         B, H, W, C = x.shape
         assert H % self.patch_size[0] == 0, "Image height must be divisible by patch height"
         assert W % self.patch_size[1] == 0, "Image width must be divisible by patch width"
-
-        patches = self.proj(x, **kwargs)  # BHWC
-
-        B, H, W, C = patches.shape
-        patches = tf.reshape(patches, (B, (H * W), C))  # (batch_size, num_patches, d_model)
+        # patchify image without convolution
+        # adapted from:
+        # https://uvadlc-notebooks.readthedocs.io/en/latest/tutorial_notebooks/tutorial15/Vision_Transformer.html
+        # NOTE: tf.image.extract_patches has no ONNX support and Conv2D with padding=valid consumes too much memory
+        patches = tf.reshape(
+            x, (B, H // self.patch_size[0], self.patch_size[0], W // self.patch_size[1], self.patch_size[1], C)
+        )
+        patches = tf.transpose(a=patches, perm=(0, 1, 3, 2, 4, 5))
+        # (B, H', W', C, ph, pw) -> (B, H'*W', C*ph*pw)
+        patches = tf.reshape(tensor=patches, shape=(B, -1, self.patch_size[0] * self.patch_size[1] * C))
+        patches = self.proj(patches, **kwargs)  # (batch_size, num_patches, d_model)
 
         cls_tokens = tf.repeat(self.cls_token, B, axis=0)  # (batch_size, 1, d_model)
         # concate cls_tokens to patches
         embeddings = tf.concat([cls_tokens, patches], axis=1)  # (batch_size, num_patches + 1, d_model)
-        # add positions to embeddings
-        embeddings += self.positions  # (batch_size, num_patches + 1, d_model)
+        # add positions to embeddings -> (batch_size, num_patches + 1, d_model)
+        embeddings = embeddings + self.interpolate_pos_encoding(embeddings, H, W)
 
         return embeddings

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -26,7 +26,8 @@ class PatchEmbedding(layers.Layer, NestedObject):
 
         super().__init__()
         height, width, _ = input_shape
-        self.patch_size = patch_size
+        # fix patch size if recognition task
+        self.patch_size = (4, 8) if height != width else patch_size
         self.grid_size = (height // patch_size[0], width // patch_size[1])
         self.num_patches = (height // patch_size[0]) * (width // patch_size[1])
 

--- a/doctr/models/recognition/__init__.py
+++ b/doctr/models/recognition/__init__.py
@@ -1,4 +1,5 @@
 from .crnn import *
 from .master import *
 from .sar import *
+from .vitstr import *
 from .zoo import *

--- a/doctr/models/recognition/vitstr/__init__.py
+++ b/doctr/models/recognition/vitstr/__init__.py
@@ -1,0 +1,6 @@
+from doctr.file_utils import is_tf_available, is_torch_available
+
+if is_tf_available():
+    from .tensorflow import *
+elif is_torch_available():
+    from .pytorch import *  # type: ignore[misc]

--- a/doctr/models/recognition/vitstr/base.py
+++ b/doctr/models/recognition/vitstr/base.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from typing import List, Tuple
+
+import numpy as np
+
+from ....datasets import encode_sequences
+from ..core import RecognitionPostProcessor
+
+
+class _ViTSTR:
+
+    vocab: str
+    max_length: int
+
+    def build_target(
+        self,
+        gts: List[str],
+    ) -> Tuple[np.ndarray, List[int]]:
+        """Encode a list of gts sequences into a np array and gives the corresponding*
+        sequence lengths.
+
+        Args:
+            gts: list of ground-truth labels
+
+        Returns:
+            A tuple of 2 tensors: Encoded labels and sequence lengths (for each entry of the batch)
+        """
+        encoded = encode_sequences(
+            sequences=gts,
+            vocab=self.vocab,
+            target_size=self.max_length,
+            eos=len(self.vocab),
+            sos=len(self.vocab) + 1,
+            pad=len(self.vocab) + 2,
+        )
+        seq_len = [len(word) for word in gts]
+        return encoded, seq_len
+
+
+class _ViTSTRPostProcessor(RecognitionPostProcessor):
+    """Abstract class to postprocess the raw output of the model
+
+    Args:
+        vocab: string containing the ordered sequence of supported characters
+    """
+
+    def __init__(
+        self,
+        vocab: str,
+    ) -> None:
+
+        super().__init__(vocab)
+        self._embedding = list(vocab) + ["<eos>"] + ["<sos>"] + ["<pad>"]

--- a/doctr/models/recognition/vitstr/base.py
+++ b/doctr/models/recognition/vitstr/base.py
@@ -54,4 +54,4 @@ class _ViTSTRPostProcessor(RecognitionPostProcessor):
     ) -> None:
 
         super().__init__(vocab)
-        self._embedding = list(vocab) + ["<eos>"] + ["<sos>"] + ["<pad>"]
+        self._embedding = list(vocab) + ["<eos>", "<sos>", "<pad>"]

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -49,7 +49,7 @@ class ViTSTR(_ViTSTR, nn.Module):
         self,
         feature_extractor,
         vocab: str,
-        embedding_units: int = 384,
+        embedding_units: int,
         max_length: int = 25,
         dropout_prob: float = 0.0,
         input_shape: Tuple[int, int, int] = (3, 32, 128),  # different from paper
@@ -242,7 +242,7 @@ def vitstr_small(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
         num_layers=12,
         num_heads=6,
         ffd_ratio=4,
-        dropout_prob=0.1,
+        dropout_prob=0.0,
         ignore_keys=["head.weight", "head.bias"],
         **kwargs,
     )

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -201,7 +201,7 @@ def _vitstr(
 
     # Feature extractor
     feat_extractor = IntermediateLayerGetter(
-        backbone_fn(pretrained_backbone),
+        backbone_fn(pretrained_backbone, input_shape=_cfg["input_shape"]),  # type: ignore[call-arg]
         {layer: "features"},
     )
 

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -65,14 +65,7 @@ class ViTSTR(nn.Module, RecognitionModel):
 
         self.max_length = max_length + 1  # Add 1 timestep for EOS after the longest word
 
-        self.feat_extractor = VisionTransformer(
-            img_size=input_shape[1:],
-            patch_size=patch_size,
-            d_model=embedding_units,
-            num_layers=12,
-            num_heads=6,
-            dropout=dropout_prob,
-        )
+        self.feat_extractor = feature_extractor
         self.head = nn.Linear(embedding_units, len(self.vocab) + 1)
 
         self.postprocessor = ViTSTRPostProcessor(vocab=self.vocab)

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -100,7 +100,7 @@ class ViTSTR(_ViTSTR, nn.Module):
         # (batch_size, seq_len, d_model)
         B, N, E = features.size()
         features = features.reshape(B * N, E)
-        logits = self.head(features).view(B, N, len(self.vocab) + 3)  # (batch, seqlen, vocab + 3)
+        logits = self.head(features).view(B, N, len(self.vocab) + 3)  # (batch_size, seq_len, vocab + 3)
         decoded_features = logits[:, 1:]  # remove cls_token
 
         out: Dict[str, Any] = {}

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -195,13 +195,16 @@ def _vitstr(
         pretrained=pretrained_backbone,
         input_shape=_cfg["input_shape"],
         patch_size=(4, 8),
-        d_model=384,
-        num_layers=12,
-        num_heads=6,
-        ffd_ratio=4,
-        dropout=0.0,
+        d_model=kwargs.get("embedding_units"),
+        num_layers=kwargs.get("num_layers"),
+        num_heads=kwargs.get("num_heads"),
+        ffd_ratio=kwargs.get("ffd_ratio"),
+        dropout=kwargs.get("dropout_prob"),
         include_top=False,
     )
+    kwargs.pop("num_layers")
+    kwargs.pop("num_heads")
+    kwargs.pop("ffd_ratio")
 
     # Build the model
     model = ViTSTR(feat_extractor, cfg=_cfg, **kwargs)
@@ -235,6 +238,11 @@ def vitstr_small(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
     return _vitstr(
         "vitstr_small",
         pretrained,
+        embedding_units=384,
+        num_layers=12,
+        num_heads=6,
+        ffd_ratio=4,
+        dropout_prob=0.1,
         ignore_keys=["head.weight", "head.bias"],
         **kwargs,
     )

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -97,7 +97,7 @@ class ViTSTR(_ViTSTR, nn.Module):
 
         # borrowed from : https://github.com/baudm/parseq/blob/main/strhub/models/vitstr/model.py
         features = features[:, : self.max_length + 1]  # add 1 for unused cls token (ViT)
-        # batch, seqlen, embedding_size
+        # (batch_size, seq_len, d_model)
         B, N, E = features.size()
         features = features.reshape(B * N, E)
         logits = self.head(features).view(B, N, len(self.vocab) + 3)  # (batch, seqlen, vocab + 3)
@@ -130,8 +130,8 @@ class ViTSTR(_ViTSTR, nn.Module):
         Sequences are masked after the EOS character.
 
         Args:
-            gt: the encoded tensor with gt labels
             model_output: predicted logits of the model
+            gt: the encoded tensor with gt labels
             seq_len: lengths of each gt word inside the batch
 
         Returns:

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -1,0 +1,244 @@
+# Copyright (C) 2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from doctr.datasets import VOCABS
+from doctr.models.classification import vit
+
+from ...utils.pytorch import load_pretrained_params
+from ..core import RecognitionModel, RecognitionPostProcessor
+
+__all__ = ["ViTSTR", "vitstr"]
+
+default_cfgs: Dict[str, Dict[str, Any]] = {
+    "vitstr": {
+        "mean": (0.694, 0.695, 0.693),
+        "std": (0.299, 0.296, 0.301),
+        "input_shape": (3, 32, 128),
+        "vocab": VOCABS["french"],
+        "url": None,
+    },
+}
+
+
+class ViTSTR(nn.Module, RecognitionModel):
+    """Implements a ViTSTR architecture as described in `"Vision Transformer for Fast and
+    Efficient Scene Text Recognition" <https://arxiv.org/pdf/2105.08582.pdf>`_.
+
+    Args:
+        feature_extractor: the backbone serving as feature extractor
+        vocab: vocabulary used for encoding
+        embedding_units: number of embedding units
+        max_length: maximum word length handled by the model
+        dropout_prob: dropout probability of the encoder LSTM
+        input_shape: input shape of the image
+        patch_size: size of the patches
+        exportable: onnx exportable returns only logits
+        cfg: dictionary containing information about the model
+    """
+
+    def __init__(
+        self,
+        feature_extractor,
+        vocab: str,
+        embedding_units: int = 384,
+        max_length: int = 25,
+        dropout_prob: float = 0.0,
+        input_shape: Tuple[int, int, int] = (3, 32, 128),  # different from paper
+        patch_size: Tuple[int, int] = (4, 8),  # different from paper to match our size
+        exportable: bool = False,
+        cfg: Optional[Dict[str, Any]] = None,
+    ) -> None:
+
+        super().__init__()
+        self.vocab = vocab
+        self.exportable = exportable
+        self.cfg = cfg
+
+        self.max_length = max_length + 1  # Add 1 timestep for EOS after the longest word
+
+        self.feat_extractor = VisionTransformer(
+            img_size=input_shape[1:],
+            patch_size=patch_size,
+            d_model=embedding_units,
+            num_layers=12,
+            num_heads=6,
+            dropout=dropout_prob,
+        )
+        self.head = nn.Linear(embedding_units, len(self.vocab) + 1)
+
+        self.postprocessor = ViTSTRPostProcessor(vocab=self.vocab)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        target: Optional[List[str]] = None,
+        return_model_output: bool = False,
+        return_preds: bool = False,
+    ) -> Dict[str, Any]:
+
+        features = self.feat_extractor(x)  # (batch_size, seq_len, d_model)
+
+        if target is not None:
+            _gt, _seq_len = self.build_target(target)
+            gt, seq_len = torch.from_numpy(_gt).to(dtype=torch.long), torch.tensor(_seq_len)
+            gt, seq_len = gt.to(x.device), seq_len.to(x.device)
+
+        if self.training and target is None:
+            raise ValueError("Need to provide labels during training")
+
+        # borrowed from : https://github.com/baudm/parseq/blob/main/strhub/models/vitstr/model.py
+        features = features[:, : self.max_length + 1]  # add 1 for unused cls token (ViT)
+        # batch, seqlen, embedding_size
+        B, N, E = features.size()
+        features = features.reshape(B * N, E)
+        logits = self.head(features).view(B, N, len(self.vocab) + 1)  # (batch, seqlen, vocab + 1)
+        decoded_features = logits[:, 1:]  # remove cls_token
+
+        out: Dict[str, Any] = {}
+        if self.exportable:
+            out["logits"] = decoded_features
+            return out
+
+        if return_model_output:
+            out["out_map"] = decoded_features
+
+        if target is None or return_preds:
+            # Post-process boxes
+            out["preds"] = self.postprocessor(decoded_features)
+
+        if target is not None:
+            out["loss"] = self.compute_loss(decoded_features, gt, seq_len)
+
+        return out
+
+    @staticmethod
+    def compute_loss(
+        model_output: torch.Tensor,
+        gt: torch.Tensor,
+        seq_len: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute categorical cross-entropy loss for the model.
+        Sequences are masked after the EOS character.
+        Args:
+            model_output: predicted logits of the model
+            gt: the encoded tensor with gt labels
+            seq_len: lengths of each gt word inside the batch
+        Returns:
+            The loss of the model on the batch
+        """
+        # Input length : number of timesteps
+        input_len = model_output.shape[1]
+        # Add one for additional <eos> token
+        seq_len = seq_len + 1
+        # Compute loss
+        # (N, L, vocab_size + 1)
+        cce = F.cross_entropy(model_output.permute(0, 2, 1), gt, reduction="none")
+        mask_2d = torch.arange(input_len, device=model_output.device)[None, :] >= seq_len[:, None]
+        cce[mask_2d] = 0
+
+        ce_loss = cce.sum(1) / seq_len.to(dtype=model_output.dtype)
+        return ce_loss.mean()
+
+
+class ViTSTRPostProcessor(RecognitionPostProcessor):
+    """Post processor for ViTSTR architectures
+
+    Args:
+        vocab: string containing the ordered sequence of supported characters
+    """
+
+    def __call__(
+        self,
+        logits: torch.Tensor,
+    ) -> List[Tuple[str, float]]:
+        # compute pred with argmax for attention models
+        out_idxs = logits.argmax(-1)
+        # N x L
+        probs = torch.gather(torch.softmax(logits, -1), -1, out_idxs.unsqueeze(-1)).squeeze(-1)
+        # Take the minimum confidence of the sequence
+        probs = probs.min(dim=1).values.detach().cpu()
+
+        # Manual decoding
+        word_values = [
+            "".join(self._embedding[idx] for idx in encoded_seq).split("<eos>")[0]
+            for encoded_seq in out_idxs.detach().cpu().numpy()
+        ]
+
+        return list(zip(word_values, probs.numpy().tolist()))
+
+
+def _vitstr(
+    arch: str,
+    pretrained: bool,
+    pretrained_backbone: bool = True,
+    ignore_keys: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> ViTSTR:
+
+    pretrained_backbone = pretrained_backbone and not pretrained
+
+    # Patch the config
+    _cfg = deepcopy(default_cfgs[arch])
+    _cfg["vocab"] = kwargs.get("vocab", _cfg["vocab"])
+    _cfg["input_shape"] = kwargs.get("input_shape", _cfg["input_shape"])
+
+    kwargs["vocab"] = _cfg["vocab"]
+    kwargs["input_shape"] = _cfg["input_shape"]
+
+    # Feature extractor
+    feat_extractor = vit(
+        pretrained=pretrained_backbone,
+        input_shape=_cfg["input_shape"],
+        patch_size=(4, 8),
+        d_model=384,
+        num_layers=12,
+        num_heads=6,
+        dropout=0.0,
+        include_top=False,
+    )
+    # TODO: update also Tensorflow all !!!
+
+    # Build the model
+    model = ViTSTR(feat_extractor, cfg=_cfg, **kwargs)
+    # Load pretrained parameters
+    if pretrained:
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if _cfg["vocab"] != default_cfgs[arch]["vocab"] else None
+        load_pretrained_params(model, default_cfgs[arch]["url"], ignore_keys=_ignore_keys)
+
+    return model
+
+
+def vitstr(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
+    """ViTSTR as described in `"Vision Transformer for Fast and Efficient Scene Text Recognition"
+    <https://arxiv.org/pdf/2105.08582.pdf>`_.
+
+    >>> import torch
+    >>> from doctr.models import vitstr
+    >>> model = vitstr(pretrained=False)
+    >>> input_tensor = torch.rand((1, 3, 32, 128))
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
+
+    Returns:
+        text recognition architecture
+    """
+
+    return _vitstr(
+        "vitstr",
+        pretrained,
+        ignore_keys=["head.weight", "head.bias"],
+        **kwargs,
+    )

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -194,7 +194,7 @@ def _vitstr(
     kwargs["vocab"] = _cfg["vocab"]
 
     # Feature extractor
-    feat_extractor = vit_b(
+    feat_extractor = vit_b(  # type: ignore[operator]
         pretrained=pretrained_backbone,
         input_shape=_cfg["input_shape"],
         patch_size=(4, 8),

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -88,8 +88,8 @@ class ViTSTR(_ViTSTR, Model):
         Sequences are masked after the EOS character.
 
         Args:
-            gt: the encoded tensor with gt labels
             model_output: predicted logits of the model
+            gt: the encoded tensor with gt labels
             seq_len: lengths of each gt word inside the batch
 
         Returns:
@@ -131,7 +131,7 @@ class ViTSTR(_ViTSTR, Model):
             raise ValueError("Need to provide labels during training")
 
         features = features[:, : self.max_length + 1]  # add 1 for unused cls token (ViT)
-        # batch, seqlen, embedding_size
+        # (batch_size, seq_len, d_model)
         B, N, E = features.shape
         features = tf.reshape(features, (B * N, E))
         logits = tf.reshape(self.head(features), (B, N, len(self.vocab) + 3))  # (batch, seqlen, vocab + 3)

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -50,7 +50,7 @@ class ViTSTR(_ViTSTR, Model):
         self,
         feature_extractor,
         vocab: str,
-        embedding_units: int = 384,
+        embedding_units: int,
         max_length: int = 25,
         dropout_prob: float = 0.0,
         input_shape: Tuple[int, int, int] = (32, 128, 3),  # different from paper
@@ -243,6 +243,6 @@ def vitstr_small(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
         num_layers=12,
         num_heads=6,
         ffd_ratio=4,
-        dropout_prob=0.1,
+        dropout_prob=0.0,
         **kwargs,
     )

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -223,7 +223,7 @@ def vitstr_small(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
     """ViTSTR-Small as described in `"Vision Transformer for Fast and Efficient Scene Text Recognition"
     <https://arxiv.org/pdf/2105.08582.pdf>`_.
 
-    >>> import tf
+    >>> import tensorflow as tf
     >>> from doctr.models import vitstr_small
     >>> model = vitstr_small(pretrained=False)
     >>> input_tensor = tf.random.uniform(shape=[1, 32, 128, 3], maxval=1, dtype=tf.float32)
@@ -249,7 +249,7 @@ def vitstr_base(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
     """ViTSTR-Base as described in `"Vision Transformer for Fast and Efficient Scene Text Recognition"
     <https://arxiv.org/pdf/2105.08582.pdf>`_.
 
-    >>> import tf
+    >>> import tensorflow as tf
     >>> from doctr.models import vitstr_base
     >>> model = vitstr_base(pretrained=False)
     >>> input_tensor = tf.random.uniform(shape=[1, 32, 128, 3], maxval=1, dtype=tf.float32)

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -244,4 +244,5 @@ def vitstr_small(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
         num_heads=6,
         ffd_ratio=4,
         dropout_prob=0.1,
-        **kwargs)
+        **kwargs,
+    )

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -1,0 +1,220 @@
+# Copyright (C) 2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Tuple
+
+import tensorflow as tf
+from tensorflow.keras import Model, layers
+
+from doctr.datasets import VOCABS
+
+from ...modules import VisionTransformer
+from ...utils.tensorflow import load_pretrained_params
+from ..core import RecognitionModel, RecognitionPostProcessor
+
+__all__ = ["ViTSTR", "vitstr"]
+
+default_cfgs: Dict[str, Dict[str, Any]] = {
+    "vitstr": {
+        "mean": (0.694, 0.695, 0.693),
+        "std": (0.299, 0.296, 0.301),
+        "input_shape": (32, 128, 3),
+        "vocab": VOCABS["french"],
+        "url": None,
+    },
+}
+
+
+class ViTSTR(Model, RecognitionModel):
+    """Implements a ViTSTR architecture as described in `"Vision Transformer for Fast and
+    Efficient Scene Text Recognition" <https://arxiv.org/pdf/2105.08582.pdf>`_.
+
+    Args:
+        vocab: vocabulary used for encoding
+        embedding_units: number of embedding units
+        max_length: maximum word length handled by the model
+        dropout_prob: dropout probability for the encoder and decoder
+        input_shape: input shape of the image
+        patch_size: size of the patches
+        exportable: onnx exportable returns only logits
+        cfg: dictionary containing information about the model
+    """
+
+    _children_names: List[str] = ["feat_extractor", "postprocessor"]
+
+    def __init__(
+        self,
+        vocab: str,
+        embedding_units: int = 384,
+        max_length: int = 25,
+        dropout_prob: float = 0.0,
+        input_shape: Tuple[int, int, int] = (32, 128, 3),  # different from paper
+        patch_size: Tuple[int, int] = (4, 8),  # different from paper to match our size
+        exportable: bool = False,
+        cfg: Optional[Dict[str, Any]] = None,
+    ) -> None:
+
+        super().__init__()
+        self.vocab = vocab
+        self.exportable = exportable
+        self.cfg = cfg
+        self.max_length = max_length + 1  # Add 1 timestep for EOS after the longest word
+
+        self.feat_extractor = VisionTransformer(
+            img_size=input_shape[:-1],
+            patch_size=patch_size,
+            d_model=embedding_units,
+            num_layers=12,
+            num_heads=6,
+            dropout=dropout_prob,
+        )
+        self.head = layers.Dense(len(self.vocab) + 1)
+
+        self.postprocessor = ViTSTRPostProcessor(vocab=self.vocab)
+
+    @staticmethod
+    def compute_loss(
+        model_output: tf.Tensor,
+        gt: tf.Tensor,
+        seq_len: tf.Tensor,
+    ) -> tf.Tensor:
+        """Compute categorical cross-entropy loss for the model.
+        Sequences are masked after the EOS character.
+        Args:
+            gt: the encoded tensor with gt labels
+            model_output: predicted logits of the model
+            seq_len: lengths of each gt word inside the batch
+        Returns:
+            The loss of the model on the batch
+        """
+        # Input length : number of timesteps
+        input_len = tf.shape(model_output)[1]
+        # Add one for additional <eos> token
+        seq_len = seq_len + 1
+        # One-hot gt labels
+        oh_gt = tf.one_hot(gt, depth=model_output.shape[2])
+        # Compute loss
+        cce = tf.nn.softmax_cross_entropy_with_logits(oh_gt, model_output)
+        # Compute mask
+        mask_values = tf.zeros_like(cce)
+        mask_2d = tf.sequence_mask(seq_len, input_len)
+        masked_loss = tf.where(mask_2d, cce, mask_values)
+        ce_loss = tf.math.divide(tf.reduce_sum(masked_loss, axis=1), tf.cast(seq_len, model_output.dtype))
+        return tf.expand_dims(ce_loss, axis=1)
+
+    def call(
+        self,
+        x: tf.Tensor,
+        target: Optional[List[str]] = None,
+        return_model_output: bool = False,
+        return_preds: bool = False,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+
+        features = self.feat_extractor(x, **kwargs)
+
+        if target is not None:
+            gt, seq_len = self.build_target(target)
+            seq_len = tf.cast(seq_len, tf.int32)
+
+        if kwargs.get("training", False) and target is None:
+            raise ValueError("Need to provide labels during training")
+
+        features = features[:, : self.max_length + 1]  # add 1 for unused cls token (ViT)
+        # batch, seqlen, embedding_size
+        B, N, E = features.shape
+        features = tf.reshape(features, (B * N, E))
+        logits = tf.reshape(self.head(features), (B, N, len(self.vocab) + 1))  # (batch, seqlen, vocab + 1)
+        decoded_features = logits[:, 1:]  # remove cls_token
+
+        out: Dict[str, tf.Tensor] = {}
+        if self.exportable:
+            out["logits"] = decoded_features
+            return out
+
+        if return_model_output:
+            out["out_map"] = decoded_features
+
+        if target is None or return_preds:
+            # Post-process boxes
+            out["preds"] = self.postprocessor(decoded_features)
+
+        if target is not None:
+            out["loss"] = self.compute_loss(decoded_features, gt, seq_len)
+
+        return out
+
+
+class ViTSTRPostProcessor(RecognitionPostProcessor):
+    """Post processor for ViTSTR architecture
+
+    Args:
+        vocab: string containing the ordered sequence of supported characters
+    """
+
+    def __call__(
+        self,
+        logits: tf.Tensor,
+    ) -> List[Tuple[str, float]]:
+        # compute pred with argmax for attention models
+        out_idxs = tf.math.argmax(logits, axis=2)
+        # N x L
+        probs = tf.gather(tf.nn.softmax(logits, axis=-1), out_idxs, axis=-1, batch_dims=2)
+        # Take the minimum confidence of the sequence
+        probs = tf.math.reduce_min(probs, axis=1)
+
+        # decode raw output of the model with tf_label_to_idx
+        out_idxs = tf.cast(out_idxs, dtype="int32")
+        embedding = tf.constant(self._embedding, dtype=tf.string)
+        decoded_strings_pred = tf.strings.reduce_join(inputs=tf.nn.embedding_lookup(embedding, out_idxs), axis=-1)
+        decoded_strings_pred = tf.strings.split(decoded_strings_pred, "<eos>")
+        decoded_strings_pred = tf.sparse.to_dense(decoded_strings_pred.to_sparse(), default_value="not valid")[:, 0]
+        word_values = [word.decode() for word in decoded_strings_pred.numpy().tolist()]
+
+        return list(zip(word_values, probs.numpy().tolist()))
+
+
+def _vitstr(
+    arch: str,
+    pretrained: bool,
+    input_shape: Optional[Tuple[int, int, int]] = None,
+    **kwargs: Any,
+) -> ViTSTR:
+
+    # Patch the config
+    _cfg = deepcopy(default_cfgs[arch])
+    _cfg["input_shape"] = input_shape or _cfg["input_shape"]
+    _cfg["vocab"] = kwargs.get("vocab", _cfg["vocab"])
+
+    kwargs["vocab"] = _cfg["vocab"]
+
+    # Build the model
+    model = ViTSTR(cfg=_cfg, **kwargs)
+    # Load pretrained parameters
+    if pretrained:
+        load_pretrained_params(model, default_cfgs[arch]["url"])
+
+    return model
+
+
+def vitstr(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
+    """ViTSTR as described in `"Vision Transformer for Fast and Efficient Scene Text Recognition"
+    <https://arxiv.org/pdf/2105.08582.pdf>`_.
+
+    >>> import tensorflow as tf
+    >>> from doctr.models import vitstr
+    >>> model = vitstr(pretrained=False)
+    >>> input_tensor = tf.random.uniform(shape=[1, 32, 128, 3], maxval=1, dtype=tf.float32)
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
+
+    Returns:
+        text recognition architecture
+    """
+
+    return _vitstr("vitstr", pretrained, **kwargs)

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -199,13 +199,16 @@ def _vitstr(
         pretrained=pretrained_backbone,
         input_shape=_cfg["input_shape"],
         patch_size=(4, 8),
-        d_model=384,
-        num_layers=12,
-        num_heads=6,
-        dropout=0.0,
-        ffd_ratio=4,
+        d_model=kwargs.get("embedding_units"),
+        num_layers=kwargs.get("num_layers"),
+        num_heads=kwargs.get("num_heads"),
+        ffd_ratio=kwargs.get("ffd_ratio"),
+        dropout=kwargs.get("dropout_prob"),
         include_top=False,
     )
+    kwargs.pop("num_layers")
+    kwargs.pop("num_heads")
+    kwargs.pop("ffd_ratio")
 
     # Build the model
     model = ViTSTR(feat_extractor, cfg=_cfg, **kwargs)
@@ -233,4 +236,12 @@ def vitstr_small(pretrained: bool = False, **kwargs: Any) -> ViTSTR:
         text recognition architecture
     """
 
-    return _vitstr("vitstr_small", pretrained, **kwargs)
+    return _vitstr(
+        "vitstr_small",
+        pretrained,
+        embedding_units=384,
+        num_layers=12,
+        num_heads=6,
+        ffd_ratio=4,
+        dropout_prob=0.1,
+        **kwargs)

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -121,7 +121,7 @@ class ViTSTR(_ViTSTR, Model):
         **kwargs: Any,
     ) -> Dict[str, Any]:
 
-        features = self.feat_extractor(x, **kwargs)
+        features = self.feat_extractor(x, **kwargs)  # (batch_size, seq_len, d_model)
 
         if target is not None:
             gt, seq_len = self.build_target(target)
@@ -134,7 +134,7 @@ class ViTSTR(_ViTSTR, Model):
         # (batch_size, seq_len, d_model)
         B, N, E = features.shape
         features = tf.reshape(features, (B * N, E))
-        logits = tf.reshape(self.head(features), (B, N, len(self.vocab) + 3))  # (batch, seqlen, vocab + 3)
+        logits = tf.reshape(self.head(features), (B, N, len(self.vocab) + 3))  # (batch_size, seq_len, vocab + 3)
         decoded_features = logits[:, 1:]  # remove cls_token
 
         out: Dict[str, tf.Tensor] = {}

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -20,7 +20,7 @@ ARCHS: List[str] = [
     "crnn_mobilenet_v3_large",
     "sar_resnet31",
     "master",
-    "vitstr",
+    "vitstr_small",
 ]
 
 
@@ -34,7 +34,7 @@ def _predictor(arch: Any, pretrained: bool, **kwargs: Any) -> RecognitionPredict
             pretrained=pretrained, pretrained_backbone=kwargs.get("pretrained_backbone", True)
         )
     else:
-        if not isinstance(arch, (recognition.CRNN, recognition.SAR, recognition.MASTER)):
+        if not isinstance(arch, (recognition.CRNN, recognition.SAR, recognition.MASTER, recognition.ViTSTR)):
             raise ValueError(f"unknown architecture: {type(arch)}")
         _model = arch
 

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -21,6 +21,7 @@ ARCHS: List[str] = [
     "sar_resnet31",
     "master",
     "vitstr_small",
+    "vitstr_base",
 ]
 
 

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -14,7 +14,14 @@ from .predictor import RecognitionPredictor
 __all__ = ["recognition_predictor"]
 
 
-ARCHS: List[str] = ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master"]
+ARCHS: List[str] = [
+    "crnn_vgg16_bn",
+    "crnn_mobilenet_v3_small",
+    "crnn_mobilenet_v3_large",
+    "sar_resnet31",
+    "master",
+    "vitstr",
+]
 
 
 def _predictor(arch: Any, pretrained: bool, **kwargs: Any) -> RecognitionPredictor:

--- a/tests/pytorch/test_models_classification_pt.py
+++ b/tests/pytorch/test_models_classification_pt.py
@@ -40,6 +40,7 @@ def _test_classification(model, input_shape, output_size, batch_size=2):
         ["magc_resnet31", (3, 32, 32), (126,)],
         ["mobilenet_v3_small", (3, 32, 32), (126,)],
         ["mobilenet_v3_large", (3, 32, 32), (126,)],
+        ["vit_s", (3, 32, 32), (126,)],
         ["vit_b", (3, 32, 32), (126,)],
     ],
 )

--- a/tests/pytorch/test_models_factory.py
+++ b/tests/pytorch/test_models_factory.py
@@ -46,6 +46,7 @@ def test_push_to_hf_hub():
         ["crnn_mobilenet_v3_large", "recognition", "Felix92/doctr-dummy-torch-crnn-mobilenet-v3-large"],
         ["sar_resnet31", "recognition", "Felix92/doctr-dummy-torch-sar-resnet31"],
         ["master", "recognition", "Felix92/doctr-dummy-torch-master"],
+        ["vitstr_small", "recognition", "Felix92/doctr-dummy-torch-vitstr-small"],
         [
             "fasterrcnn_mobilenet_v3_large_fpn",
             "obj_detection",

--- a/tests/pytorch/test_models_recognition_pt.py
+++ b/tests/pytorch/test_models_recognition_pt.py
@@ -23,6 +23,7 @@ from doctr.models.utils import export_model_to_onnx
         ["sar_resnet31", (3, 32, 128), False],
         ["master", (3, 32, 128), False],
         ["vitstr_small", (3, 32, 128), False],
+        ["vitstr_base", (3, 32, 128), False],
     ],
 )
 def test_recognition_models(arch_name, input_shape, pretrained, mock_vocab):
@@ -72,7 +73,15 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
 
 @pytest.mark.parametrize(
     "arch_name",
-    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master", "vitstr_small"],
+    [
+        "crnn_vgg16_bn",
+        "crnn_mobilenet_v3_small",
+        "crnn_mobilenet_v3_large",
+        "sar_resnet31",
+        "master",
+        "vitstr_small",
+        "vitstr_base",
+    ],
 )
 def test_recognition_zoo(arch_name):
     batch_size = 2
@@ -102,7 +111,7 @@ def test_recognition_zoo(arch_name):
         ["crnn_mobilenet_v3_large", (3, 32, 128)],
         ["sar_resnet31", (3, 32, 128)],
         ["master", (3, 32, 128)],
-        ["vitstr_small", (3, 32, 128)],
+        ["vitstr_small", (3, 32, 128)],  # testing one vitstr version is enough
     ],
 )
 def test_models_onnx_export(arch_name, input_shape):

--- a/tests/pytorch/test_models_recognition_pt.py
+++ b/tests/pytorch/test_models_recognition_pt.py
@@ -9,6 +9,8 @@ from doctr.models import recognition
 from doctr.models.recognition.crnn.pytorch import CTCPostProcessor
 from doctr.models.recognition.master.pytorch import MASTERPostProcessor
 from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.models.recognition.sar.pytorch import SARPostProcessor
+from doctr.models.recognition.vitstr.pytorch import ViTSTRPostProcessor
 from doctr.models.utils import export_model_to_onnx
 
 
@@ -20,6 +22,7 @@ from doctr.models.utils import export_model_to_onnx
         ["crnn_mobilenet_v3_large", (3, 32, 128), True],
         ["sar_resnet31", (3, 32, 128), False],
         ["master", (3, 32, 128), False],
+        ["vitstr", (3, 32, 128), False],
     ],
 )
 def test_recognition_models(arch_name, input_shape, pretrained, mock_vocab):
@@ -51,6 +54,8 @@ def test_recognition_models(arch_name, input_shape, pretrained, mock_vocab):
     "post_processor, input_shape",
     [
         [CTCPostProcessor, [2, 119, 30]],
+        [SARPostProcessor, [2, 119, 30]],
+        [ViTSTRPostProcessor, [2, 119, 30]],
         [MASTERPostProcessor, [2, 119, 30]],
     ],
 )
@@ -67,7 +72,7 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
 
 @pytest.mark.parametrize(
     "arch_name",
-    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master"],
+    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master", "vitstr"],
 )
 def test_recognition_zoo(arch_name):
     batch_size = 2
@@ -97,6 +102,7 @@ def test_recognition_zoo(arch_name):
         ["crnn_mobilenet_v3_large", (3, 32, 128)],
         ["sar_resnet31", (3, 32, 128)],
         ["master", (3, 32, 128)],
+        ["vitstr", (3, 32, 128)],
     ],
 )
 def test_models_onnx_export(arch_name, input_shape):

--- a/tests/pytorch/test_models_recognition_pt.py
+++ b/tests/pytorch/test_models_recognition_pt.py
@@ -22,7 +22,7 @@ from doctr.models.utils import export_model_to_onnx
         ["crnn_mobilenet_v3_large", (3, 32, 128), True],
         ["sar_resnet31", (3, 32, 128), False],
         ["master", (3, 32, 128), False],
-        ["vitstr", (3, 32, 128), False],
+        ["vitstr_small", (3, 32, 128), False],
     ],
 )
 def test_recognition_models(arch_name, input_shape, pretrained, mock_vocab):
@@ -72,7 +72,7 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
 
 @pytest.mark.parametrize(
     "arch_name",
-    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master", "vitstr"],
+    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master", "vitstr_small"],
 )
 def test_recognition_zoo(arch_name):
     batch_size = 2
@@ -102,7 +102,7 @@ def test_recognition_zoo(arch_name):
         ["crnn_mobilenet_v3_large", (3, 32, 128)],
         ["sar_resnet31", (3, 32, 128)],
         ["master", (3, 32, 128)],
-        ["vitstr", (3, 32, 128)],
+        ["vitstr_small", (3, 32, 128)],
     ],
 )
 def test_models_onnx_export(arch_name, input_shape):

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -24,6 +24,7 @@ from doctr.models.utils import export_model_to_onnx
         ["magc_resnet31", (32, 32, 3), (126,)],
         ["mobilenet_v3_small", (32, 32, 3), (126,)],
         ["mobilenet_v3_large", (32, 32, 3), (126,)],
+        ["vit_s", (32, 32, 3), (126,)],
         ["vit_b", (32, 32, 3), (126,)],
     ],
 )

--- a/tests/tensorflow/test_models_factory.py
+++ b/tests/tensorflow/test_models_factory.py
@@ -44,7 +44,7 @@ def test_push_to_hf_hub():
         ["crnn_mobilenet_v3_large", "recognition", "Felix92/doctr-dummy-tf-crnn-mobilenet-v3-large"],
         ["sar_resnet31", "recognition", "Felix92/doctr-dummy-tf-sar-resnet31"],
         ["master", "recognition", "Felix92/doctr-dummy-tf-master"],
-        # TODO: ["vitstr", "recognition", "Felix92/doctr-dummy-tf-vitstr"],
+        ["vitstr_small", "recognition", "Felix92/doctr-dummy-tf-vitstr-small"],
     ],
 )
 def test_models_for_hub(arch_name, task_name, dummy_model_id, tmpdir):

--- a/tests/tensorflow/test_models_factory.py
+++ b/tests/tensorflow/test_models_factory.py
@@ -44,6 +44,7 @@ def test_push_to_hf_hub():
         ["crnn_mobilenet_v3_large", "recognition", "Felix92/doctr-dummy-tf-crnn-mobilenet-v3-large"],
         ["sar_resnet31", "recognition", "Felix92/doctr-dummy-tf-sar-resnet31"],
         ["master", "recognition", "Felix92/doctr-dummy-tf-master"],
+        # TODO: ["vitstr", "recognition", "Felix92/doctr-dummy-tf-vitstr"],
     ],
 )
 def test_models_for_hub(arch_name, task_name, dummy_model_id, tmpdir):

--- a/tests/tensorflow/test_models_recognition_tf.py
+++ b/tests/tensorflow/test_models_recognition_tf.py
@@ -27,7 +27,7 @@ from doctr.utils.geometry import extract_crops
         ["crnn_mobilenet_v3_large", (32, 128, 3)],
         ["sar_resnet31", (32, 128, 3)],
         ["master", (32, 128, 3)],
-        ["vitstr", (32, 128, 3)],
+        ["vitstr_small", (32, 128, 3)],
     ],
 )
 def test_recognition_models(arch_name, input_shape):
@@ -101,7 +101,7 @@ def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
 
 @pytest.mark.parametrize(
     "arch_name",
-    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master", "vitstr"],
+    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master", "vitstr_small"],
 )
 def test_recognition_zoo(arch_name):
     batch_size = 2
@@ -155,7 +155,7 @@ def test_recognition_zoo_error():
         ["crnn_mobilenet_v3_large", (32, 128, 3)],
         ["sar_resnet31", (32, 128, 3)],
         ["master", (32, 128, 3)],
-        ["vitstr", (32, 128, 3)],
+        ["vitstr_small", (32, 128, 3)],
     ],
 )
 def test_models_onnx_export(arch_name, input_shape):
@@ -163,9 +163,8 @@ def test_models_onnx_export(arch_name, input_shape):
     batch_size = 2
     tf.keras.backend.clear_session()
     model = recognition.__dict__[arch_name](pretrained=True, exportable=True, input_shape=input_shape)
-    if arch_name == "sar_resnet31":  # SAR export currently only available with constant batch size
-        dummy_input = [tf.TensorSpec([batch_size, *input_shape], tf.float32, name="input")]
-    elif arch_name == "master":  # MASTER export currently only available with constant batch size
+    # SAR, MASTER, ViTSTR export currently only available with constant batch size
+    if arch_name in ["sar_resnet31", "master", "vitstr_small"]:
         dummy_input = [tf.TensorSpec([batch_size, *input_shape], tf.float32, name="input")]
     else:
         # batch_size = None for dynamic batch size

--- a/tests/tensorflow/test_models_recognition_tf.py
+++ b/tests/tensorflow/test_models_recognition_tf.py
@@ -14,6 +14,7 @@ from doctr.models.recognition.crnn.tensorflow import CTCPostProcessor
 from doctr.models.recognition.master.tensorflow import MASTERPostProcessor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.models.recognition.sar.tensorflow import SARPostProcessor
+from doctr.models.recognition.vitstr.tensorflow import ViTSTRPostProcessor
 from doctr.models.utils import export_model_to_onnx
 from doctr.utils.geometry import extract_crops
 
@@ -26,6 +27,7 @@ from doctr.utils.geometry import extract_crops
         ["crnn_mobilenet_v3_large", (32, 128, 3)],
         ["sar_resnet31", (32, 128, 3)],
         ["master", (32, 128, 3)],
+        ["vitstr", (32, 128, 3)],
     ],
 )
 def test_recognition_models(arch_name, input_shape):
@@ -55,6 +57,7 @@ def test_recognition_models(arch_name, input_shape):
         [SARPostProcessor, [2, 30, 119]],
         [CTCPostProcessor, [2, 30, 119]],
         [MASTERPostProcessor, [2, 30, 119]],
+        [ViTSTRPostProcessor, [2, 30, 119]],
     ],
 )
 def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
@@ -98,7 +101,7 @@ def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
 
 @pytest.mark.parametrize(
     "arch_name",
-    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master"],
+    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master", "vitstr"],
 )
 def test_recognition_zoo(arch_name):
     batch_size = 2
@@ -152,6 +155,7 @@ def test_recognition_zoo_error():
         ["crnn_mobilenet_v3_large", (32, 128, 3)],
         ["sar_resnet31", (32, 128, 3)],
         ["master", (32, 128, 3)],
+        ["vitstr", (32, 128, 3)],
     ],
 )
 def test_models_onnx_export(arch_name, input_shape):

--- a/tests/tensorflow/test_models_recognition_tf.py
+++ b/tests/tensorflow/test_models_recognition_tf.py
@@ -28,6 +28,7 @@ from doctr.utils.geometry import extract_crops
         ["sar_resnet31", (32, 128, 3)],
         ["master", (32, 128, 3)],
         ["vitstr_small", (32, 128, 3)],
+        ["vitstr_base", (32, 128, 3)],
     ],
 )
 def test_recognition_models(arch_name, input_shape):
@@ -101,7 +102,15 @@ def test_recognitionpredictor(mock_pdf, mock_vocab):  # noqa: F811
 
 @pytest.mark.parametrize(
     "arch_name",
-    ["crnn_vgg16_bn", "crnn_mobilenet_v3_small", "crnn_mobilenet_v3_large", "sar_resnet31", "master", "vitstr_small"],
+    [
+        "crnn_vgg16_bn",
+        "crnn_mobilenet_v3_small",
+        "crnn_mobilenet_v3_large",
+        "sar_resnet31",
+        "master",
+        "vitstr_small",
+        "vitstr_base",
+    ],
 )
 def test_recognition_zoo(arch_name):
     batch_size = 2
@@ -155,7 +164,7 @@ def test_recognition_zoo_error():
         ["crnn_mobilenet_v3_large", (32, 128, 3)],
         ["sar_resnet31", (32, 128, 3)],
         ["master", (32, 128, 3)],
-        ["vitstr_small", (32, 128, 3)],
+        ["vitstr_small", (32, 128, 3)],  # testing one vitstr version is enough
     ],
 )
 def test_models_onnx_export(arch_name, input_shape):


### PR DESCRIPTION
This PR:

- adds ViTSTR in TF and PT
- update ViT config
- add pos_interpolation to ViT to make it work also on higher image resolutions (case: recognition) as backbone
- ViT tf refactor patchify to reduce memory consuption (now it is similar to PT implementation TF: vit_s: 8.9 GB to PT: 7.5GB)
  (This difference is normal faiced the same % diff in SAR and MASTER between TF and PT)
- apply some fixes
- added model configs in this PR in both frameworks are: vit_s, vit_b (updated), viststr_small, vitstr_base 

Any feedback is very welcome :hugs: 

NOTE: 
Unlike the SAR or MASTER architecture, I am not able to fully train the model because ViT requires a lot of data and I cannot muster the computing power. So just a little test this time based on our word generator to show that it trains well.

slow tests: passed

PT: 

```
(doctr-dev) felix@felix-GS66-Stealth-11UH:~/Desktop/doctr$ python3 /home/felix/Desktop/doctr/references/recognition/train_pytorch.py vitstr
2022-09-19 09:35:14.038958: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
Namespace(amp=False, arch='vitstr', batch_size=64, device=None, epochs=10, find_lr=False, font='FreeMono.ttf,FreeSans.ttf,FreeSerif.ttf', input_size=32, lr=0.001, max_chars=12, min_chars=1, name=None, pretrained=False, push_to_hub=False, resume=None, sched='cosine', show_samples=False, test_only=False, train_path=None, train_samples=1000, val_path=None, val_samples=20, vocab='french', wb=False, weight_decay=0, workers=None)
Validation set loaded in 1.727s (2520 samples in 40 batches)
WARNING:root:Invalid model URL, using default initialization.
Train set loaded in 0.002008s (126000 samples in 1968 batches)
Validation loss decreased inf --> 3.90789: saving state...                                                                                                      
Epoch 1/10 - Validation loss: 3.90789 (Exact: 1.35% | Partial: 2.26%)
Validation loss decreased 3.90789 --> 3.54396: saving state...                                                                                                  
Epoch 2/10 - Validation loss: 3.54396 (Exact: 3.93% | Partial: 5.00%)
```

TF:

```
(doctr-dev-tf) felix@felix-GS66-Stealth-11UH:~/Desktop/doctr$ python3 /home/felix/Desktop/doctr/references/recognition/train_tensorflow.py vitstr
Namespace(amp=False, arch='vitstr', batch_size=64, epochs=10, find_lr=False, font='FreeMono.ttf,FreeSans.ttf,FreeSerif.ttf', input_size=32, lr=0.001, max_chars=12, min_chars=1, name=None, pretrained=False, push_to_hub=False, resume=None, show_samples=False, test_only=False, train_path=None, train_samples=1000, val_path=None, val_samples=20, vocab='french', wb=False, workers=None)
Validation set loaded in 0.002643s (2520 samples in 40 batches)
WARNING:root:Invalid model URL, using default initialization.
Train set loaded in 0.004127s (126000 samples in 1968 batches)
Validation loss decreased inf --> 3.9933: saving state...                                                                                                       
Epoch 1/10 - Validation loss: 3.9933 (Exact: 3.45% | Partial: 3.73%)
Validation loss decreased 3.9933 --> 3.74347: saving state...                                                                                                   
Epoch 2/10 - Validation loss: 3.74347 (Exact: 7.50% | Partial: 7.78%)
```

Additional:
pred works also: (only tested with a model which reaches ~15% exact after 9 epochs trained with WordGenerator samples)
```
Word(value='฿฿_', confidence=0.048),
Word(value='4฿^฿', confidence=0.038),
Word(value='|', confidence=0.05),
Word(value='ërwW', confidence=0.031),
Word(value='x¢฿MMo', confidence=0.018),
```