### PR TITLE
[models] ViT add checkpoints and some rework to use pretrained ViT backbone in ViTSTR

### DIFF
--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -130,7 +130,7 @@ def _vit(
 def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     """VisionTransformer-S architecture
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
-    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+    <https://arxiv.org/pdf/2010.11929.pdf>`_. Patches: (H, W) -> (H/8, W/8)
 
     NOTE: unofficial config used in ViTSTR and ParSeq
 
@@ -162,7 +162,7 @@ def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
 def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     """VisionTransformer-B architecture as described in
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
-    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+    <https://arxiv.org/pdf/2010.11929.pdf>`_. Patches: (H, W) -> (H/8, W/8)
 
     >>> import torch
     >>> from doctr.models import vit_b

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -24,14 +24,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-103002d1.pt",
+        "url": "https://doctr-static.mindee.com/models?id=v0.5.1/vit_b-103002d1.pt&src=0",
     },
     "vit_s": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-cd3472bd.pt",
+        "url": "https://doctr-static.mindee.com/models?id=v0.5.1/vit_s-cd3472bd.pt&src=0",
     },
 }
 

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -124,7 +124,7 @@ def _vit(
         _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) else []
         # The model is used as a feature extractor => remove the patch embedding and position weights
         _ignore_keys = (
-            _ignore_keys + ["0.positions", "0.proj.weight"]
+            _ignore_keys + ["0.positions", "0.proj.weight"]  # type: ignore
             if kwargs["input_shape"] != default_cfgs[arch]["input_shape"]
             else _ignore_keys
         )

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -69,7 +69,6 @@ class VisionTransformer(nn.Sequential):
         num_heads: number of attention heads
         ffd_ratio: multiplier for the hidden dimension of the feedforward layer
         input_shape: size of the input image
-        patch_size: size of the patches to be extracted from the input
         dropout: dropout rate
         num_classes: number of output classes
         include_top: whether the classifier head should be instantiated
@@ -82,7 +81,6 @@ class VisionTransformer(nn.Sequential):
         num_heads: int,
         ffd_ratio: int,
         input_shape: Tuple[int, int, int] = (3, 32, 32),
-        patch_size: Tuple[int, int] = (4, 4),
         dropout: float = 0.0,
         num_classes: int = 1000,
         include_top: bool = True,
@@ -90,7 +88,7 @@ class VisionTransformer(nn.Sequential):
     ) -> None:
 
         _layers: List[nn.Module] = [
-            PatchEmbedding(input_shape, patch_size, d_model),
+            PatchEmbedding(input_shape, d_model),
             EncoderBlock(num_layers, num_heads, d_model, d_model * ffd_ratio, dropout, nn.GELU()),
         ]
         if include_top:
@@ -103,7 +101,7 @@ class VisionTransformer(nn.Sequential):
 def _vit(
     arch: str,
     pretrained: bool,
-    ignore_keys: Optional[List[str]] = None,
+    ignore_keys: Optional[List[str]] = [],
     **kwargs: Any,
 ) -> VisionTransformer:
 

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -24,14 +24,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": None,
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-13bbe405.pt",
     },
     "vit_s": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": None,
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-ff3c4666.pt",
     },
 }
 
@@ -129,36 +129,6 @@ def _vit(
     return model
 
 
-def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
-    """VisionTransformer-B architecture as described in
-    `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
-    <https://arxiv.org/pdf/2010.11929.pdf>`_.
-
-    >>> import torch
-    >>> from doctr.models import vit_b
-    >>> model = vit_b(pretrained=False)
-    >>> input_tensor = torch.rand((1, 3, 32, 32), dtype=tf.float32)
-    >>> out = model(input_tensor)
-
-    Args:
-        pretrained: boolean, True if model is pretrained
-
-    Returns:
-        A feature extractor model
-    """
-
-    return _vit(
-        "vit_b",
-        pretrained,
-        d_model=768,
-        num_layers=12,
-        num_heads=12,
-        ffd_ratio=4,
-        ignore_keys=["head.weight", "head.bias"],
-        **kwargs,
-    )
-
-
 def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     """VisionTransformer-S architecture
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
@@ -185,6 +155,36 @@ def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
         d_model=384,
         num_layers=12,
         num_heads=6,
+        ffd_ratio=4,
+        ignore_keys=["head.weight", "head.bias"],
+        **kwargs,
+    )
+
+
+def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
+    """VisionTransformer-B architecture as described in
+    `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+
+    >>> import torch
+    >>> from doctr.models import vit_b
+    >>> model = vit_b(pretrained=False)
+    >>> input_tensor = torch.rand((1, 3, 32, 32), dtype=tf.float32)
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained: boolean, True if model is pretrained
+
+    Returns:
+        A feature extractor model
+    """
+
+    return _vit(
+        "vit_b",
+        pretrained,
+        d_model=768,
+        num_layers=12,
+        num_heads=12,
         ffd_ratio=4,
         ignore_keys=["head.weight", "head.bias"],
         **kwargs,

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -24,14 +24,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-13bbe405.pt",
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-103002d1.pt",
     },
     "vit_s": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-ff3c4666.pt",
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-cd3472bd.pt",
     },
 }
 
@@ -101,7 +101,7 @@ class VisionTransformer(nn.Sequential):
 def _vit(
     arch: str,
     pretrained: bool,
-    ignore_keys: Optional[List[str]] = [],
+    ignore_keys: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> VisionTransformer:
 
@@ -121,13 +121,7 @@ def _vit(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) else []
-        # The model is used as a feature extractor => remove the patch embedding and position weights
-        _ignore_keys = (
-            _ignore_keys + ["0.positions", "0.proj.weight"]  # type: ignore
-            if kwargs["input_shape"] != default_cfgs[arch]["input_shape"]
-            else _ignore_keys
-        )
+        _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) else None
         load_pretrained_params(model, default_cfgs[arch]["url"], ignore_keys=_ignore_keys)
 
     return model

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -123,7 +123,8 @@ def _vit(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) else None
+        _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) \
+            else ["0.positions", "0.proj.weight"]
         load_pretrained_params(model, default_cfgs[arch]["url"], ignore_keys=_ignore_keys)
 
     return model

--- a/doctr/models/classification/vit/pytorch.py
+++ b/doctr/models/classification/vit/pytorch.py
@@ -123,8 +123,13 @@ def _vit(
     if pretrained:
         # The number of classes is not the same as the number of classes in the pretrained model =>
         # remove the last layer weights
-        _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) \
-            else ["0.positions", "0.proj.weight"]
+        _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) else []
+        # The model is used as a feature extractor => remove the patch embedding and position weights
+        _ignore_keys = (
+            _ignore_keys + ["0.positions", "0.proj.weight"]
+            if kwargs["input_shape"] != default_cfgs[arch]["input_shape"]
+            else _ignore_keys
+        )
         load_pretrained_params(model, default_cfgs[arch]["url"], ignore_keys=_ignore_keys)
 
     return model
@@ -157,7 +162,7 @@ def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
         num_layers=12,
         num_heads=6,
         ffd_ratio=4,
-        ignore_keys=["head.weight", "head.bias"],
+        ignore_keys=["2.head.weight", "2.head.bias"],
         **kwargs,
     )
 
@@ -187,6 +192,6 @@ def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
         num_layers=12,
         num_heads=12,
         ffd_ratio=4,
-        ignore_keys=["head.weight", "head.bias"],
+        ignore_keys=["2.head.weight", "2.head.bias"],
         **kwargs,
     )

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -26,14 +26,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-ff5179fb.zip",
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-f87ad69c.zip",
     },
     "vit_b": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (32, 32, 3),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-2bacd237.zip",
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-71da99f5.zip",
     },
 }
 

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -26,14 +26,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-7a23bea4.zip",
+        "url": "https://doctr-static.mindee.com/models?id=v0.5.1/vit_s-7a23bea4.zip&src=0",
     },
     "vit_b": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (32, 32, 3),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-983c86b5.zip",
+        "url": "https://doctr-static.mindee.com/models?id=v0.5.1/vit_b-983c86b5.zip&src=0",
     },
 }
 

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -48,7 +48,7 @@ class ClassifierHead(layers.Layer, NestedObject):
     def __init__(self, num_classes: int) -> None:
         super().__init__()
 
-        self.head = layers.Dense(num_classes, kernel_initializer="he_normal")
+        self.head = layers.Dense(num_classes, kernel_initializer="he_normal", name="dense")
 
     def call(self, x: tf.Tensor) -> tf.Tensor:
         # (batch_size, num_classes) cls token

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -123,7 +123,7 @@ def _vit(
 def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     """VisionTransformer-S architecture
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
-    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+    <https://arxiv.org/pdf/2010.11929.pdf>`_. Patches: (H, W) -> (H/8, W/8)
 
     NOTE: unofficial config used in ViTSTR and ParSeq
 
@@ -154,7 +154,7 @@ def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
 def vit_b(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
     """VisionTransformer-B architecture as described in
     `"An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
-    <https://arxiv.org/pdf/2010.11929.pdf>`_.
+    <https://arxiv.org/pdf/2010.11929.pdf>`_. Patches: (H, W) -> (H/8, W/8)
 
     >>> import tensorflow as tf
     >>> from doctr.models import vit_b

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -26,14 +26,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-f87ad69c.zip",
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-7a23bea4.zip",
     },
     "vit_b": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (32, 32, 3),
         "classes": list(VOCABS["french"]),
-        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-71da99f5.zip",
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-983c86b5.zip",
     },
 }
 

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -26,14 +26,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 32),
         "classes": list(VOCABS["french"]),
-        "url": None,
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_s-ff5179fb.zip",
     },
     "vit_b": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (32, 32, 3),
         "classes": list(VOCABS["french"]),
-        "url": None,
+        "url": "https://github.com/mindee/doctr/releases/download/v0.5.1/vit_b-2bacd237.zip",
     },
 }
 
@@ -129,7 +129,7 @@ def vit_s(pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
 
     NOTE: unofficial config used in ViTSTR and ParSeq
 
-    >>> import tf
+    >>> import tensorflow as tf
     >>> from doctr.models import vit_s
     >>> model = vit_s(pretrained=False)
     >>> input_tensor = tf.random.uniform(shape=[1, 32, 32, 3], maxval=1, dtype=tf.float32)

--- a/doctr/models/classification/vit/tensorflow.py
+++ b/doctr/models/classification/vit/tensorflow.py
@@ -66,7 +66,6 @@ class VisionTransformer(Sequential):
         num_heads: number of attention heads
         ffd_ratio: multiplier for the hidden dimension of the feedforward layer
         input_shape: size of the input image
-        patch_size: size of the patches to be extracted from the input
         dropout: dropout rate
         num_classes: number of output classes
         include_top: whether the classifier head should be instantiated
@@ -79,7 +78,6 @@ class VisionTransformer(Sequential):
         num_heads: int,
         ffd_ratio: int,
         input_shape: Tuple[int, int, int] = (32, 32, 3),
-        patch_size: Tuple[int, int] = (4, 4),
         dropout: float = 0.0,
         num_classes: int = 1000,
         include_top: bool = True,
@@ -87,7 +85,7 @@ class VisionTransformer(Sequential):
     ) -> None:
 
         _layers = [
-            PatchEmbedding(input_shape, patch_size, d_model),
+            PatchEmbedding(input_shape, d_model),
             EncoderBlock(num_layers, num_heads, d_model, d_model * ffd_ratio, dropout, activation_fct=GELU()),
         ]
         if include_top:

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -50,8 +50,8 @@ class PatchEmbedding(nn.Module):
         class_pos_embed = self.positions[:, 0]
         patch_pos_embed = self.positions[:, 1:]
         dim = embeddings.shape[-1]
-        h0 = height // self.patch_size[0]
-        w0 = width // self.patch_size[1]
+        h0 = float(height // self.patch_size[0])
+        w0 = float(width // self.patch_size[1])
         # we add a small number to avoid floating point error in the interpolation
         # see discussion at https://github.com/facebookresearch/dino/issues/8
         h0, w0 = h0 + 0.1, w0 + 0.1

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -16,19 +16,15 @@ __all__ = ["PatchEmbedding"]
 class PatchEmbedding(nn.Module):
     """Compute 2D patch embeddings with cls token and positional encoding"""
 
-    def __init__(
-        self,
-        input_shape: Tuple[int, int, int],
-        patch_size: Tuple[int, int],
-        embed_dim: int,
-    ) -> None:
+    def __init__(self, input_shape: Tuple[int, int, int], embed_dim: int) -> None:
 
         super().__init__()
         channels, height, width = input_shape
-        # fix patch size if recognition task with 32x128 input
-        self.patch_size = (4, 8) if height != width else patch_size
-        self.grid_size = (height // patch_size[0], width // patch_size[1])
-        self.num_patches = (height // patch_size[0]) * (width // patch_size[1])
+        # calculate patch size 32x32 -> (4, 4) 32x128 -> (4, 16)
+        # NOTE: this is different from the original implementation
+        self.patch_size = (height // 8, width // 8)
+        self.grid_size = (height // self.patch_size[0], width // self.patch_size[1])
+        self.num_patches = (height // self.patch_size[0]) * (width // self.patch_size[1])
 
         self.cls_token = nn.Parameter(torch.randn(1, 1, embed_dim))  # type: ignore[attr-defined]
         self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -50,8 +50,8 @@ class PatchEmbedding(nn.Module):
         class_pos_embed = self.positions[:, 0]
         patch_pos_embed = self.positions[:, 1:]
         dim = embeddings.shape[-1]
-        h0 = float(height // self.patch_size[0])
-        w0 = float(width // self.patch_size[1])
+        h0 = height // self.patch_size[0]
+        w0 = width // self.patch_size[1]
         # we add a small number to avoid floating point error in the interpolation
         # see discussion at https://github.com/facebookresearch/dino/issues/8
         h0, w0 = h0 + 0.1, w0 + 0.1
@@ -59,9 +59,10 @@ class PatchEmbedding(nn.Module):
         patch_pos_embed = patch_pos_embed.permute(0, 3, 1, 2)
         patch_pos_embed = nn.functional.interpolate(
             patch_pos_embed,
+            scale_factor=(h0 / math.sqrt(num_positions), w0 / math.sqrt(num_positions)),
             mode="bicubic",
             align_corners=False,
-            scale_factor=(h0 / math.sqrt(num_positions), w0 / math.sqrt(num_positions)),
+            recompute_scale_factor=True,
         )
         assert int(h0) == patch_pos_embed.shape[-2], "height of interpolated patch embedding doesn't match"
         assert int(w0) == patch_pos_embed.shape[-1], "width of interpolated patch embedding doesn't match"

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -20,11 +20,12 @@ class PatchEmbedding(nn.Module):
 
         super().__init__()
         channels, height, width = input_shape
-        # calculate patch size 32x32 -> (4, 4) 32x128 -> (4, 16)
+        # calculate patch size
         # NOTE: this is different from the original implementation
-        self.patch_size = (height // 8, width // 8)
-        self.grid_size = (height // self.patch_size[0], width // self.patch_size[1])
-        self.num_patches = (height // self.patch_size[0]) * (width // self.patch_size[1])
+        self.patch_size = (height // (height // 8), width // (width // 8))
+
+        self.grid_size = (self.patch_size[0], self.patch_size[1])
+        self.num_patches = self.patch_size[0] * self.patch_size[1]
 
         self.cls_token = nn.Parameter(torch.randn(1, 1, embed_dim))  # type: ignore[attr-defined]
         self.positions = nn.Parameter(torch.randn(1, self.num_patches + 1, embed_dim))  # type: ignore[attr-defined]

--- a/doctr/models/modules/vision_transformer/pytorch.py
+++ b/doctr/models/modules/vision_transformer/pytorch.py
@@ -60,7 +60,7 @@ class PatchEmbedding(nn.Module):
         patch_pos_embed = nn.functional.interpolate(
             patch_pos_embed,
             scale_factor=(h0 / math.sqrt(num_positions), w0 / math.sqrt(num_positions)),
-            mode="bicubic",
+            mode="bilinear",
             align_corners=False,
             recompute_scale_factor=True,
         )

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -34,7 +34,7 @@ class PatchEmbedding(layers.Layer, NestedObject):
             trainable=True,
             name="positions",
         )
-        self.proj = layers.Dense(embed_dim, kernel_initializer="he_normal")
+        self.proj = layers.Dense(embed_dim, kernel_initializer="he_normal", name="projection")
 
     def interpolate_pos_encoding(self, embeddings: tf.Tensor, height: int, width: int) -> tf.Tensor:
         """

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -65,7 +65,7 @@ class PatchEmbedding(layers.Layer, NestedObject):
                 patch_pos_embed, shape=(1, int(math.sqrt(num_positions)), int(math.sqrt(num_positions)), dim)
             ),
             size=(h0, w0),
-            method="bicubic",
+            method="bilinear",
         )
 
         shape = patch_pos_embed.shape

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -17,19 +17,15 @@ __all__ = ["PatchEmbedding"]
 class PatchEmbedding(layers.Layer, NestedObject):
     """Compute 2D patch embeddings with cls token and positional encoding"""
 
-    def __init__(
-        self,
-        input_shape: Tuple[int, int, int],
-        patch_size: Tuple[int, int],
-        embed_dim: int,
-    ) -> None:
+    def __init__(self, input_shape: Tuple[int, int, int], embed_dim: int) -> None:
 
         super().__init__()
         height, width, _ = input_shape
-        # fix patch size if recognition task with 32x128 input
-        self.patch_size = (4, 8) if height != width else patch_size
-        self.grid_size = (height // patch_size[0], width // patch_size[1])
-        self.num_patches = (height // patch_size[0]) * (width // patch_size[1])
+        # calculate patch size 32x32 -> (4, 4) 32x128 -> (4, 16)
+        # NOTE: this is different from the original implementation
+        self.patch_size = (height // 8, width // 8)
+        self.grid_size = (height // self.patch_size[0], width // self.patch_size[1])
+        self.num_patches = (height // self.patch_size[0]) * (width // self.patch_size[1])
 
         self.cls_token = self.add_weight(shape=(1, 1, embed_dim), initializer="zeros", trainable=True, name="cls_token")
         self.positions = self.add_weight(

--- a/doctr/models/modules/vision_transformer/tensorflow.py
+++ b/doctr/models/modules/vision_transformer/tensorflow.py
@@ -21,11 +21,12 @@ class PatchEmbedding(layers.Layer, NestedObject):
 
         super().__init__()
         height, width, _ = input_shape
-        # calculate patch size 32x32 -> (4, 4) 32x128 -> (4, 16)
+        # calculate patch size
         # NOTE: this is different from the original implementation
-        self.patch_size = (height // 8, width // 8)
-        self.grid_size = (height // self.patch_size[0], width // self.patch_size[1])
-        self.num_patches = (height // self.patch_size[0]) * (width // self.patch_size[1])
+        self.patch_size = (height // (height // 8), width // (width // 8))
+
+        self.grid_size = (self.patch_size[0], self.patch_size[1])
+        self.num_patches = self.patch_size[0] * self.patch_size[1]
 
         self.cls_token = self.add_weight(shape=(1, 1, embed_dim), initializer="zeros", trainable=True, name="cls_token")
         self.positions = self.add_weight(

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -48,7 +48,6 @@ class ViTSTR(_ViTSTR, nn.Module):
         max_length: maximum word length handled by the model
         dropout_prob: dropout probability of the encoder LSTM
         input_shape: input shape of the image
-        patch_size: size of the patches
         exportable: onnx exportable returns only logits
         cfg: dictionary containing information about the model
     """
@@ -60,7 +59,6 @@ class ViTSTR(_ViTSTR, nn.Module):
         embedding_units: int,
         max_length: int = 25,
         input_shape: Tuple[int, int, int] = (3, 32, 128),  # different from paper
-        patch_size: Tuple[int, int] = (4, 8),  # different from paper to match our size
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -46,7 +46,6 @@ class ViTSTR(_ViTSTR, Model):
         max_length: maximum word length handled by the model
         dropout_prob: dropout probability for the encoder and decoder
         input_shape: input shape of the image
-        patch_size: size of the patches
         exportable: onnx exportable returns only logits
         cfg: dictionary containing information about the model
     """
@@ -61,7 +60,6 @@ class ViTSTR(_ViTSTR, Model):
         max_length: int = 25,
         dropout_prob: float = 0.0,
         input_shape: Tuple[int, int, int] = (32, 128, 3),  # different from paper
-        patch_size: Tuple[int, int] = (4, 8),  # different from paper to match our size
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -202,10 +200,9 @@ def _vitstr(
 
     kwargs["vocab"] = _cfg["vocab"]
 
-    # Feature extractor
-    # NOTE: switch to IntermediateLayerGetter if pretrained vit models are available
+    # feature extractor
     feat_extractor = backbone_fn(
-        pretrained=pretrained_backbone,
+        pretrained=False,  # TODO: pretrained_backbone, solve weights shape mismatch
         input_shape=_cfg["input_shape"],
         include_top=False,
     )

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -200,7 +200,7 @@ def _vitstr(
 
     kwargs["vocab"] = _cfg["vocab"]
 
-    # feature extractor
+    # Feature extractor
     feat_extractor = backbone_fn(
         pretrained=pretrained_backbone,
         input_shape=_cfg["input_shape"],

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -202,7 +202,7 @@ def _vitstr(
 
     # feature extractor
     feat_extractor = backbone_fn(
-        pretrained=False,  # TODO: pretrained_backbone, solve weights shape mismatch
+        pretrained=pretrained_backbone,
         input_shape=_cfg["input_shape"],
         include_top=False,
     )

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -72,7 +72,7 @@ class ViTSTR(_ViTSTR, Model):
         self.max_length = max_length + 3  # Add 1 step for EOS, 1 for SOS, 1 for PAD
 
         self.feat_extractor = feature_extractor
-        self.head = layers.Dense(len(self.vocab) + 3)
+        self.head = layers.Dense(len(self.vocab) + 3, name="head")
 
         self.postprocessor = ViTSTRPostProcessor(vocab=self.vocab)
 

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -116,7 +116,7 @@ def export_model_to_onnx(model: nn.Module, model_name: str, dummy_input: torch.T
         output_names=["logits"],
         dynamic_axes={"input": {0: "batch_size"}, "logits": {0: "batch_size"}},
         export_params=True,
-        opset_version=15,  # minimum opset which support all operators we use (v0.5.2)
+        opset_version=14,  # minimum opset which support all operators we use (v0.5.2)
         verbose=False,
         **kwargs,
     )

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -116,7 +116,7 @@ def export_model_to_onnx(model: nn.Module, model_name: str, dummy_input: torch.T
         output_names=["logits"],
         dynamic_axes={"input": {0: "batch_size"}, "logits": {0: "batch_size"}},
         export_params=True,
-        opset_version=14,  # minimum opset which support all operators we use (v0.5.2)
+        opset_version=15,  # minimum opset which support all operators we use (v0.5.2)
         verbose=False,
         **kwargs,
     )


### PR DESCRIPTION
This PR: 

- make pretrained checkpoints available for ViT (TF and PT)
- rework patchify make it dynamic to the input shape
- rework pretrained backbone usage for ViTSTR with checkpoints
- fix issue with bicubic scale and onnxruntime (use bilinear : minor cost on quality and speed up)

All added checkpoints >98% acc

Any feedback is welcome