### PR TITLE
ViTSTR disable pretrained backbone by default

### DIFF
--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -182,7 +182,7 @@ def _vitstr(
     pretrained: bool,
     backbone_fn: Callable[[bool], nn.Module],
     layer: str,
-    pretrained_backbone: bool = True,
+    pretrained_backbone: bool = False,  # NOTE: training from scratch without a pretrained backbone works better
     ignore_keys: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> ViTSTR:

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -186,7 +186,7 @@ def _vitstr(
     arch: str,
     pretrained: bool,
     backbone_fn,
-    pretrained_backbone: bool = True,
+    pretrained_backbone: bool = False,  # NOTE: training from scratch without a pretrained backbone works better
     input_shape: Optional[Tuple[int, int, int]] = None,
     **kwargs: Any,
 ) -> ViTSTR:


### PR DESCRIPTION
This PR:

- disable using pretrained backbone in VITSTR by default
- after some tests it runs much better without using the pretrained backbone