### PR TITLE
Feat: Make detection training and inference Multiclass

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,14 +28,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Install poetry
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: 1.1.13
-      - name: Lock the requirements
-        run: |
-          cd api
-          make lock
       - name: Build & run docker
         run: cd api && docker-compose up -d --build
       - name: Ping server

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -140,7 +140,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[torch] --upgrade
       - name: Run evaluation script
-        run: python scripts/evaluate.py db_resnet50 crnn_vgg16_bn --samples 10
+        run: |
+          python scripts/evaluate.py db_resnet50 crnn_vgg16_bn --samples 10
+          python scripts/evaluate_kie.py db_resnet50 crnn_vgg16_bn --samples 10
 
   test-collectenv:
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -99,6 +99,30 @@ You can also export them as a nested dict, more appropriate for JSON format:
 json_output = result.export()
 ```
 
+### Use the KIE predictor
+The KIE predictor is a more flexible predictor compared to OCR as your detection model can detect multiple classes in a document. For example, you can have a detection model to detect just dates and adresses in a document.
+
+The KIE predictor makes it possible to use detector with multiple classes with a recognition model and to have the whole pipeline already setup for you.
+
+```python
+from doctr.io import DocumentFile
+from doctr.models import kie_predictor
+
+# Model
+model = kie_predictor(det_arch='db_resnet50', reco_arch='crnn_vgg16_bn', pretrained=True)
+# PDF
+doc = DocumentFile.from_pdf("path/to/your/doc.pdf")
+# Analyze
+result = model(doc)
+
+predictions = result.pages[0].predictions
+for class_name in predictions.keys():
+    list_blocks = predictions[class_name]
+    print(f"Prediction for {class_name}: {list_blocks}")
+```
+The KIE predictor results per page are in a dictionary format with each key representing a class name and it's value are the predictions for that class.
+
+
 ### If you are looking for support from the Mindee team
 [![Bad OCR test detection image asking the developer if they need help](https://github.com/mindee/doctr/releases/download/v0.5.1/doctr-need-help.png)](https://mindee.com/product/doctr)
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,10 @@ Looking to integrate docTR into your API? Here is a template to get you started 
 #### Deploy your API locally
 Specific dependencies are required to run the API template, which you can install as follows:
 ```shell
-pip install -r api/requirements.txt
+cd api/
+pip install poetry
+make lock
+pip install -r requirements.txt
 ```
 You can now run your API locally:
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ PORT=8002 docker-compose up -d --build
 
 #### What you have deployed
 
-Your API should now be running locally on your port 8002. Access your automatically-built documentation at [http://localhost:8002/redoc](http://localhost:8002/redoc) and enjoy your three functional routes ("/detection", "/recognition", "/ocr"). Here is an example with Python to send a request to the OCR route:
+Your API should now be running locally on your port 8002. Access your automatically-built documentation at [http://localhost:8002/redoc](http://localhost:8002/redoc) and enjoy your three functional routes ("/detection", "/recognition", "/ocr", "/kie"). Here is an example with Python to send a request to the OCR route:
 
 ```python
 import requests

--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ result = model(doc)
 
 predictions = result.pages[0].predictions
 for class_name in predictions.keys():
-    list_blocks = predictions[class_name]
-    print(f"Prediction for {class_name}: {list_blocks}")
+    list_predictions = predictions[class_name]
+    for prediction in list_predictions:
+        print(f"Prediction for {class_name}: {prediction}")
 ```
 The KIE predictor results per page are in a dictionary format with each key representing a class name and it's value are the predictions for that class.
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,6 +8,10 @@ ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH "${PYTHONPATH}:/app"
 
 # copy requirements file
+COPY pyproject.toml  /app/pyproject.toml
+RUN pip install --upgrade pip \
+    && pip install poetry \
+    && poetry export -f requirements.txt --without-hashes --output requirements.txt
 COPY requirements.txt  /app/requirements.txt
 COPY Makefile /app/Makefile
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH "${PYTHONPATH}:/app"
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends ffmpeg libsm6 libxext6 git make -y \
+    && apt-get install --no-install-recommends ffmpeg libsm6 libxext6 make -y \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,21 +7,18 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH "${PYTHONPATH}:/app"
 
-# copy requirements file
+RUN apt-get update \
+    && apt-get install --no-install-recommends ffmpeg libsm6 libxext6 git make -y \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY pyproject.toml  /app/pyproject.toml
-RUN pip install --upgrade pip \
-    && pip install poetry \
-    && poetry export -f requirements.txt --without-hashes --output requirements.txt
-COPY requirements.txt  /app/requirements.txt
 COPY Makefile /app/Makefile
 
-RUN apt-get update \
-    && apt-get install --no-install-recommends ffmpeg libsm6 libxext6 -y \
-    && pip install --upgrade pip setuptools wheel \
+RUN pip install --upgrade pip setuptools wheel poetry \
+    && make lock \
     && pip install -r /app/requirements.txt \
     && pip cache purge \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
     && rm -rf /root/.cache/pip
 
 # copy project

--- a/api/Makefile
+++ b/api/Makefile
@@ -5,7 +5,7 @@
 lock:
 	poetry lock
 	poetry export -f requirements.txt --without-hashes --output requirements.txt
-	poetry export -f requirements.txt --without-hashes --dev --output requirements-dev.txt
+	poetry export -f requirements.txt --without-hashes --with dev --output requirements-dev.txt
 
 # Run the docker
 run:

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 
 from app import config as cfg
-from app.routes import detection, ocr, recognition
+from app.routes import detection, kie, ocr, recognition
 
 app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, debug=cfg.DEBUG, version=cfg.VERSION)
 
@@ -18,6 +18,7 @@ app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, debug
 app.include_router(recognition.router, prefix="/recognition", tags=["recognition"])
 app.include_router(detection.router, prefix="/detection", tags=["detection"])
 app.include_router(ocr.router, prefix="/ocr", tags=["ocr"])
+app.include_router(kie.router, prefix="/kie", tags=["kie"])
 
 
 # Middleware

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, File, UploadFile, status
 
 from app.schemas import DetectionOut
 from app.vision import det_predictor
+from doctr.file_utils import CLASS_NAME
 from doctr.io import decode_img_as_tensor
 
 router = APIRouter()
@@ -19,4 +20,4 @@ async def text_detection(file: UploadFile = File(...)):
     """Runs docTR text detection model to analyze the input image"""
     img = decode_img_as_tensor(file.file.read())
     boxes = det_predictor([img])[0]
-    return [DetectionOut(box=box.tolist()) for box in boxes[:, :-1]]
+    return [DetectionOut(box=box.tolist()) for box in boxes[CLASS_NAME][:, :-1]]

--- a/api/app/routes/kie.py
+++ b/api/app/routes/kie.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2021-2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from typing import Dict, List
+
+from fastapi import APIRouter, File, UploadFile, status
+
+from app.schemas import OCROut
+from app.vision import kie_predictor
+from doctr.io import decode_img_as_tensor
+
+router = APIRouter()
+
+
+@router.post("/", response_model=Dict[str, List[OCROut]], status_code=status.HTTP_200_OK, summary="Perform KIE")
+async def perform_kie(file: UploadFile = File(...)):
+    """Runs docTR KIE model to analyze the input image"""
+    img = decode_img_as_tensor(file.file.read())
+    out = kie_predictor([img])
+
+    return {
+        class_name: [
+            OCROut(box=(*word.geometry[0], *word.geometry[1]), value=word.value)
+            for block in out.pages[0].predictions[class_name]
+            for line in block.lines
+            for word in line.words
+        ]
+        for class_name in out.pages[0].predictions.keys()
+    }

--- a/api/app/routes/kie.py
+++ b/api/app/routes/kie.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022, Mindee.
+# Copyright (C) 2022, Mindee.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.

--- a/api/app/routes/kie.py
+++ b/api/app/routes/kie.py
@@ -22,10 +22,8 @@ async def perform_kie(file: UploadFile = File(...)):
 
     return {
         class_name: [
-            OCROut(box=(*word.geometry[0], *word.geometry[1]), value=word.value)
-            for block in out.pages[0].predictions[class_name]
-            for line in block.lines
-            for word in line.words
+            OCROut(box=(*prediction.geometry[0], *prediction.geometry[1]), value=prediction.value)
+            for prediction in out.pages[0].predictions[class_name]
         ]
         for class_name in out.pages[0].predictions.keys()
     }

--- a/api/app/routes/ocr.py
+++ b/api/app/routes/ocr.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, File, UploadFile, status
 
 from app.schemas import OCROut
 from app.vision import predictor
-from doctr.file_utils import CLASS_NAME
 from doctr.io import decode_img_as_tensor
 
 router = APIRouter()
@@ -23,7 +22,7 @@ async def perform_ocr(file: UploadFile = File(...)):
 
     return [
         OCROut(box=(*word.geometry[0], *word.geometry[1]), value=word.value)
-        for block in out.pages[0].blocks[CLASS_NAME]
+        for block in out.pages[0].blocks
         for line in block.lines
         for word in line.words
     ]

--- a/api/app/routes/ocr.py
+++ b/api/app/routes/ocr.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, File, UploadFile, status
 
 from app.schemas import OCROut
 from app.vision import predictor
+from doctr.file_utils import CLASS_NAME
 from doctr.io import decode_img_as_tensor
 
 router = APIRouter()
@@ -22,5 +23,7 @@ async def perform_ocr(file: UploadFile = File(...)):
 
     return [
         OCROut(box=(*word.geometry[0], *word.geometry[1]), value=word.value)
-        for word in out.pages[0].blocks[0].lines[0].words
+        for block in out.pages[0].blocks[CLASS_NAME]
+        for line in block.lines
+        for word in line.words
     ]

--- a/api/app/vision.py
+++ b/api/app/vision.py
@@ -9,8 +9,9 @@ gpu_devices = tf.config.experimental.list_physical_devices("GPU")
 if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
-from doctr.models import ocr_predictor
+from doctr.models import kie_predictor, ocr_predictor
 
 predictor = ocr_predictor(pretrained=True)
 det_predictor = predictor.det_predictor
 reco_predictor = predictor.reco_predictor
+kie_predictor = kie_predictor(pretrained=True)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -10,7 +10,7 @@ authors = ["Mindee <contact@mindee.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8.2,<3.11"
+python = ">=3.8.2,<3.11"  # pypdfium2 needs a python version above 3.8.2
 tensorflow = ">=2.9.0,<3.0.0"
 tensorflow-addons = ">=0.17.1"
 python-doctr = { version = ">=1.0.0", extras = ['tf'] }

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -10,10 +10,10 @@ authors = ["Mindee <contact@mindee.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8.2,<3.11"
 tensorflow = ">=2.9.0,<3.0.0"
 tensorflow-addons = ">=0.17.1"
-python-doctr = ">=0.2.0"
+python-doctr = { version = ">=0.6.0", extras = ['tf'] }
 # Fastapi: minimum version required to avoid pydantic error
 # cf. https://github.com/tiangolo/fastapi/issues/4168
 fastapi = ">=0.73.0"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "doctr-api"
-version = "0.5.2a0"
+version = "1.0.1a0"
 description = "Backend template for your OCR API with docTR"
 authors = ["Mindee <contact@mindee.com>"]
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 python = ">=3.8.2,<3.11"
 tensorflow = ">=2.9.0,<3.0.0"
 tensorflow-addons = ">=0.17.1"
-python-doctr = { version = ">=0.6.0", extras = ['tf'] }
+python-doctr = { version = ">=1.0.0", extras = ['tf'] }
 # Fastapi: minimum version required to avoid pydantic error
 # cf. https://github.com/tiangolo/fastapi/issues/4168
 fastapi = ">=0.73.0"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 python = ">=3.8.2,<3.11"  # pypdfium2 needs a python version above 3.8.2
 tensorflow = ">=2.9.0,<3.0.0"
 tensorflow-addons = ">=0.17.1"
-python-doctr = { version = ">=1.0.0", extras = ['tf'] }
+python-doctr = { version = ">=0.7.0", extras = ['tf'] }
 # Fastapi: minimum version required to avoid pydantic error
 # cf. https://github.com/tiangolo/fastapi/issues/4168
 fastapi = ">=0.73.0"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "doctr-api"
-version = "1.0.1a0"
+version = "0.7.1a0"
 description = "Backend template for your OCR API with docTR"
 authors = ["Mindee <contact@mindee.com>"]
 license = "Apache-2.0"

--- a/api/tests/routes/test_kie.py
+++ b/api/tests/routes/test_kie.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+from scipy.optimize import linear_sum_assignment
+
+from doctr.utils.metrics import box_iou
+
+
+@pytest.mark.asyncio
+async def test_perform_kie(test_app_asyncio, mock_detection_image):
+
+    response = await test_app_asyncio.post("/kie", files={"file": mock_detection_image})
+    assert response.status_code == 200
+    json_response = response.json()
+
+    gt_boxes = np.array([[1240, 430, 1355, 470], [1360, 430, 1495, 470]], dtype=np.float32)
+    gt_boxes[:, [0, 2]] = gt_boxes[:, [0, 2]] / 1654
+    gt_boxes[:, [1, 3]] = gt_boxes[:, [1, 3]] / 2339
+    gt_labels = ["Hello", "world!"]
+
+    # Check that IoU with GT if reasonable
+    assert isinstance(json_response, dict) and len(list(json_response.values())[0]) == gt_boxes.shape[0]
+    pred_boxes = np.array([elt["box"] for json_out in json_response.values() for elt in json_out])
+    pred_labels = np.array([elt["value"] for json_out in json_response.values() for elt in json_out])
+    iou_mat = box_iou(gt_boxes, pred_boxes)
+    gt_idxs, pred_idxs = linear_sum_assignment(-iou_mat)
+    is_kept = iou_mat[gt_idxs, pred_idxs] >= 0.8
+    gt_idxs, pred_idxs = gt_idxs[is_kept], pred_idxs[is_kept]
+    assert gt_idxs.shape[0] == gt_boxes.shape[0]
+    assert all(gt_labels[gt_idx] == pred_labels[pred_idx] for gt_idx, pred_idx in zip(gt_idxs, pred_idxs))

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -81,6 +81,8 @@ doctr.models.zoo
 
 .. autofunction:: doctr.models.ocr_predictor
 
+.. autofunction:: doctr.models.kie_predictor
+
 
 doctr.models.factory
 --------------------

--- a/doctr/__init__.py
+++ b/doctr/__init__.py
@@ -1,3 +1,3 @@
-from . import datasets, io, models, transforms, utils
+from . import io, datasets, models, transforms, utils
 from .file_utils import is_tf_available, is_torch_available
 from .version import __version__  # noqa: F401

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -8,8 +8,6 @@ import shutil
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-import numpy as np
-
 from doctr.io.image import get_img_shape
 from doctr.utils.data import download_from_url
 
@@ -57,11 +55,11 @@ class _AbstractDataset:
             img = self.img_transforms(img)
 
         if self.sample_transforms is not None:
-            if isinstance(target, np.ndarray):
-                img, target = self.sample_transforms(img, target)
-            elif isinstance(target, dict):
+            if isinstance(target, dict):
                 for k, v in target.items():
                     img, target[k] = self.sample_transforms(img, v)
+            else:
+                img, target = self.sample_transforms(img, target)
 
         return img, target
 

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -8,6 +8,8 @@ import shutil
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
+import numpy as np
+
 from doctr.io.image import get_img_shape
 from doctr.utils.data import download_from_url
 
@@ -55,7 +57,11 @@ class _AbstractDataset:
             img = self.img_transforms(img)
 
         if self.sample_transforms is not None:
-            img, target = self.sample_transforms(img, target)
+            if isinstance(target, np.ndarray):
+                img, target = self.sample_transforms(img, target)
+            elif isinstance(target, dict):
+                for k, v in target.items():
+                    img, target[k] = self.sample_transforms(img, v)
 
         return img, target
 

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -8,6 +8,8 @@ import shutil
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
+import numpy as np
+
 from doctr.file_utils import copy_tensor
 from doctr.io.image import get_img_shape
 from doctr.utils.data import download_from_url
@@ -56,7 +58,7 @@ class _AbstractDataset:
             img = self.img_transforms(img)
 
         if self.sample_transforms is not None:
-            if isinstance(target, dict):
+            if isinstance(target, dict) and all([isinstance(item, np.ndarray) for item in target.values()]):
                 img_transformed = copy_tensor(img)
                 for class_name, bboxes in target.items():
                     img_transformed, target[class_name] = self.sample_transforms(img, bboxes)

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -56,8 +56,10 @@ class _AbstractDataset:
 
         if self.sample_transforms is not None:
             if isinstance(target, dict):
+                img_transformed = img.copy()
                 for class_name, bboxes in target.items():
-                    img, target[class_name] = self.sample_transforms(img, bboxes)
+                    img_transformed, target[class_name] = self.sample_transforms(img, bboxes)
+                img = img_transformed
             else:
                 img, target = self.sample_transforms(img, target)
 

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -56,8 +56,8 @@ class _AbstractDataset:
 
         if self.sample_transforms is not None:
             if isinstance(target, dict):
-                for k, v in target.items():
-                    img, target[k] = self.sample_transforms(img, v)
+                for class_name, bboxes in target.items():
+                    img, target[class_name] = self.sample_transforms(img, bboxes)
             else:
                 img, target = self.sample_transforms(img, target)
 

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -8,6 +8,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
+from doctr.file_utils import copy_tensor
 from doctr.io.image import get_img_shape
 from doctr.utils.data import download_from_url
 
@@ -56,7 +57,7 @@ class _AbstractDataset:
 
         if self.sample_transforms is not None:
             if isinstance(target, dict):
-                img_transformed = img.copy()
+                img_transformed = copy_tensor(img)
                 for class_name, bboxes in target.items():
                     img_transformed, target[class_name] = self.sample_transforms(img, bboxes)
                 img = img_transformed

--- a/doctr/datasets/datasets/pytorch.py
+++ b/doctr/datasets/datasets/pytorch.py
@@ -25,6 +25,10 @@ class AbstractDataset(_AbstractDataset):
         if isinstance(target, dict):
             assert "boxes" in target, "Target should contain 'boxes' key"
             assert "labels" in target, "Target should contain 'labels' key"
+        elif isinstance(target, tuple):
+            assert isinstance(target[0], str) or isinstance(
+                target[0], np.ndarray
+            ), "Target should be a string or a numpy array"
         else:
             assert isinstance(target, str) or isinstance(
                 target, np.ndarray

--- a/doctr/datasets/datasets/pytorch.py
+++ b/doctr/datasets/datasets/pytorch.py
@@ -26,6 +26,7 @@ class AbstractDataset(_AbstractDataset):
             assert "boxes" in target, "Target should contain 'boxes' key"
             assert "labels" in target, "Target should contain 'labels' key"
         elif isinstance(target, tuple):
+            assert len(target) == 2
             assert isinstance(target[0], str) or isinstance(
                 target[0], np.ndarray
             ), "first element of the tuple should be a string or a numpy array"

--- a/doctr/datasets/datasets/pytorch.py
+++ b/doctr/datasets/datasets/pytorch.py
@@ -28,7 +28,8 @@ class AbstractDataset(_AbstractDataset):
         elif isinstance(target, tuple):
             assert isinstance(target[0], str) or isinstance(
                 target[0], np.ndarray
-            ), "Target should be a string or a numpy array"
+            ), "first element of the tuple should be a string or a numpy array"
+            assert isinstance(target[1], list), "second element of the tuple should be a list"
         else:
             assert isinstance(target, str) or isinstance(
                 target, np.ndarray

--- a/doctr/datasets/datasets/tensorflow.py
+++ b/doctr/datasets/datasets/tensorflow.py
@@ -25,6 +25,10 @@ class AbstractDataset(_AbstractDataset):
         if isinstance(target, dict):
             assert "boxes" in target, "Target should contain 'boxes' key"
             assert "labels" in target, "Target should contain 'labels' key"
+        elif isinstance(target, tuple):
+            assert isinstance(target[0], str) or isinstance(
+                target[0], np.ndarray
+            ), "Target should be a string or a numpy array"
         else:
             assert isinstance(target, str) or isinstance(
                 target, np.ndarray

--- a/doctr/datasets/datasets/tensorflow.py
+++ b/doctr/datasets/datasets/tensorflow.py
@@ -26,6 +26,7 @@ class AbstractDataset(_AbstractDataset):
             assert "boxes" in target, "Target should contain 'boxes' key"
             assert "labels" in target, "Target should contain 'labels' key"
         elif isinstance(target, tuple):
+            assert len(target) == 2
             assert isinstance(target[0], str) or isinstance(
                 target[0], np.ndarray
             ), "first element of the tuple should be a string or a numpy array"

--- a/doctr/datasets/datasets/tensorflow.py
+++ b/doctr/datasets/datasets/tensorflow.py
@@ -28,7 +28,8 @@ class AbstractDataset(_AbstractDataset):
         elif isinstance(target, tuple):
             assert isinstance(target[0], str) or isinstance(
                 target[0], np.ndarray
-            ), "Target should be a string or a numpy array"
+            ), "first element of the tuple should be a string or a numpy array"
+            assert isinstance(target[1], list), "second element of the tuple should be a list"
         else:
             assert isinstance(target, str) or isinstance(
                 target, np.ndarray

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
+from doctr.file_utils import CLASS_NAME
 from doctr.io.image import get_img_shape
 from doctr.utils.geometry import convert_to_relative_coords
 
@@ -73,8 +74,19 @@ class DetectionDataset(AbstractDataset):
     def format_polygons(
         self, polygons: Union[List, Dict], use_polygons: bool, np_dtype: Type
     ) -> Tuple[Union[np.ndarray, Dict], Optional[List]]:
+        """format polygons into an array
+
+        Args:
+            polygons: the bounding boxes
+            use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
+            np_dtype: dtype of array
+
+        Returns:
+            geoms: bounding boxes as np array
+            polygons_classes: list of classes for each bounding box
+        """
         if isinstance(polygons, list):
-            self._class_names += ["words"]
+            self._class_names += [CLASS_NAME]
             polygons_classes = None
             _polygons: np.ndarray = np.asarray(polygons, dtype=np_dtype)
         elif isinstance(polygons, dict):

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -92,4 +92,4 @@ class DetectionDataset(AbstractDataset):
 
     @property
     def class_names(self):
-        return list(set(self._class_names))
+        return sorted(list(set(self._class_names)))

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -73,7 +73,7 @@ class DetectionDataset(AbstractDataset):
 
     def format_polygons(
         self, polygons: Union[List, Dict], use_polygons: bool, np_dtype: Type
-    ) -> Tuple[Union[np.ndarray, Dict], Optional[List]]:
+    ) -> Tuple[Union[np.ndarray, Dict], Optional[List[str]]]:
         """format polygons into an array
 
         Args:

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -5,7 +5,7 @@
 
 import json
 import os
-from typing import Any, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
@@ -13,6 +13,7 @@ from doctr.io.image import get_img_shape
 from doctr.utils.geometry import convert_to_relative_coords
 
 from .datasets import AbstractDataset
+from .utils import pre_transform_multiclass
 
 __all__ = ["DetectionDataset"]
 
@@ -46,6 +47,7 @@ class DetectionDataset(AbstractDataset):
         )
 
         # File existence check
+        self._class_names: List = []
         if not os.path.exists(label_path):
             raise FileNotFoundError(f"unable to locate {label_path}")
         with open(label_path, "rb") as f:
@@ -58,7 +60,32 @@ class DetectionDataset(AbstractDataset):
             if not os.path.exists(os.path.join(self.root, img_name)):
                 raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_name)}")
 
-            polygons: np.ndarray = np.asarray(label["polygons"], dtype=np_dtype)
-            geoms = polygons if use_polygons else np.concatenate((polygons.min(axis=1), polygons.max(axis=1)), axis=1)
+            geoms, polygons_classes = self.format_polygons(label["polygons"], use_polygons, np_dtype)
 
-            self.data.append((img_name, np.asarray(geoms, dtype=np_dtype)))
+            if polygons_classes:
+                self._pre_transforms = pre_transform_multiclass
+                self.data.append(
+                    (img_name, (np.asarray(geoms, dtype=np_dtype), polygons_classes))  # type: ignore[arg-type]
+                )
+            else:
+                self.data.append((img_name, np.asarray(geoms, dtype=np_dtype)))
+
+    def format_polygons(
+        self, polygons: Union[List, Dict], use_polygons: bool, np_dtype: Type
+    ) -> Tuple[Union[np.ndarray, Dict], Optional[List]]:
+        if isinstance(polygons, list):
+            self._class_names += ["words"]
+            polygons_classes = None
+            _polygons: np.ndarray = np.asarray(polygons, dtype=np_dtype)
+        elif isinstance(polygons, dict):
+            self._class_names += list(polygons.keys())
+            polygons_classes = [k for k, v in polygons.items() for _ in v]
+            _polygons = np.concatenate([np.asarray(poly, dtype=np_dtype) for poly in polygons.values()], axis=0)
+        else:
+            raise TypeError(f"polygons should be a dictionary or list, it was {type(polygons)}")
+        geoms = _polygons if use_polygons else np.concatenate((_polygons.min(axis=1), _polygons.max(axis=1)), axis=1)
+        return geoms, polygons_classes
+
+    @property
+    def class_names(self):
+        return list(set(self._class_names))

--- a/doctr/datasets/detection.py
+++ b/doctr/datasets/detection.py
@@ -84,7 +84,7 @@ class DetectionDataset(AbstractDataset):
         elif isinstance(polygons, dict):
             self._class_names += list(polygons.keys())
             polygons_classes = [k for k, v in polygons.items() for _ in v]
-            _polygons = np.concatenate([np.asarray(poly, dtype=np_dtype) for poly in polygons.values()], axis=0)
+            _polygons = np.concatenate([np.asarray(poly, dtype=np_dtype) for poly in polygons.values() if poly], axis=0)
         else:
             raise TypeError(f"polygons should be a dictionary or list, it was {type(polygons)}")
         geoms = _polygons if use_polygons else np.concatenate((_polygons.min(axis=1), _polygons.max(axis=1)), axis=1)

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -20,7 +20,7 @@ from doctr.utils.geometry import convert_to_relative_coords, extract_crops, extr
 
 from .vocabs import VOCABS
 
-__all__ = ["translate", "encode_string", "decode_sequence", "encode_sequences"]
+__all__ = ["translate", "encode_string", "decode_sequence", "encode_sequences", "pre_transform_multiclass"]
 
 ImageTensor = TypeVar("ImageTensor")
 
@@ -183,3 +183,19 @@ def crop_bboxes_from_image(img_path: Union[str, Path], geoms: np.ndarray) -> Lis
     if geoms.ndim == 2 and geoms.shape[1] == 4:
         return extract_crops(img, geoms.astype(dtype=int))
     raise ValueError("Invalid geometry format")
+
+
+def pre_transform_multiclass(img, target: Dict):
+    """Converts multiclass target to relative coordinates.
+
+    Args:
+        img (tensor): Image
+        target (dict): dict of target polygons
+    """
+    boxes = convert_to_relative_coords(target[0], get_img_shape(img))
+    boxes_classes = target[1]
+    boxes_dict: Dict = {k: [] for k in set(boxes_classes)}
+    for k, poly in zip(boxes_classes, boxes):
+        boxes_dict[k].append(poly)
+    boxes_dict = {k: np.stack(v, axis=0) for k, v in boxes_dict.items()}
+    return img, boxes_dict

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -194,7 +194,7 @@ def pre_transform_multiclass(img, target: Tuple[np.ndarray, List]) -> Tuple[np.n
     """
     boxes = convert_to_relative_coords(target[0], get_img_shape(img))
     boxes_classes = target[1]
-    boxes_dict: Dict = {k: [] for k in set(boxes_classes)}
+    boxes_dict: Dict = {k: [] for k in sorted(set(boxes_classes))}
     for k, poly in zip(boxes_classes, boxes):
         boxes_dict[k].append(poly)
     boxes_dict = {k: np.stack(v, axis=0) for k, v in boxes_dict.items()}

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -185,12 +185,12 @@ def crop_bboxes_from_image(img_path: Union[str, Path], geoms: np.ndarray) -> Lis
     raise ValueError("Invalid geometry format")
 
 
-def pre_transform_multiclass(img, target: Dict):
+def pre_transform_multiclass(img, target: Tuple[np.ndarray, List]):
     """Converts multiclass target to relative coordinates.
 
     Args:
-        img (tensor): Image
-        target (dict): dict of target polygons
+        img: Image
+        target: tuple of target polygons and their classes names
     """
     boxes = convert_to_relative_coords(target[0], get_img_shape(img))
     boxes_classes = target[1]

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -185,7 +185,7 @@ def crop_bboxes_from_image(img_path: Union[str, Path], geoms: np.ndarray) -> Lis
     raise ValueError("Invalid geometry format")
 
 
-def pre_transform_multiclass(img, target: Tuple[np.ndarray, List]):
+def pre_transform_multiclass(img, target: Tuple[np.ndarray, List]) -> Tuple[np.ndarray, Dict[str, List]]:
     """Converts multiclass target to relative coordinates.
 
     Args:

--- a/doctr/file_utils.py
+++ b/doctr/file_utils.py
@@ -10,13 +10,16 @@ import logging
 import os
 import sys
 
+CLASS_NAME: str = "words"
+
+
 if sys.version_info < (3, 8):
     import importlib_metadata
 else:
     import importlib.metadata as importlib_metadata
 
 
-__all__ = ["is_tf_available", "is_torch_available"]
+__all__ = ["is_tf_available", "is_torch_available", "CLASS_NAME"]
 
 ENV_VARS_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
 ENV_VARS_TRUE_AND_AUTO_VALUES = ENV_VARS_TRUE_VALUES.union({"AUTO"})

--- a/doctr/file_utils.py
+++ b/doctr/file_utils.py
@@ -88,3 +88,11 @@ def is_torch_available():
 
 def is_tf_available():
     return _tf_available
+
+
+def copy_tensor(x):
+    if is_tf_available():
+        import tensorflow as tf
+        return tf.identity(x)
+    elif is_torch_available():
+        return x.detach().clone()

--- a/doctr/file_utils.py
+++ b/doctr/file_utils.py
@@ -93,6 +93,7 @@ def is_tf_available():
 def copy_tensor(x):
     if is_tf_available():
         import tensorflow as tf
+
         return tf.identity(x)
     elif is_torch_available():
         return x.detach().clone()

--- a/doctr/file_utils.py
+++ b/doctr/file_utils.py
@@ -19,7 +19,7 @@ else:
     import importlib.metadata as importlib_metadata
 
 
-__all__ = ["is_tf_available", "is_torch_available", "CLASS_NAME"]
+__all__ = ["is_tf_available", "is_torch_available", "CLASS_NAME", "copy_tensor"]
 
 ENV_VARS_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
 ENV_VARS_TRUE_AND_AUTO_VALUES = ENV_VARS_TRUE_VALUES.union({"AUTO"})

--- a/doctr/io/elements.py
+++ b/doctr/io/elements.py
@@ -42,7 +42,12 @@ class Element(NestedObject):
 
         export_dict = {k: getattr(self, k) for k in self._exported_keys}
         for children_name in self._children_names:
-            export_dict[children_name] = [c.export() for c in getattr(self, children_name)]
+            if children_name in ["blocks"]:
+                export_dict[children_name] = {
+                    k: [item.export() for item in c] for k, c in getattr(self, children_name).items()
+                }
+            else:
+                export_dict[children_name] = [c.export() for c in getattr(self, children_name)]
 
         return export_dict
 
@@ -228,7 +233,7 @@ class Page(Element):
 
     def __init__(
         self,
-        blocks: List[Block],
+        blocks: Dict[str, List[Block]],
         page_idx: int,
         dimensions: Tuple[int, int],
         orientation: Optional[Dict[str, Any]] = None,

--- a/doctr/io/elements.py
+++ b/doctr/io/elements.py
@@ -220,7 +220,7 @@ class Page(Element):
     """Implements a page element as a collection of blocks
 
     Args:
-        blocks: list of block elements
+        blocks: Dictionary with list of block elements for each detection class
         page_idx: the index of the page in the input raw document
         dimensions: the page size in pixels in format (height, width)
         orientation: a dictionary with the value of the rotation angle in degress and confidence of the prediction

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -5,7 +5,7 @@
 
 from math import floor
 from statistics import median_low
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -161,3 +161,36 @@ def get_language(text: str) -> Tuple[str, float]:
     if len(text) <= 1 or (len(text) <= 5 and lang.prob <= 0.2):
         return "unknown", 0.0
     return lang.lang, lang.prob
+
+
+def invert_list_dict_to_dict_list(list_dict: List[Dict[str, Any]]) -> Dict[str, List[Any]]:
+    """Convert a List of Dict of elements to a Dict of list of elements
+
+    Args:
+        list_dict (List): the list of dictionaries
+
+    Returns:
+        dict_list (Dict): the dictionary of lists
+    """
+    dict_list: Dict[str, List[Any]] = {k: [] for k in list_dict[0].keys()}
+    for dic in list_dict:
+        for k, v in dic.items():
+            dict_list[k].append(v)
+    return dict_list
+
+
+def invert_dict_list_to_list_dict(dict_list: Dict[str, List[Any]]) -> List[Dict[str, Any]]:
+    """Convert a Dict of list of elements to a List of Dict of elements
+
+    Args:
+        dict_list (Dict): the dictionary of lists
+
+    Returns:
+        list_dict (List): the list of dictionaries
+    """
+    n = len(list(dict_list.values())[0])
+    list_dict: List[Dict[str, Any]] = [{k: None for k in dict_list.keys()} for _ in range(n)]
+    for k, value in dict_list.items():
+        for i, v in enumerate(value):
+            list_dict[i][k] = v
+    return list_dict

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -11,7 +11,7 @@ import cv2
 import numpy as np
 from langdetect import LangDetectException, detect_langs
 
-__all__ = ["estimate_orientation", "get_bitmap_angle", "get_language", "invert_between_dict_of_lists_and_list_of_dicts"]
+__all__ = ["estimate_orientation", "get_bitmap_angle", "get_language", "invert_data_structure"]
 
 
 def get_max_width_length_ratio(contour: np.ndarray) -> float:
@@ -163,9 +163,17 @@ def get_language(text: str) -> Tuple[str, float]:
     return lang.lang, lang.prob
 
 
-def invert_between_dict_of_lists_and_list_of_dicts(
+def invert_data_structure(
     x: Union[List[Dict[str, Any]], Dict[str, List[Any]]]
 ) -> Union[List[Dict[str, Any]], Dict[str, List[Any]]]:
+    """Invert a List of Dict of elements to a Dict of list of elements and the other way around
+
+    Args:
+        x: a list of dictionaries with the same keys or a dictionary of lists of the same length
+
+    Returns:
+        dictionary of list when x is a list of dictionaries or a list of dictionaries when x is dictionary of lists
+    """
 
     if isinstance(x, dict):
         assert (

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -188,6 +188,9 @@ def convert_dict_list_to_list_dict(dict_list: Dict[str, List[Any]]) -> List[Dict
     Returns:
         list_dict (List): the list of dictionaries
     """
+    assert (
+        len(set([len(v) for v in dict_list.values()])) == 1
+    ), "All the lists in the dictionnary should have the same length."
     n = len(list(dict_list.values())[0])
     list_dict: List[Dict[str, Any]] = [{k: None for k in dict_list.keys()} for _ in range(n)]
     for k, value in dict_list.items():

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -5,13 +5,13 @@
 
 from math import floor
 from statistics import median_low
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
 from langdetect import LangDetectException, detect_langs
 
-__all__ = ["estimate_orientation", "get_bitmap_angle", "get_language"]
+__all__ = ["estimate_orientation", "get_bitmap_angle", "get_language", "invert_between_dict_of_lists_and_list_of_dicts"]
 
 
 def get_max_width_length_ratio(contour: np.ndarray) -> float:
@@ -163,37 +163,16 @@ def get_language(text: str) -> Tuple[str, float]:
     return lang.lang, lang.prob
 
 
-def convert_list_dict_to_dict_list(list_dict: List[Dict[str, Any]]) -> Dict[str, List[Any]]:
-    """Convert a List of Dict of elements to a Dict of list of elements
+def invert_between_dict_of_lists_and_list_of_dicts(
+    x: Union[List[Dict[str, Any]], Dict[str, List[Any]]]
+) -> Union[List[Dict[str, Any]], Dict[str, List[Any]]]:
 
-    Args:
-        list_dict (List): the list of dictionaries with the same keys (class names)
-
-    Returns:
-        dict_list (Dict): the dictionary of lists
-    """
-    dict_list: Dict[str, List[Any]] = {k: [] for k in list_dict[0].keys()}
-    for dic in list_dict:
-        for k, v in dic.items():
-            dict_list[k].append(v)
-    return dict_list
-
-
-def convert_dict_list_to_list_dict(dict_list: Dict[str, List[Any]]) -> List[Dict[str, Any]]:
-    """Convert a Dict of list of elements to a List of Dict of elements
-
-    Args:
-        dict_list (Dict): the dictionary of lists of the same length
-
-    Returns:
-        list_dict (List): the list of dictionaries
-    """
-    assert (
-        len(set([len(v) for v in dict_list.values()])) == 1
-    ), "All the lists in the dictionnary should have the same length."
-    n = len(list(dict_list.values())[0])
-    list_dict: List[Dict[str, Any]] = [{k: None for k in dict_list.keys()} for _ in range(n)]
-    for k, value in dict_list.items():
-        for i, v in enumerate(value):
-            list_dict[i][k] = v
-    return list_dict
+    if isinstance(x, dict):
+        assert (
+            len(set([len(v) for v in x.values()])) == 1
+        ), "All the lists in the dictionnary should have the same length."
+        return [dict(zip(x, t)) for t in zip(*x.values())]
+    elif isinstance(x, list):
+        return {k: [dic[k] for dic in x] for k in x[0]}
+    else:
+        raise TypeError(f"Expected input to be either a dict or a list, got {type(input)} instead.")

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -163,11 +163,11 @@ def get_language(text: str) -> Tuple[str, float]:
     return lang.lang, lang.prob
 
 
-def invert_list_dict_to_dict_list(list_dict: List[Dict[str, Any]]) -> Dict[str, List[Any]]:
+def convert_list_dict_to_dict_list(list_dict: List[Dict[str, Any]]) -> Dict[str, List[Any]]:
     """Convert a List of Dict of elements to a Dict of list of elements
 
     Args:
-        list_dict (List): the list of dictionaries
+        list_dict (List): the list of dictionaries with the same keys (class names)
 
     Returns:
         dict_list (Dict): the dictionary of lists
@@ -179,11 +179,11 @@ def invert_list_dict_to_dict_list(list_dict: List[Dict[str, Any]]) -> Dict[str, 
     return dict_list
 
 
-def invert_dict_list_to_list_dict(dict_list: Dict[str, List[Any]]) -> List[Dict[str, Any]]:
+def convert_dict_list_to_list_dict(dict_list: Dict[str, List[Any]]) -> List[Dict[str, Any]]:
     """Convert a Dict of list of elements to a List of Dict of elements
 
     Args:
-        dict_list (Dict): the dictionary of lists
+        dict_list (Dict): the dictionary of lists of the same length
 
     Returns:
         list_dict (List): the list of dictionaries

--- a/doctr/models/builder.py
+++ b/doctr/models/builder.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 from scipy.cluster.hierarchy import fclusterdata
 
+from doctr.file_utils import is_tf_available
 from doctr.io.elements import Block, Document, Line, Page, Word
 from doctr.utils.geometry import estimate_page_angle, resolve_enclosing_bbox, resolve_enclosing_rbbox, rotate_boxes
 from doctr.utils.repr import NestedObject
@@ -39,6 +40,10 @@ class DocumentBuilder(NestedObject):
         self.resolve_blocks = resolve_blocks
         self.paragraph_break = paragraph_break
         self.export_as_straight_boxes = export_as_straight_boxes
+        if is_tf_available():
+            self.__call__ = self.tf_call
+        else:
+            self.__call__ = self.torch_call  # type: ignore[assignment]
 
     @staticmethod
     def _sort_boxes(boxes: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
@@ -279,7 +284,7 @@ class DocumentBuilder(NestedObject):
             f"export_as_straight_boxes={self.export_as_straight_boxes}"
         )
 
-    def __call__(
+    def torch_call(
         self,
         boxes: List[np.ndarray],
         text_preds: List[List[Tuple[str, float]]],
@@ -317,10 +322,72 @@ class DocumentBuilder(NestedObject):
 
         _pages = [
             Page(
-                self._build_blocks(
-                    page_boxes,
-                    word_preds,
-                ),
+                {
+                    "words": self._build_blocks(
+                        page_boxes,
+                        word_preds,
+                    )
+                },
+                _idx,
+                shape,
+                orientation,
+                language,
+            )
+            for _idx, shape, page_boxes, word_preds, orientation, language in zip(
+                range(len(boxes)), page_shapes, boxes, text_preds, _orientations, _languages
+            )
+        ]
+
+        return Document(_pages)
+
+    def tf_call(
+        self,
+        boxes: List[Dict[str, np.ndarray]],
+        text_preds: List[Dict[str, List[Tuple[str, float]]]],
+        page_shapes: List[Tuple[int, int]],
+        orientations: Optional[List[Dict[str, Any]]] = None,
+        languages: Optional[List[Dict[str, Any]]] = None,
+    ) -> Document:
+        """Re-arrange detected words into structured blocks
+
+        Args:
+            boxes: list of N elements, where each element represents the localization predictions, of shape (*, 5)
+                or (*, 6) for all words for a given page
+            text_preds: list of N elements, where each element is the list of all word prediction (text + confidence)
+            page_shape: shape of each page, of size N
+
+        Returns:
+            document object
+        """
+        if len(boxes) != len(text_preds) or len(boxes) != len(page_shapes):
+            raise ValueError("All arguments are expected to be lists of the same size")
+
+        _orientations = (
+            orientations if isinstance(orientations, list) else [None] * len(boxes)  # type: ignore[list-item]
+        )
+        _languages = languages if isinstance(languages, list) else [None] * len(boxes)  # type: ignore[list-item]
+        if self.export_as_straight_boxes and len(boxes) > 0:
+            # If boxes are already straight OK, else fit a bounding rect
+            if list(boxes[0].values())[0].ndim == 3:
+                straight_boxes: List[Dict[str, np.ndarray]] = []
+                # Iterate over pages
+                for p_boxes in boxes:
+                    # Iterate over boxes of the pages
+                    straight_boxes_dict = {}
+                    for k, box in p_boxes.items():
+                        straight_boxes_dict[k] = np.concatenate((box.min(1), box.max(1)), 1)
+                    straight_boxes.append(straight_boxes_dict)
+                boxes = straight_boxes
+
+        _pages = [
+            Page(
+                {
+                    k: self._build_blocks(
+                        page_boxes[k],
+                        word_preds[k],
+                    )
+                    for k in page_boxes.keys()
+                },
                 _idx,
                 shape,
                 orientation,

--- a/doctr/models/builder.py
+++ b/doctr/models/builder.py
@@ -310,7 +310,7 @@ class DocumentBuilder(NestedObject):
         _languages = languages if isinstance(languages, list) else [None] * len(boxes)  # type: ignore[list-item]
         if self.export_as_straight_boxes and len(boxes) > 0:
             # If boxes are already straight OK, else fit a bounding rect
-            if list(boxes[0].values())[0].ndim == 3:  # type: ignore[union-attr]
+            if next(iter(boxes[0].values())).ndim == 3:  # type: ignore[union-attr]
                 straight_boxes: List[Dict[str, np.ndarray]] = []
                 # Iterate over pages
                 for p_boxes in boxes:

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -270,19 +270,19 @@ class _DBNet:
         output_shape: Tuple[int, int, int, int],
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
 
-        new_target = []
+        _target = []  # target is converted from List to List[Dict]
         for tgt in target:
             if isinstance(tgt, np.ndarray):
-                new_target.append({CLASS_NAME: tgt})
+                _target.append({CLASS_NAME: tgt})
             else:
-                new_target.append(tgt)
-        target = new_target.copy()
+                _target.append(tgt)
+        target = _target.copy()
         if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
             raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
         if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for tgt in target for t in tgt.values()):
             raise ValueError("the 'boxes' entry of the target is expected to take values between 0 & 1.")
 
-        input_dtype = list(target[0].values())[0].dtype if len(target) > 0 else np.float32
+        input_dtype = next(iter(target[0].values())).dtype if len(target) > 0 else np.float32
 
         if is_tf_available():
             h, w = output_shape[1:-1]
@@ -296,15 +296,15 @@ class _DBNet:
         thresh_mask: np.ndarray = np.ones(target_shape, dtype=np.uint8)
 
         for idx, tgt in enumerate(target):
-            for class_idx, _target in enumerate(tgt.values()):
+            for class_idx, _tgt in enumerate(tgt.values()):
                 # Draw each polygon on gt
-                if _target.shape[0] == 0:
+                if _tgt.shape[0] == 0:
                     # Empty image, full masked
                     # seg_mask[idx, :, :, class_idx] = False
                     seg_mask[idx, class_idx] = False
 
                 # Absolute bounding boxes
-                abs_boxes = _target.copy()
+                abs_boxes = _tgt.copy()
                 if abs_boxes.ndim == 3:
                     abs_boxes[:, :, 0] *= w
                     abs_boxes[:, :, 1] *= h

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -12,7 +12,7 @@ import numpy as np
 import pyclipper
 from shapely.geometry import Polygon
 
-from doctr.file_utils import is_tf_available
+from doctr.file_utils import CLASS_NAME, is_tf_available
 
 from ..core import DetectionPostProcessor
 
@@ -226,7 +226,7 @@ class _DBNet:
         padded_polygon: np.ndarray = np.array(padding.Execute(distance)[0])
 
         # Fill the mask with 1 on the new padded polygon
-        cv2.fillPoly(mask.copy(), [padded_polygon.astype(np.int32)], 1.0)
+        cv2.fillPoly(mask, [padded_polygon.astype(np.int32)], 1.0)
 
         # Get min/max to recover polygon after distance computation
         xmin = padded_polygon[:, 0].min()
@@ -273,7 +273,7 @@ class _DBNet:
         new_target = []
         for tgt in target:
             if isinstance(tgt, np.ndarray):
-                new_target.append({"words": tgt})
+                new_target.append({CLASS_NAME: tgt})
             else:
                 new_target.append(tgt)
         target = new_target.copy()
@@ -286,10 +286,10 @@ class _DBNet:
 
         if is_tf_available():
             h, w = output_shape[1:-1]
-            target_shape = (output_shape[0], output_shape[-1], h, w)
+            target_shape = (output_shape[0], output_shape[-1], h, w)  # (Batch_size, num_classes, h, w)
         else:
             h, w = output_shape[-2:]
-            target_shape = output_shape
+            target_shape = output_shape  # (Batch_size, num_classes, h, w)
         seg_target: np.ndarray = np.zeros(target_shape, dtype=np.uint8)
         seg_mask: np.ndarray = np.ones(target_shape, dtype=bool)
         thresh_target: np.ndarray = np.zeros(target_shape, dtype=np.float32)

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -12,7 +12,7 @@ import numpy as np
 import pyclipper
 from shapely.geometry import Polygon
 
-from doctr.file_utils import CLASS_NAME, is_tf_available
+from doctr.file_utils import is_tf_available
 
 from ..core import DetectionPostProcessor
 
@@ -266,17 +266,10 @@ class _DBNet:
 
     def build_target(
         self,
-        target: Union[List[Dict[str, np.ndarray]], List[np.ndarray]],
+        target: List[Dict[str, np.ndarray]],
         output_shape: Tuple[int, int, int, int],
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
 
-        _target = []  # target is converted from List to List[Dict]
-        for tgt in target:
-            if isinstance(tgt, np.ndarray):
-                _target.append({CLASS_NAME: tgt})
-            else:
-                _target.append(tgt)
-        target = _target.copy()
         if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
             raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
         if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for tgt in target for t in tgt.values()):

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -12,8 +12,6 @@ import numpy as np
 import pyclipper
 from shapely.geometry import Polygon
 
-from doctr.file_utils import is_tf_available
-
 from ..core import DetectionPostProcessor
 
 __all__ = ["DBPostProcessor"]
@@ -268,6 +266,7 @@ class _DBNet:
         self,
         target: List[Dict[str, np.ndarray]],
         output_shape: Tuple[int, int, int, int],
+        channels_last: bool = True,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
 
         if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
@@ -277,7 +276,7 @@ class _DBNet:
 
         input_dtype = next(iter(target[0].values())).dtype if len(target) > 0 else np.float32
 
-        if is_tf_available():
+        if channels_last:
             h, w = output_shape[1:-1]
             target_shape = (output_shape[0], output_shape[-1], h, w)  # (Batch_size, num_classes, h, w)
         else:
@@ -350,7 +349,7 @@ class _DBNet:
                     poly, thresh_target[idx, class_idx], thresh_mask[idx, class_idx] = self.draw_thresh_map(
                         poly, thresh_target[idx, class_idx], thresh_mask[idx, class_idx]
                     )
-        if is_tf_available():
+        if channels_last:
             seg_target = seg_target.transpose((0, 2, 3, 1))
             seg_mask = seg_mask.transpose((0, 2, 3, 1))
             thresh_target = thresh_target.transpose((0, 2, 3, 1))

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -310,13 +310,10 @@ def _dbnet(
         {layer_name: str(idx) for idx, layer_name in enumerate(fpn_layers)},
     )
 
+    if not kwargs.get("class_names", None):
+        kwargs["class_names"] = default_cfgs[arch].get("class_names", None)
     # Build the model
-    model = DBNet(
-        feat_extractor,
-        cfg=default_cfgs[arch],
-        class_names=default_cfgs[arch].get("class_names", None),
-        **kwargs,
-    )
+    model = DBNet(feat_extractor, cfg=default_cfgs[arch], **kwargs)
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, default_cfgs[arch]["url"])

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -125,14 +125,11 @@ class DBNet(_DBNet, nn.Module):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: Optional[List[str]] = None,
+        class_names: List[str] = [CLASS_NAME],
     ) -> None:
 
         super().__init__()
-        if class_names:
-            self.class_names = class_names
-        else:
-            self.class_names = [CLASS_NAME]
+        self.class_names = class_names
         num_classes: int = len(self.class_names)
         self.cfg = cfg
 
@@ -243,7 +240,7 @@ class DBNet(_DBNet, nn.Module):
         prob_map = torch.sigmoid(out_map)
         thresh_map = torch.sigmoid(thresh_map)
 
-        targets = self.build_target(target, prob_map.shape)  # type: ignore[arg-type]
+        targets = self.build_target(target, prob_map.shape, False)  # type: ignore[arg-type]
 
         seg_target, seg_mask = torch.from_numpy(targets[0]), torch.from_numpy(targets[1])
         seg_target, seg_mask = seg_target.to(out_map.device), seg_mask.to(out_map.device)
@@ -311,7 +308,7 @@ def _dbnet(
     )
 
     if not kwargs.get("class_names", None):
-        kwargs["class_names"] = default_cfgs[arch].get("class_names", None)
+        kwargs["class_names"] = default_cfgs[arch].get("class_names", [CLASS_NAME])
     else:
         kwargs["class_names"] = sorted(kwargs["class_names"])
     # Build the model

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -312,6 +312,8 @@ def _dbnet(
 
     if not kwargs.get("class_names", None):
         kwargs["class_names"] = default_cfgs[arch].get("class_names", None)
+    else:
+        kwargs["class_names"] = sorted(kwargs["class_names"])
     # Build the model
     model = DBNet(feat_extractor, cfg=default_cfgs[arch], **kwargs)
     # Load pretrained parameters

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -125,11 +125,14 @@ class DBNet(_DBNet, nn.Module):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: List[str] = [CLASS_NAME],
+        class_names: Optional[List[str]] = None,
     ) -> None:
 
         super().__init__()
-        self.class_names = class_names
+        if class_names:
+            self.class_names = class_names
+        else:
+            self.class_names = [CLASS_NAME]
         num_classes: int = len(self.class_names)
         self.cfg = cfg
 
@@ -308,7 +311,12 @@ def _dbnet(
     )
 
     # Build the model
-    model = DBNet(feat_extractor, cfg=default_cfgs[arch], **kwargs)
+    model = DBNet(
+        feat_extractor,
+        cfg=default_cfgs[arch],
+        class_names=default_cfgs[arch].get("class_names", None),
+        **kwargs,
+    )
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, default_cfgs[arch]["url"])

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -110,7 +110,6 @@ class DBNet(_DBNet, nn.Module):
         feature extractor: the backbone serving as feature extractor
         head_chans: the number of channels in the head
         deform_conv: whether to use deformable convolution
-        num_classes: number of output channels in the segmentation map
         assume_straight_pages: if True, fit straight bounding boxes only
         exportable: onnx exportable returns only logits
         cfg: the configuration dict of the model
@@ -122,7 +121,6 @@ class DBNet(_DBNet, nn.Module):
         feat_extractor: IntermediateLayerGetter,
         head_chans: int = 256,
         deform_conv: bool = False,
-        num_classes: int = 1,
         bin_thresh: float = 0.3,
         assume_straight_pages: bool = True,
         exportable: bool = False,
@@ -132,6 +130,7 @@ class DBNet(_DBNet, nn.Module):
 
         super().__init__()
         self.class_names = class_names
+        num_classes: int = len(self.class_names)
         self.cfg = cfg
 
         conv_layer = DeformConv2d if deform_conv else nn.Conv2d

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -126,14 +126,11 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: Optional[List[str]] = None,
+        class_names: List[str] = [CLASS_NAME],
     ) -> None:
 
         super().__init__()
-        if class_names:
-            self.class_names = class_names
-        else:
-            self.class_names = [CLASS_NAME]
+        self.class_names = class_names
         num_classes: int = len(self.class_names)
         self.cfg = cfg
 
@@ -188,7 +185,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         prob_map = tf.math.sigmoid(out_map)
         thresh_map = tf.math.sigmoid(thresh_map)
 
-        seg_target, seg_mask, thresh_target, thresh_mask = self.build_target(target, out_map.shape)
+        seg_target, seg_mask, thresh_target, thresh_mask = self.build_target(target, out_map.shape, True)
         seg_target = tf.convert_to_tensor(seg_target, dtype=out_map.dtype)
         seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
         thresh_target = tf.convert_to_tensor(thresh_target, dtype=out_map.dtype)
@@ -280,7 +277,7 @@ def _db_resnet(
     _cfg = deepcopy(default_cfgs[arch])
     _cfg["input_shape"] = input_shape or _cfg["input_shape"]
     if not kwargs.get("class_names", None):
-        kwargs["class_names"] = _cfg.get("class_names", None)
+        kwargs["class_names"] = _cfg.get("class_names", [CLASS_NAME])
     else:
         kwargs["class_names"] = sorted(kwargs["class_names"])
 

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -171,7 +171,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         self,
         out_map: tf.Tensor,
         thresh_map: tf.Tensor,
-        target: List[np.ndarray],
+        target: List[Dict[str, np.ndarray]],
     ) -> tf.Tensor:
         """Compute a batch of gts, masks, thresh_gts, thresh_masks from a list of boxes
         and a list of masks for each image. From there it computes the loss with the model output
@@ -231,7 +231,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
     def call(
         self,
         x: tf.Tensor,
-        target: Optional[List[np.ndarray]] = None,
+        target: Optional[List[Dict[str, np.ndarray]]] = None,
         return_model_output: bool = False,
         return_preds: bool = False,
         **kwargs: Any,

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -126,11 +126,14 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: List[str] = [CLASS_NAME],
+        class_names: Optional[List[str]] = None,
     ) -> None:
 
         super().__init__()
-        self.class_names = class_names
+        if class_names:
+            self.class_names = class_names
+        else:
+            self.class_names = [CLASS_NAME]
         num_classes: int = len(self.class_names)
         self.cfg = cfg
 
@@ -276,6 +279,7 @@ def _db_resnet(
     # Patch the config
     _cfg = deepcopy(default_cfgs[arch])
     _cfg["input_shape"] = input_shape or _cfg["input_shape"]
+    class_names = _cfg.get("class_names", None)
 
     # Feature extractor
     feat_extractor = IntermediateLayerGetter(
@@ -289,7 +293,7 @@ def _db_resnet(
     )
 
     # Build the model
-    model = DBNet(feat_extractor, cfg=_cfg, **kwargs)
+    model = DBNet(feat_extractor, cfg=_cfg, class_names=class_names, **kwargs)
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, _cfg["url"])

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -281,6 +281,8 @@ def _db_resnet(
     _cfg["input_shape"] = input_shape or _cfg["input_shape"]
     if not kwargs.get("class_names", None):
         kwargs["class_names"] = _cfg.get("class_names", None)
+    else:
+        kwargs["class_names"] = sorted(kwargs["class_names"])
 
     # Feature extractor
     feat_extractor = IntermediateLayerGetter(

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -279,7 +279,8 @@ def _db_resnet(
     # Patch the config
     _cfg = deepcopy(default_cfgs[arch])
     _cfg["input_shape"] = input_shape or _cfg["input_shape"]
-    class_names = _cfg.get("class_names", None)
+    if not kwargs.get("class_names", None):
+        kwargs["class_names"] = _cfg.get("class_names", None)
 
     # Feature extractor
     feat_extractor = IntermediateLayerGetter(
@@ -293,7 +294,7 @@ def _db_resnet(
     )
 
     # Build the model
-    model = DBNet(feat_extractor, cfg=_cfg, class_names=class_names, **kwargs)
+    model = DBNet(feat_extractor, cfg=_cfg, **kwargs)
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, _cfg["url"])

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -110,7 +110,6 @@ class DBNet(_DBNet, keras.Model, NestedObject):
     Args:
         feature extractor: the backbone serving as feature extractor
         fpn_channels: number of channels each extracted feature maps is mapped to
-        num_classes: number of output channels in the segmentation map
         assume_straight_pages: if True, fit straight bounding boxes only
         exportable: onnx exportable returns only logits
         cfg: the configuration dict of the model
@@ -123,7 +122,6 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         self,
         feature_extractor: IntermediateLayerGetter,
         fpn_channels: int = 128,  # to be set to 256 to represent the author's initial idea
-        num_classes: int = 1,
         bin_thresh: float = 0.3,
         assume_straight_pages: bool = True,
         exportable: bool = False,
@@ -133,6 +131,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
 
         super().__init__()
         self.class_names = class_names
+        num_classes: int = len(self.class_names)
         self.cfg = cfg
 
         self.feat_extractor = feature_extractor

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -126,9 +126,13 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
+        class_names: List[str] = ["words"],
     ) -> None:
 
         super().__init__()
+        self.class_names = class_names
+        if cfg and cfg.get("class_names"):
+            self.class_names = cfg["class_names"]
         self.cfg = cfg
 
         self.feat_extractor = feature_extractor
@@ -181,60 +185,6 @@ class DBNet(_DBNet, keras.Model, NestedObject):
             A loss tensor
         """
 
-        # prob_map = tf.math.sigmoid(out_map)
-        # thresh_map = tf.math.sigmoid(thresh_map)
-        #
-        # seg_target_all, seg_mask_all, thresh_target_all, thresh_mask_all = self.build_target(target, out_map.shape)
-        # seg_target_all = tf.convert_to_tensor(seg_target_all, dtype=out_map.dtype)
-        # seg_mask_all = tf.convert_to_tensor(seg_mask_all, dtype=tf.bool)
-        # thresh_target_all = tf.convert_to_tensor(thresh_target_all, dtype=out_map.dtype)
-        # thresh_mask_all = tf.convert_to_tensor(thresh_mask_all, dtype=tf.bool)
-
-        # final_loss = tf.convert_to_tensor(0, dtype=float)
-        # for idx in range(out_map.shape[-1]):
-        #     seg_target = seg_target_all[..., idx]
-        #     seg_mask = seg_mask_all[..., idx]
-        #     thresh_target = thresh_target_all[..., idx]
-        #     thresh_mask = thresh_mask_all[..., idx]
-        #     _out_map = out_map[..., idx]
-        #     _thresh_map = thresh_map[..., idx]
-        #     _prob_map = prob_map[..., idx]
-        #     # Compute balanced BCE loss for proba_map
-        #     bce_scale = 5.0
-        #
-        #     bce_loss = tf.keras.losses.binary_crossentropy(
-        #         seg_target[..., None], _out_map[..., None], from_logits=True
-        #     )[seg_mask]
-        #
-        #     neg_target = 1 - seg_target[seg_mask]
-        #     positive_count = tf.math.reduce_sum(seg_target[seg_mask])
-        #     negative_count = tf.math.reduce_min([tf.math.reduce_sum(neg_target), 3.0 * positive_count])
-        #     negative_loss = bce_loss * neg_target
-        #     negative_loss, _ = tf.nn.top_k(negative_loss, tf.cast(negative_count, tf.int32))
-        #     sum_losses = tf.math.reduce_sum(bce_loss * seg_target[seg_mask]) + tf.math.reduce_sum(negative_loss)
-        #     balanced_bce_loss = sum_losses / (positive_count + negative_count + 1e-6)
-        #
-        #     # Compute dice loss for approxbin_map
-        #     bin_map = 1 / (1 + tf.exp(-50.0 * (_prob_map[seg_mask] - _thresh_map[seg_mask])))
-        #
-        #     bce_min = tf.math.reduce_min(bce_loss)
-        #     weights = (bce_loss - bce_min) / (tf.math.reduce_max(bce_loss) - bce_min) + 1.0
-        #     inter = tf.math.reduce_sum(bin_map * seg_target[seg_mask] * weights)
-        #     union = tf.math.reduce_sum(bin_map) + tf.math.reduce_sum(seg_target[seg_mask]) + 1e-8
-        #     dice_loss = 1 - 2.0 * (inter + eps) / (union + eps)
-        #
-        #     # Compute l1 loss for thresh_map
-        #     l1_scale = 10.0
-        #     if tf.reduce_any(thresh_mask):
-        #         l1_loss = tf.math.reduce_mean(tf.math.abs(_thresh_map[thresh_mask] - thresh_target[thresh_mask]))
-        #     else:
-        #         l1_loss = tf.constant(0.0)
-        #
-        #     final_loss += l1_scale * l1_loss + bce_scale * balanced_bce_loss + dice_loss
-        # return final_loss
-
-        # prob_map = tf.math.sigmoid(tf.squeeze(out_map, axis=[-1]))
-        # thresh_map = tf.math.sigmoid(tf.squeeze(thresh_map, axis=[-1]))
         prob_map = tf.math.sigmoid(out_map)
         thresh_map = tf.math.sigmoid(thresh_map)
 
@@ -304,8 +254,10 @@ class DBNet(_DBNet, keras.Model, NestedObject):
 
         if target is None or return_preds:
             # Post-process boxes (keep only text predictions)
-            out["preds"] = self.postprocessor(prob_map.numpy())
-            # out["preds"] = [preds[0] for preds in self.postprocessor(prob_map.numpy())]
+            out["preds"] = [
+                {class_name: p for class_name, p in zip(self.class_names, preds)}
+                for preds in self.postprocessor(prob_map.numpy())
+            ]
 
         if target is not None:
             thresh_map = self.threshold_head(feat_concat, **kwargs)

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -170,7 +170,6 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         out_map: tf.Tensor,
         thresh_map: tf.Tensor,
         target: List[np.ndarray],
-        eps: float = 1e-8,
     ) -> tf.Tensor:
         """Compute a batch of gts, masks, thresh_gts, thresh_masks from a list of boxes
         and a list of masks for each image. From there it computes the loss with the model output
@@ -179,7 +178,6 @@ class DBNet(_DBNet, keras.Model, NestedObject):
             out_map: output feature map of the model of shape (N, H, W, C)
             thresh_map: threshold map of shape (N, H, W, C)
             target: list of dictionary where each dict has a `boxes` and a `flags` entry
-            eps: epsilon factor in dice loss
 
         Returns:
             A loss tensor

--- a/doctr/models/detection/differentiable_binarization/tensorflow.py
+++ b/doctr/models/detection/differentiable_binarization/tensorflow.py
@@ -161,7 +161,13 @@ class DBNet(_DBNet, keras.Model, NestedObject):
 
         self.postprocessor = DBPostProcessor(assume_straight_pages=assume_straight_pages, bin_thresh=bin_thresh)
 
-    def compute_loss(self, out_map: tf.Tensor, thresh_map: tf.Tensor, target: List[np.ndarray]) -> tf.Tensor:
+    def compute_loss(
+        self,
+        out_map: tf.Tensor,
+        thresh_map: tf.Tensor,
+        target: List[np.ndarray],
+        eps: float = 1e-8,
+    ) -> tf.Tensor:
         """Compute a batch of gts, masks, thresh_gts, thresh_masks from a list of boxes
         and a list of masks for each image. From there it computes the loss with the model output
 
@@ -169,6 +175,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
             out_map: output feature map of the model of shape (N, H, W, C)
             thresh_map: threshold map of shape (N, H, W, C)
             target: list of dictionary where each dict has a `boxes` and a `flags` entry
+            eps: epsilon factor in dice loss
 
         Returns:
             A loss tensor
@@ -179,45 +186,54 @@ class DBNet(_DBNet, keras.Model, NestedObject):
         prob_map = tf.math.sigmoid(out_map)
         thresh_map = tf.math.sigmoid(thresh_map)
 
-        seg_target, seg_mask, thresh_target, thresh_mask = self.build_target(target, out_map.shape)
-        seg_target = tf.convert_to_tensor(seg_target, dtype=out_map.dtype)
-        seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
-        thresh_target = tf.convert_to_tensor(thresh_target, dtype=out_map.dtype)
-        thresh_mask = tf.convert_to_tensor(thresh_mask, dtype=tf.bool)
+        seg_target_all, seg_mask_all, thresh_target_all, thresh_mask_all = self.build_target(target, out_map.shape)
+        seg_target_all = tf.convert_to_tensor(seg_target_all, dtype=out_map.dtype)
+        seg_mask_all = tf.convert_to_tensor(seg_mask_all, dtype=tf.bool)
+        thresh_target_all = tf.convert_to_tensor(thresh_target_all, dtype=out_map.dtype)
+        thresh_mask_all = tf.convert_to_tensor(thresh_mask_all, dtype=tf.bool)
 
-        # Compute balanced BCE loss for proba_map
-        bce_scale = 5.0
-        bce_loss = tf.concat([
-            tf.keras.losses.binary_crossentropy(seg_target[:,:,:,idx: idx+1], out_map[:,:,:,idx: idx+1], from_logits=True)[..., None]
-            for idx in range(out_map.shape[-1])
-        ], axis=-1)[seg_mask]
-        # bce_loss = tf.keras.losses.binary_crossentropy(seg_target, out_map, from_logits=True)[..., None][seg_mask]
+        final_loss = tf.convert_to_tensor(0, dtype=float)
+        for idx in range(out_map.shape[-1]):
+            seg_target = seg_target_all[..., idx]
+            seg_mask = seg_mask_all[..., idx]
+            thresh_target = thresh_target_all[..., idx]
+            thresh_mask = thresh_mask_all[..., idx]
+            _out_map = out_map[..., idx]
+            _thresh_map = thresh_map[..., idx]
+            _prob_map = prob_map[..., idx]
+            # Compute balanced BCE loss for proba_map
+            bce_scale = 5.0
 
-        neg_target = 1 - seg_target[seg_mask]
-        positive_count = tf.math.reduce_sum(seg_target[seg_mask])
-        negative_count = tf.math.reduce_min([tf.math.reduce_sum(neg_target), 3.0 * positive_count])
-        negative_loss = bce_loss * neg_target
-        negative_loss, _ = tf.nn.top_k(negative_loss, tf.cast(negative_count, tf.int32))
-        sum_losses = tf.math.reduce_sum(bce_loss * seg_target[seg_mask]) + tf.math.reduce_sum(negative_loss)
-        balanced_bce_loss = sum_losses / (positive_count + negative_count + 1e-6)
+            bce_loss = tf.keras.losses.binary_crossentropy(
+                seg_target[..., None], _out_map[..., None], from_logits=True
+            )[seg_mask]
 
-        # Compute dice loss for approxbin_map
-        bin_map = 1 / (1 + tf.exp(-50.0 * (prob_map[seg_mask] - thresh_map[seg_mask])))
+            neg_target = 1 - seg_target[seg_mask]
+            positive_count = tf.math.reduce_sum(seg_target[seg_mask])
+            negative_count = tf.math.reduce_min([tf.math.reduce_sum(neg_target), 3.0 * positive_count])
+            negative_loss = bce_loss * neg_target
+            negative_loss, _ = tf.nn.top_k(negative_loss, tf.cast(negative_count, tf.int32))
+            sum_losses = tf.math.reduce_sum(bce_loss * seg_target[seg_mask]) + tf.math.reduce_sum(negative_loss)
+            balanced_bce_loss = sum_losses / (positive_count + negative_count + 1e-6)
 
-        bce_min = tf.math.reduce_min(bce_loss)
-        weights = (bce_loss - bce_min) / (tf.math.reduce_max(bce_loss) - bce_min) + 1.0
-        inter = tf.math.reduce_sum(bin_map * seg_target[seg_mask] * weights)
-        union = tf.math.reduce_sum(bin_map) + tf.math.reduce_sum(seg_target[seg_mask]) + 1e-8
-        dice_loss = 1 - 2.0 * inter / union
+            # Compute dice loss for approxbin_map
+            bin_map = 1 / (1 + tf.exp(-50.0 * (_prob_map[seg_mask] - _thresh_map[seg_mask])))
 
-        # Compute l1 loss for thresh_map
-        l1_scale = 10.0
-        if tf.reduce_any(thresh_mask):
-            l1_loss = tf.math.reduce_mean(tf.math.abs(thresh_map[thresh_mask] - thresh_target[thresh_mask]))
-        else:
-            l1_loss = tf.constant(0.0)
+            bce_min = tf.math.reduce_min(bce_loss)
+            weights = (bce_loss - bce_min) / (tf.math.reduce_max(bce_loss) - bce_min) + 1.0
+            inter = tf.math.reduce_sum(bin_map * seg_target[seg_mask] * weights)
+            union = tf.math.reduce_sum(bin_map) + tf.math.reduce_sum(seg_target[seg_mask]) + 1e-8
+            dice_loss = 1 - 2.0 * (inter + eps) / (union + eps)
 
-        return l1_scale * l1_loss + bce_scale * balanced_bce_loss + dice_loss
+            # Compute l1 loss for thresh_map
+            l1_scale = 10.0
+            if tf.reduce_any(thresh_mask):
+                l1_loss = tf.math.reduce_mean(tf.math.abs(_thresh_map[thresh_mask] - thresh_target[thresh_mask]))
+            else:
+                l1_loss = tf.constant(0.0)
+
+            final_loss += l1_scale * l1_loss + bce_scale * balanced_bce_loss + dice_loss
+        return final_loss
 
     def call(
         self,
@@ -245,7 +261,7 @@ class DBNet(_DBNet, keras.Model, NestedObject):
 
         if target is None or return_preds:
             # Post-process boxes (keep only text predictions)
-            out['preds'] = self.postprocessor(prob_map.numpy())
+            out["preds"] = self.postprocessor(prob_map.numpy())
             # out["preds"] = [preds[0] for preds in self.postprocessor(prob_map.numpy())]
 
         if target is not None:

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -5,7 +5,7 @@
 
 # Credits: post-processing adapted from https://github.com/xuannianz/DifferentiableBinarization
 
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Dict
 
 import cv2
 import numpy as np
@@ -153,6 +153,89 @@ class _LinkNet(BaseModel):
     min_size_box: int = 3
     assume_straight_pages: bool = True
     shrink_ratio = 0.5
+
+    # def build_target(
+    #     self,
+    #     target: Union[List[Dict[str, np.ndarray]], List[np.ndarray]],
+    #     output_shape: Tuple[int, int, int],
+    # ) -> Tuple[np.ndarray, np.ndarray]:
+    #
+    #     for i, tgt in enumerate(target):
+    #         if isinstance(tgt, np.ndarray):
+    #             target[i] = {"words": tgt}
+    #     if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
+    #         raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
+    #     if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for tgt in target for t in tgt.values()
+    #            ):
+    #         raise ValueError("the 'boxes' entry of the target is expected to take values between 0 & 1.")
+    #
+    #     h, w, num_classes = output_shape
+    #     target_shape = (len(target), h, w, num_classes)
+    #
+    #     seg_target: np.ndarray = np.zeros(target_shape, dtype=np.uint8)
+    #     seg_mask: np.ndarray = np.ones(target_shape, dtype=bool)
+    #
+    #     for idx, tgt in enumerate(target):
+    #         for class_idx, _target in enumerate(tgt.values()):
+    #             # Draw each polygon on gt
+    #             if _target.shape[0] == 0:
+    #                 # Empty image, full masked
+    #                 seg_mask[idx, :, :, class_idx] = False
+    #
+    #             # Absolute bounding boxes
+    #             abs_boxes = _target.copy()
+    #
+    #             if abs_boxes.ndim == 3:
+    #                 abs_boxes[:, :, 0] *= w
+    #                 abs_boxes[:, :, 1] *= h
+    #                 polys = abs_boxes
+    #                 boxes_size = np.linalg.norm(abs_boxes[:, 2, :] - abs_boxes[:, 0, :], axis=-1)
+    #                 abs_boxes = np.concatenate((abs_boxes.min(1), abs_boxes.max(1)), -1).round().astype(np.int32)
+    #             else:
+    #                 abs_boxes[:, [0, 2]] *= w
+    #                 abs_boxes[:, [1, 3]] *= h
+    #                 abs_boxes = abs_boxes.round().astype(np.int32)
+    #                 polys = np.stack(
+    #                     [
+    #                         abs_boxes[:, [0, 1]],
+    #                         abs_boxes[:, [0, 3]],
+    #                         abs_boxes[:, [2, 3]],
+    #                         abs_boxes[:, [2, 1]],
+    #                     ],
+    #                     axis=1,
+    #                 )
+    #                 boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
+    #
+    #             for poly, box, box_size in zip(polys, abs_boxes, boxes_size):
+    #                 # Mask boxes that are too small
+    #                 if box_size < self.min_size_box:
+    #                     seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
+    #                     continue
+    #
+    #                 # Negative shrink for gt, as described in paper
+    #                 polygon = Polygon(poly)
+    #                 distance = polygon.area * (1 - np.power(self.shrink_ratio, 2)) / polygon.length
+    #                 subject = [tuple(coor) for coor in poly]
+    #                 padding = pyclipper.PyclipperOffset()
+    #                 padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
+    #                 shrunken = padding.Execute(-distance)
+    #
+    #                 # Draw polygon on gt if it is valid
+    #                 if len(shrunken) == 0:
+    #                     seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
+    #                     continue
+    #                 shrunken = np.array(shrunken[0]).reshape(-1, 2)
+    #                 if shrunken.shape[0] <= 2 or not Polygon(shrunken).is_valid:
+    #                     seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
+    #                     continue
+    #                 cv2.fillPoly(seg_target[idx, :, :, class_idx: class_idx+1].copy(), [shrunken.astype(np.int32)], 1)
+    #
+    #     # Don't forget to switch back to channel first if PyTorch is used
+    #     if not is_tf_available():
+    #         seg_target = seg_target.transpose(0, 3, 1, 2)
+    #         seg_mask = seg_mask.transpose(0, 3, 1, 2)
+    #
+    #     return seg_target, seg_mask
 
     def build_target(
         self,

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -12,7 +12,7 @@ import numpy as np
 import pyclipper
 from shapely.geometry import Polygon
 
-from doctr.file_utils import is_tf_available
+from doctr.file_utils import CLASS_NAME, is_tf_available
 from doctr.models.core import BaseModel
 
 from ..core import DetectionPostProcessor
@@ -159,11 +159,20 @@ class _LinkNet(BaseModel):
         target: Union[List[Dict[str, np.ndarray]], List[np.ndarray]],
         output_shape: Tuple[int, int, int],
     ) -> Tuple[np.ndarray, np.ndarray]:
+        """Build the target, and it's mask to be used from loss computation.
+
+        Args:
+            target: target coming from dataset
+            output_shape: shape of the output of the model without batch_size
+
+        Returns:
+            the new formatted target and the mask
+        """
 
         new_target = []
         for tgt in target:
             if isinstance(tgt, np.ndarray):
-                new_target.append({"words": tgt})
+                new_target.append({CLASS_NAME: tgt})
             else:
                 new_target.append(tgt)
         target = new_target.copy()

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -164,13 +164,20 @@ class _LinkNet(BaseModel):
         for tgt in target:
             if isinstance(tgt, np.ndarray):
                 new_target.append({"words": tgt})
+            else:
+                new_target.append(tgt)
         target = new_target.copy()
         if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
             raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
         if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for tgt in target for t in tgt.values()):
             raise ValueError("the 'boxes' entry of the target is expected to take values between 0 & 1.")
 
-        h, w, num_classes = output_shape
+        h: int
+        w: int
+        if is_tf_available():
+            h, w, num_classes = output_shape
+        else:
+            num_classes, h, w = output_shape
         target_shape = (len(target), num_classes, h, w)
 
         seg_target: np.ndarray = np.zeros(target_shape, dtype=np.uint8)

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -154,159 +154,80 @@ class _LinkNet(BaseModel):
     assume_straight_pages: bool = True
     shrink_ratio = 0.5
 
-    # def build_target(
-    #     self,
-    #     target: Union[List[Dict[str, np.ndarray]], List[np.ndarray]],
-    #     output_shape: Tuple[int, int, int],
-    # ) -> Tuple[np.ndarray, np.ndarray]:
-    #
-    #     for i, tgt in enumerate(target):
-    #         if isinstance(tgt, np.ndarray):
-    #             target[i] = {"words": tgt}
-    #     if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
-    #         raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
-    #     if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for tgt in target for t in tgt.values()
-    #            ):
-    #         raise ValueError("the 'boxes' entry of the target is expected to take values between 0 & 1.")
-    #
-    #     h, w, num_classes = output_shape
-    #     target_shape = (len(target), h, w, num_classes)
-    #
-    #     seg_target: np.ndarray = np.zeros(target_shape, dtype=np.uint8)
-    #     seg_mask: np.ndarray = np.ones(target_shape, dtype=bool)
-    #
-    #     for idx, tgt in enumerate(target):
-    #         for class_idx, _target in enumerate(tgt.values()):
-    #             # Draw each polygon on gt
-    #             if _target.shape[0] == 0:
-    #                 # Empty image, full masked
-    #                 seg_mask[idx, :, :, class_idx] = False
-    #
-    #             # Absolute bounding boxes
-    #             abs_boxes = _target.copy()
-    #
-    #             if abs_boxes.ndim == 3:
-    #                 abs_boxes[:, :, 0] *= w
-    #                 abs_boxes[:, :, 1] *= h
-    #                 polys = abs_boxes
-    #                 boxes_size = np.linalg.norm(abs_boxes[:, 2, :] - abs_boxes[:, 0, :], axis=-1)
-    #                 abs_boxes = np.concatenate((abs_boxes.min(1), abs_boxes.max(1)), -1).round().astype(np.int32)
-    #             else:
-    #                 abs_boxes[:, [0, 2]] *= w
-    #                 abs_boxes[:, [1, 3]] *= h
-    #                 abs_boxes = abs_boxes.round().astype(np.int32)
-    #                 polys = np.stack(
-    #                     [
-    #                         abs_boxes[:, [0, 1]],
-    #                         abs_boxes[:, [0, 3]],
-    #                         abs_boxes[:, [2, 3]],
-    #                         abs_boxes[:, [2, 1]],
-    #                     ],
-    #                     axis=1,
-    #                 )
-    #                 boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
-    #
-    #             for poly, box, box_size in zip(polys, abs_boxes, boxes_size):
-    #                 # Mask boxes that are too small
-    #                 if box_size < self.min_size_box:
-    #                     seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
-    #                     continue
-    #
-    #                 # Negative shrink for gt, as described in paper
-    #                 polygon = Polygon(poly)
-    #                 distance = polygon.area * (1 - np.power(self.shrink_ratio, 2)) / polygon.length
-    #                 subject = [tuple(coor) for coor in poly]
-    #                 padding = pyclipper.PyclipperOffset()
-    #                 padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
-    #                 shrunken = padding.Execute(-distance)
-    #
-    #                 # Draw polygon on gt if it is valid
-    #                 if len(shrunken) == 0:
-    #                     seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
-    #                     continue
-    #                 shrunken = np.array(shrunken[0]).reshape(-1, 2)
-    #                 if shrunken.shape[0] <= 2 or not Polygon(shrunken).is_valid:
-    #                     seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
-    #                     continue
-    #                 cv2.fillPoly(seg_target[idx, :, :, class_idx: class_idx+1].copy(), [shrunken.astype(np.int32)], 1)
-    #
-    #     # Don't forget to switch back to channel first if PyTorch is used
-    #     if not is_tf_available():
-    #         seg_target = seg_target.transpose(0, 3, 1, 2)
-    #         seg_mask = seg_mask.transpose(0, 3, 1, 2)
-    #
-    #     return seg_target, seg_mask
-
     def build_target(
         self,
-        target: List[np.ndarray],
-        output_shape: Tuple[int, int],
+        target: Union[List[Dict[str, np.ndarray]], List[np.ndarray]],
+        output_shape: Tuple[int, int, int],
     ) -> Tuple[np.ndarray, np.ndarray]:
 
-        if any(t.dtype != np.float32 for t in target):
+        for i, tgt in enumerate(target):
+            if isinstance(tgt, np.ndarray):
+                target[i] = {"words": tgt}
+        if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
             raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
-        if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for t in target):
+        if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for tgt in target for t in tgt.values()):
             raise ValueError("the 'boxes' entry of the target is expected to take values between 0 & 1.")
 
-        h, w = output_shape
-        target_shape = (len(target), h, w, 1)
+        h, w, num_classes = output_shape
+        target_shape = (len(target), h, w, num_classes)
 
         seg_target: np.ndarray = np.zeros(target_shape, dtype=np.uint8)
         seg_mask: np.ndarray = np.ones(target_shape, dtype=bool)
 
-        for idx, _target in enumerate(target):
-            # Draw each polygon on gt
-            if _target.shape[0] == 0:
-                # Empty image, full masked
-                seg_mask[idx] = False
+        for idx, tgt in enumerate(target):
+            for class_idx, _target in enumerate(tgt.values()):
+                # Draw each polygon on gt
+                if _target.shape[0] == 0:
+                    # Empty image, full masked
+                    seg_mask[idx, :, :, class_idx] = False
 
-            # Absolute bounding boxes
-            abs_boxes = _target.copy()
+                # Absolute bounding boxes
+                abs_boxes = _target.copy()
 
-            if abs_boxes.ndim == 3:
-                abs_boxes[:, :, 0] *= w
-                abs_boxes[:, :, 1] *= h
-                polys = abs_boxes
-                boxes_size = np.linalg.norm(abs_boxes[:, 2, :] - abs_boxes[:, 0, :], axis=-1)
-                abs_boxes = np.concatenate((abs_boxes.min(1), abs_boxes.max(1)), -1).round().astype(np.int32)
-            else:
-                abs_boxes[:, [0, 2]] *= w
-                abs_boxes[:, [1, 3]] *= h
-                abs_boxes = abs_boxes.round().astype(np.int32)
-                polys = np.stack(
-                    [
-                        abs_boxes[:, [0, 1]],
-                        abs_boxes[:, [0, 3]],
-                        abs_boxes[:, [2, 3]],
-                        abs_boxes[:, [2, 1]],
-                    ],
-                    axis=1,
-                )
-                boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
+                if abs_boxes.ndim == 3:
+                    abs_boxes[:, :, 0] *= w
+                    abs_boxes[:, :, 1] *= h
+                    polys = abs_boxes
+                    boxes_size = np.linalg.norm(abs_boxes[:, 2, :] - abs_boxes[:, 0, :], axis=-1)
+                    abs_boxes = np.concatenate((abs_boxes.min(1), abs_boxes.max(1)), -1).round().astype(np.int32)
+                else:
+                    abs_boxes[:, [0, 2]] *= w
+                    abs_boxes[:, [1, 3]] *= h
+                    abs_boxes = abs_boxes.round().astype(np.int32)
+                    polys = np.stack(
+                        [
+                            abs_boxes[:, [0, 1]],
+                            abs_boxes[:, [0, 3]],
+                            abs_boxes[:, [2, 3]],
+                            abs_boxes[:, [2, 1]],
+                        ],
+                        axis=1,
+                    )
+                    boxes_size = np.minimum(abs_boxes[:, 2] - abs_boxes[:, 0], abs_boxes[:, 3] - abs_boxes[:, 1])
 
-            for poly, box, box_size in zip(polys, abs_boxes, boxes_size):
-                # Mask boxes that are too small
-                if box_size < self.min_size_box:
-                    seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1] = False
-                    continue
+                for poly, box, box_size in zip(polys, abs_boxes, boxes_size):
+                    # Mask boxes that are too small
+                    if box_size < self.min_size_box:
+                        seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
+                        continue
 
-                # Negative shrink for gt, as described in paper
-                polygon = Polygon(poly)
-                distance = polygon.area * (1 - np.power(self.shrink_ratio, 2)) / polygon.length
-                subject = [tuple(coor) for coor in poly]
-                padding = pyclipper.PyclipperOffset()
-                padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
-                shrunken = padding.Execute(-distance)
+                    # Negative shrink for gt, as described in paper
+                    polygon = Polygon(poly)
+                    distance = polygon.area * (1 - np.power(self.shrink_ratio, 2)) / polygon.length
+                    subject = [tuple(coor) for coor in poly]
+                    padding = pyclipper.PyclipperOffset()
+                    padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
+                    shrunken = padding.Execute(-distance)
 
-                # Draw polygon on gt if it is valid
-                if len(shrunken) == 0:
-                    seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1] = False
-                    continue
-                shrunken = np.array(shrunken[0]).reshape(-1, 2)
-                if shrunken.shape[0] <= 2 or not Polygon(shrunken).is_valid:
-                    seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1] = False
-                    continue
-                cv2.fillPoly(seg_target[idx], [shrunken.astype(np.int32)], 1)
+                    # Draw polygon on gt if it is valid
+                    if len(shrunken) == 0:
+                        seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
+                        continue
+                    shrunken = np.array(shrunken[0]).reshape(-1, 2)
+                    if shrunken.shape[0] <= 2 or not Polygon(shrunken).is_valid:
+                        seg_mask[idx, box[1] : box[3] + 1, box[0] : box[2] + 1, class_idx] = False
+                        continue
+                    cv2.fillPoly(seg_target[idx, :, :, class_idx][..., None], [shrunken.astype(np.int32)], 1)
 
         # Don't forget to switch back to channel first if PyTorch is used
         if not is_tf_available():

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -169,13 +169,13 @@ class _LinkNet(BaseModel):
             the new formatted target and the mask
         """
 
-        new_target = []
+        _target = []  # target is converted from List to List[Dict]
         for tgt in target:
             if isinstance(tgt, np.ndarray):
-                new_target.append({CLASS_NAME: tgt})
+                _target.append({CLASS_NAME: tgt})
             else:
-                new_target.append(tgt)
-        target = new_target.copy()
+                _target.append(tgt)
+        target = _target.copy()
         if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
             raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
         if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for tgt in target for t in tgt.values()):
@@ -193,14 +193,14 @@ class _LinkNet(BaseModel):
         seg_mask: np.ndarray = np.ones(target_shape, dtype=bool)
 
         for idx, tgt in enumerate(target):
-            for class_idx, _target in enumerate(tgt.values()):
+            for class_idx, _tgt in enumerate(tgt.values()):
                 # Draw each polygon on gt
-                if _target.shape[0] == 0:
+                if _tgt.shape[0] == 0:
                     # Empty image, full masked
                     seg_mask[idx, class_idx] = False
 
                 # Absolute bounding boxes
-                abs_boxes = _target.copy()
+                abs_boxes = _tgt.copy()
 
                 if abs_boxes.ndim == 3:
                     abs_boxes[:, :, 0] *= w

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -12,7 +12,6 @@ import numpy as np
 import pyclipper
 from shapely.geometry import Polygon
 
-from doctr.file_utils import is_tf_available
 from doctr.models.core import BaseModel
 
 from ..core import DetectionPostProcessor
@@ -158,12 +157,14 @@ class _LinkNet(BaseModel):
         self,
         target: List[Dict[str, np.ndarray]],
         output_shape: Tuple[int, int, int],
+        channels_last: bool = True,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Build the target, and it's mask to be used from loss computation.
 
         Args:
             target: target coming from dataset
             output_shape: shape of the output of the model without batch_size
+            channels_last: whether channels are last or not
 
         Returns:
             the new formatted target and the mask
@@ -176,7 +177,7 @@ class _LinkNet(BaseModel):
 
         h: int
         w: int
-        if is_tf_available():
+        if channels_last:
             h, w, num_classes = output_shape
         else:
             num_classes, h, w = output_shape
@@ -241,7 +242,7 @@ class _LinkNet(BaseModel):
                     cv2.fillPoly(seg_target[idx, class_idx], [shrunken.astype(np.int32)], 1)
 
         # Don't forget to switch back to channel last if Tensorflow is used
-        if is_tf_available():
+        if channels_last:
             seg_target = seg_target.transpose((0, 2, 3, 1))
             seg_mask = seg_mask.transpose((0, 2, 3, 1))
 

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -12,7 +12,7 @@ import numpy as np
 import pyclipper
 from shapely.geometry import Polygon
 
-from doctr.file_utils import CLASS_NAME, is_tf_available
+from doctr.file_utils import is_tf_available
 from doctr.models.core import BaseModel
 
 from ..core import DetectionPostProcessor
@@ -156,7 +156,7 @@ class _LinkNet(BaseModel):
 
     def build_target(
         self,
-        target: Union[List[Dict[str, np.ndarray]], List[np.ndarray]],
+        target: List[Dict[str, np.ndarray]],
         output_shape: Tuple[int, int, int],
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Build the target, and it's mask to be used from loss computation.
@@ -169,13 +169,6 @@ class _LinkNet(BaseModel):
             the new formatted target and the mask
         """
 
-        _target = []  # target is converted from List to List[Dict]
-        for tgt in target:
-            if isinstance(tgt, np.ndarray):
-                _target.append({CLASS_NAME: tgt})
-            else:
-                _target.append(tgt)
-        target = _target.copy()
         if any(t.dtype != np.float32 for tgt in target for t in tgt.values()):
             raise AssertionError("the expected dtype of target 'boxes' entry is 'np.float32'.")
         if any(np.any((t[:, :4] > 1) | (t[:, :4] < 0)) for tgt in target for t in tgt.values()):

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -264,14 +264,11 @@ def _linknet(
         backbone,
         {layer_name: str(idx) for idx, layer_name in enumerate(fpn_layers)},
     )
+    if not kwargs.get("class_names", None):
+        kwargs["class_names"] = default_cfgs[arch].get("class_names", None)
 
     # Build the model
-    model = LinkNet(
-        feat_extractor,
-        cfg=default_cfgs[arch],
-        class_names=default_cfgs[arch].get("class_names", None),
-        **kwargs,
-    )
+    model = LinkNet(feat_extractor, cfg=default_cfgs[arch], **kwargs)
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, default_cfgs[arch]["url"])

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -11,6 +11,7 @@ from torch import nn
 from torch.nn import functional as F
 from torchvision.models._utils import IntermediateLayerGetter
 
+from doctr.file_utils import CLASS_NAME
 from doctr.models.classification import resnet18, resnet34, resnet50
 
 from ...utils import load_pretrained_params
@@ -96,6 +97,7 @@ class LinkNet(nn.Module, _LinkNet):
         assume_straight_pages: if True, fit straight bounding boxes only
         exportable: onnx exportable returns only logits
         cfg: the configuration dict of the model
+        class_names: list of class names
     """
 
     def __init__(
@@ -107,7 +109,7 @@ class LinkNet(nn.Module, _LinkNet):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: List[str] = ["words"],
+        class_names: List[str] = [CLASS_NAME],
     ) -> None:
 
         super().__init__()
@@ -186,7 +188,7 @@ class LinkNet(nn.Module, _LinkNet):
         if target is None or return_preds:
             # Post-process boxes
             out["preds"] = [
-                {class_name: p for class_name, p in zip(self.class_names, preds)}
+                dict(zip(self.class_names, preds))
                 for preds in self.postprocessor(prob_map.detach().cpu().permute((0, 2, 3, 1)).numpy())
             ]
 

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -266,6 +266,8 @@ def _linknet(
     )
     if not kwargs.get("class_names", None):
         kwargs["class_names"] = default_cfgs[arch].get("class_names", None)
+    else:
+        kwargs["class_names"] = sorted(kwargs["class_names"])
 
     # Build the model
     model = LinkNet(feat_extractor, cfg=default_cfgs[arch], **kwargs)

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -107,14 +107,11 @@ class LinkNet(nn.Module, _LinkNet):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: Optional[List[str]] = None,
+        class_names: List[str] = [CLASS_NAME],
     ) -> None:
 
         super().__init__()
-        if class_names:
-            self.class_names = class_names
-        else:
-            self.class_names = [CLASS_NAME]
+        self.class_names = class_names
         num_classes: int = len(self.class_names)
         self.cfg = cfg
         self.exportable = exportable
@@ -219,7 +216,7 @@ class LinkNet(nn.Module, _LinkNet):
         Returns:
             A loss tensor
         """
-        _target, _mask = self.build_target(target, out_map.shape[1:])  # type: ignore[arg-type]
+        _target, _mask = self.build_target(target, out_map.shape[1:], False)  # type: ignore[arg-type]
 
         seg_target, seg_mask = torch.from_numpy(_target).to(dtype=out_map.dtype), torch.from_numpy(_mask)
         seg_target, seg_mask = seg_target.to(out_map.device), seg_mask.to(out_map.device)
@@ -265,7 +262,7 @@ def _linknet(
         {layer_name: str(idx) for idx, layer_name in enumerate(fpn_layers)},
     )
     if not kwargs.get("class_names", None):
-        kwargs["class_names"] = default_cfgs[arch].get("class_names", None)
+        kwargs["class_names"] = default_cfgs[arch].get("class_names", [CLASS_NAME])
     else:
         kwargs["class_names"] = sorted(kwargs["class_names"])
 

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -92,7 +92,6 @@ class LinkNet(nn.Module, _LinkNet):
 
     Args:
         feature extractor: the backbone serving as feature extractor
-        num_classes: number of output channels in the segmentation map
         head_chans: number of channels in the head layers
         assume_straight_pages: if True, fit straight bounding boxes only
         exportable: onnx exportable returns only logits
@@ -103,7 +102,6 @@ class LinkNet(nn.Module, _LinkNet):
     def __init__(
         self,
         feat_extractor: IntermediateLayerGetter,
-        num_classes: int = 1,
         bin_thresh: float = 0.1,
         head_chans: int = 32,
         assume_straight_pages: bool = True,
@@ -114,8 +112,7 @@ class LinkNet(nn.Module, _LinkNet):
 
         super().__init__()
         self.class_names = class_names
-        if cfg and cfg.get("class_names"):
-            self.class_names = cfg["class_names"]
+        num_classes: int = len(self.class_names)
         self.cfg = cfg
         self.exportable = exportable
         self.assume_straight_pages = assume_straight_pages

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -107,11 +107,14 @@ class LinkNet(nn.Module, _LinkNet):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: List[str] = [CLASS_NAME],
+        class_names: Optional[List[str]] = None,
     ) -> None:
 
         super().__init__()
-        self.class_names = class_names
+        if class_names:
+            self.class_names = class_names
+        else:
+            self.class_names = [CLASS_NAME]
         num_classes: int = len(self.class_names)
         self.cfg = cfg
         self.exportable = exportable
@@ -263,7 +266,12 @@ def _linknet(
     )
 
     # Build the model
-    model = LinkNet(feat_extractor, cfg=default_cfgs[arch], **kwargs)
+    model = LinkNet(
+        feat_extractor,
+        cfg=default_cfgs[arch],
+        class_names=default_cfgs[arch].get("class_names", None),
+        **kwargs,
+    )
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, default_cfgs[arch]["url"])

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -170,7 +170,7 @@ class LinkNet(_LinkNet, keras.Model):
     def compute_loss(
         self,
         out_map: tf.Tensor,
-        target: List[np.ndarray],
+        target: List[Dict[str, np.ndarray]],
         gamma: float = 2.0,
         alpha: float = 0.5,
         eps: float = 1e-8,
@@ -217,7 +217,7 @@ class LinkNet(_LinkNet, keras.Model):
     def call(
         self,
         x: tf.Tensor,
-        target: Optional[List[np.ndarray]] = None,
+        target: Optional[List[Dict[str, np.ndarray]]] = None,
         return_model_output: bool = False,
         return_preds: bool = False,
         **kwargs: Any,

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -262,7 +262,8 @@ def _linknet(
     # Patch the config
     _cfg = deepcopy(default_cfgs[arch])
     _cfg["input_shape"] = input_shape or default_cfgs[arch]["input_shape"]
-    class_names = _cfg.get("class_names", None)
+    if not kwargs.get("class_names", None):
+        kwargs["class_names"] = _cfg.get("class_names", None)
 
     # Feature extractor
     feat_extractor = IntermediateLayerGetter(
@@ -275,7 +276,7 @@ def _linknet(
     )
 
     # Build the model
-    model = LinkNet(feat_extractor, cfg=_cfg, class_names=class_names, **kwargs)
+    model = LinkNet(feat_extractor, cfg=_cfg, **kwargs)
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, _cfg["url"])

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -122,11 +122,14 @@ class LinkNet(_LinkNet, keras.Model):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: List[str] = [CLASS_NAME],
+        class_names: Optional[List[str]] = None,
     ) -> None:
         super().__init__(cfg=cfg)
 
-        self.class_names = class_names
+        if class_names:
+            self.class_names = class_names
+        else:
+            self.class_names = [CLASS_NAME]
         num_classes: int = len(self.class_names)
 
         self.exportable = exportable
@@ -259,6 +262,7 @@ def _linknet(
     # Patch the config
     _cfg = deepcopy(default_cfgs[arch])
     _cfg["input_shape"] = input_shape or default_cfgs[arch]["input_shape"]
+    class_names = _cfg.get("class_names", None)
 
     # Feature extractor
     feat_extractor = IntermediateLayerGetter(
@@ -271,7 +275,7 @@ def _linknet(
     )
 
     # Build the model
-    model = LinkNet(feat_extractor, cfg=_cfg, **kwargs)
+    model = LinkNet(feat_extractor, cfg=_cfg, class_names=class_names, **kwargs)
     # Load pretrained parameters
     if pretrained:
         load_pretrained_params(model, _cfg["url"])

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -122,14 +122,11 @@ class LinkNet(_LinkNet, keras.Model):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
-        class_names: Optional[List[str]] = None,
+        class_names: List[str] = [CLASS_NAME],
     ) -> None:
         super().__init__(cfg=cfg)
 
-        if class_names:
-            self.class_names = class_names
-        else:
-            self.class_names = [CLASS_NAME]
+        self.class_names = class_names
         num_classes: int = len(self.class_names)
 
         self.exportable = exportable
@@ -188,7 +185,7 @@ class LinkNet(_LinkNet, keras.Model):
         Returns:
             A loss tensor
         """
-        seg_target, seg_mask = self.build_target(target, out_map.shape[1:])
+        seg_target, seg_mask = self.build_target(target, out_map.shape[1:], True)
         seg_target = tf.convert_to_tensor(seg_target, dtype=out_map.dtype)
         seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
         seg_mask = tf.cast(seg_mask, tf.float32)
@@ -263,7 +260,7 @@ def _linknet(
     _cfg = deepcopy(default_cfgs[arch])
     _cfg["input_shape"] = input_shape or default_cfgs[arch]["input_shape"]
     if not kwargs.get("class_names", None):
-        kwargs["class_names"] = _cfg.get("class_names", None)
+        kwargs["class_names"] = _cfg.get("class_names", [CLASS_NAME])
     else:
         kwargs["class_names"] = sorted(kwargs["class_names"])
 

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -264,6 +264,8 @@ def _linknet(
     _cfg["input_shape"] = input_shape or default_cfgs[arch]["input_shape"]
     if not kwargs.get("class_names", None):
         kwargs["class_names"] = _cfg.get("class_names", None)
+    else:
+        kwargs["class_names"] = sorted(kwargs["class_names"])
 
     # Feature extractor
     feat_extractor = IntermediateLayerGetter(

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -182,6 +182,38 @@ class LinkNet(_LinkNet, keras.Model):
         Returns:
             A loss tensor
         """
+        # seg_target_all, seg_mask_all = self.build_target(target, out_map.shape[1:3])
+        # dice_loss_all = tf.convert_to_tensor(0, dtype=float)
+        # focal_loss_all = tf.convert_to_tensor(0, dtype=float)
+        # for idx in range(seg_target_all.shape[-1]):
+        #     seg_target = seg_target_all[:, :, :, idx][..., None]
+        #     seg_mask = seg_mask_all[:, :, :, idx][..., None]
+        #     _out_map = out_map[:, :, :, idx][..., None]
+        #     seg_target = tf.convert_to_tensor(seg_target, dtype=_out_map.dtype)
+        #     seg_mask = tf.convert_to_tensor(seg_mask, dtype=tf.bool)
+        #     seg_mask = tf.cast(seg_mask, tf.float32)
+        #
+        #     bce_loss = tf.keras.losses.binary_crossentropy(seg_target, _out_map, from_logits=True)[..., None]
+        #     proba_map = tf.sigmoid(_out_map)
+        #
+        #     # Focal loss
+        #     if gamma < 0:
+        #         raise ValueError("Value of gamma should be greater than or equal to zero.")
+        #     # Convert logits to prob, compute gamma factor
+        #     p_t = (seg_target * proba_map) + ((1 - seg_target) * (1 - proba_map))
+        #     alpha_t = seg_target * alpha + (1 - seg_target) * (1 - alpha)
+        #     # Unreduced loss
+        #     focal_loss = alpha_t * (1 - p_t) ** gamma * bce_loss
+        #     # Class reduced
+        #     focal_loss = tf.reduce_sum(seg_mask * focal_loss, (0, 1, 2)) / tf.reduce_sum(seg_mask, (0, 1, 2))
+        #
+        #     # Dice loss
+        #     inter = tf.math.reduce_sum(seg_mask * proba_map * seg_target, (0, 1, 2))
+        #     cardinality = tf.math.reduce_sum(seg_mask * (proba_map + seg_target), (0, 1, 2))
+        #     dice_loss = 1 - 2 * (inter + eps) / (cardinality + eps)
+        #     focal_loss_all += tf.reduce_mean(focal_loss)
+        #     dice_loss_all += tf.reduce_mean(dice_loss)
+        # return focal_loss_all + dice_loss_all
         seg_target, seg_mask = self.build_target(target, out_map.shape[1:3])
 
         seg_target = tf.convert_to_tensor(seg_target, dtype=out_map.dtype)
@@ -234,6 +266,7 @@ class LinkNet(_LinkNet, keras.Model):
 
         if target is None or return_preds:
             # Post-process boxes
+            # out['preds'] = self.postprocessor(prob_map.numpy())
             out["preds"] = [preds[0] for preds in self.postprocessor(prob_map.numpy())]
 
         if target is not None:

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -106,7 +106,6 @@ class LinkNet(_LinkNet, keras.Model):
     Args:
         feature extractor: the backbone serving as feature extractor
         fpn_channels: number of channels each extracted feature maps is mapped to
-        num_classes: number of output channels in the segmentation map
         assume_straight_pages: if True, fit straight bounding boxes only
         exportable: onnx exportable returns only logits
         cfg: the configuration dict of the model
@@ -119,7 +118,6 @@ class LinkNet(_LinkNet, keras.Model):
         self,
         feat_extractor: IntermediateLayerGetter,
         fpn_channels: int = 64,
-        num_classes: int = 1,
         bin_thresh: float = 0.1,
         assume_straight_pages: bool = True,
         exportable: bool = False,
@@ -129,8 +127,7 @@ class LinkNet(_LinkNet, keras.Model):
         super().__init__(cfg=cfg)
 
         self.class_names = class_names
-        if self.cfg and self.cfg.get("class_names"):
-            self.class_names = self.cfg["class_names"]
+        num_classes: int = len(self.class_names)
 
         self.exportable = exportable
         self.assume_straight_pages = assume_straight_pages

--- a/doctr/models/detection/linknet/tensorflow.py
+++ b/doctr/models/detection/linknet/tensorflow.py
@@ -122,8 +122,13 @@ class LinkNet(_LinkNet, keras.Model):
         assume_straight_pages: bool = True,
         exportable: bool = False,
         cfg: Optional[Dict[str, Any]] = None,
+        class_names: List[str] = ["words"],
     ) -> None:
         super().__init__(cfg=cfg)
+
+        self.class_names = class_names
+        if self.cfg and self.cfg.get("class_names"):
+            self.class_names = self.cfg["class_names"]
 
         self.exportable = exportable
         self.assume_straight_pages = assume_straight_pages
@@ -232,8 +237,10 @@ class LinkNet(_LinkNet, keras.Model):
 
         if target is None or return_preds:
             # Post-process boxes
-            out["preds"] = self.postprocessor(prob_map.numpy())
-            # out["preds"] = [preds[0] for preds in self.postprocessor(prob_map.numpy())]
+            out["preds"] = [
+                {class_name: p for class_name, p in zip(self.class_names, preds)}
+                for preds in self.postprocessor(prob_map.numpy())
+            ]
 
         if target is not None:
             loss = self.compute_loss(logits, target)

--- a/doctr/models/detection/predictor/tensorflow.py
+++ b/doctr/models/detection/predictor/tensorflow.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 import numpy as np
 import tensorflow as tf
@@ -38,7 +38,7 @@ class DetectionPredictor(NestedObject):
         self,
         pages: List[Union[np.ndarray, tf.Tensor]],
         **kwargs: Any,
-    ) -> List[np.ndarray]:
+    ) -> List[Dict[str, np.ndarray]]:
 
         # Dimension check
         if any(page.ndim != 3 for page in pages):

--- a/doctr/models/kie_predictor/__init__.py
+++ b/doctr/models/kie_predictor/__init__.py
@@ -1,0 +1,6 @@
+from doctr.file_utils import is_tf_available
+
+if is_tf_available():
+    from .tensorflow import *
+else:
+    from .pytorch import *  # type: ignore[misc]

--- a/doctr/models/kie_predictor/__init__.py
+++ b/doctr/models/kie_predictor/__init__.py
@@ -3,4 +3,4 @@ from doctr.file_utils import is_tf_available
 if is_tf_available():
     from .tensorflow import *
 else:
-    from .pytorch import *  # type: ignore[misc]
+    from .pytorch import *  # type: ignore[assignment]

--- a/doctr/models/kie_predictor/base.py
+++ b/doctr/models/kie_predictor/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022, Mindee.
+# Copyright (C) 2022, Mindee.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.

--- a/doctr/models/kie_predictor/base.py
+++ b/doctr/models/kie_predictor/base.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2021-2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from typing import Any, Optional
+
+from doctr.models.builder import KIEDocumentBuilder
+
+from ..classification.predictor import CropOrientationPredictor
+from ..predictor.base import _OCRPredictor
+
+__all__ = ["_KIEPredictor"]
+
+
+class _KIEPredictor(_OCRPredictor):
+    """Implements an object able to localize and identify text elements in a set of documents
+
+    Args:
+        assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
+            without rotated textual elements.
+        straighten_pages: if True, estimates the page general orientation based on the median line orientation.
+            Then, rotates page before passing it to the deep learning modules. The final predictions will be remapped
+            accordingly. Doing so will improve performances for documents with page-uniform rotations.
+        preserve_aspect_ratio: if True, resize preserving the aspect ratio (with padding)
+        symmetric_pad: if True and preserve_aspect_ratio is True, pas the image symmetrically.
+        kwargs: keyword args of `DocumentBuilder`
+    """
+
+    crop_orientation_predictor: Optional[CropOrientationPredictor]
+
+    def __init__(
+        self,
+        assume_straight_pages: bool = True,
+        straighten_pages: bool = False,
+        preserve_aspect_ratio: bool = True,
+        symmetric_pad: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, **kwargs)
+
+        self.doc_builder: KIEDocumentBuilder = KIEDocumentBuilder(**kwargs)

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022, Mindee.
+# Copyright (C) 2022, Mindee.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -1,0 +1,175 @@
+# Copyright (C) 2021-2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from typing import Any, Dict, List, Union
+
+import numpy as np
+import torch
+from torch import nn
+
+from doctr.io.elements import Document
+from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
+from doctr.models.detection.predictor import DetectionPredictor
+from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.utils.geometry import rotate_boxes, rotate_image
+
+from .base import _KIEPredictor
+
+__all__ = ["KIEPredictor"]
+
+
+class KIEPredictor(nn.Module, _KIEPredictor):
+    """Implements an object able to localize and identify text elements in a set of documents
+
+    Args:
+        det_predictor: detection module
+        reco_predictor: recognition module
+        assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
+            without rotated textual elements.
+        straighten_pages: if True, estimates the page general orientation based on the median line orientation.
+            Then, rotates page before passing it to the deep learning modules. The final predictions will be remapped
+            accordingly. Doing so will improve performances for documents with page-uniform rotations.
+        detect_orientation: if True, the estimated general page orientation will be added to the predictions for each
+            page. Doing so will slightly deteriorate the overall latency.
+        detect_language: if True, the language prediction will be added to the predictions for each
+            page. Doing so will slightly deteriorate the overall latency.
+        kwargs: keyword args of `DocumentBuilder`
+    """
+
+    def __init__(
+        self,
+        det_predictor: DetectionPredictor,
+        reco_predictor: RecognitionPredictor,
+        assume_straight_pages: bool = True,
+        straighten_pages: bool = False,
+        preserve_aspect_ratio: bool = False,
+        symmetric_pad: bool = True,
+        detect_orientation: bool = False,
+        detect_language: bool = False,
+        **kwargs: Any,
+    ) -> None:
+
+        nn.Module.__init__(self)
+        self.det_predictor = det_predictor.eval()  # type: ignore[attr-defined]
+        self.reco_predictor = reco_predictor.eval()  # type: ignore[attr-defined]
+        _KIEPredictor.__init__(
+            self, assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, **kwargs
+        )
+        self.detect_orientation = detect_orientation
+        self.detect_language = detect_language
+
+    @torch.no_grad()
+    def forward(
+        self,
+        pages: List[Union[np.ndarray, torch.Tensor]],
+        **kwargs: Any,
+    ) -> Document:
+
+        # Dimension check
+        if any(page.ndim != 3 for page in pages):
+            raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")
+
+        origin_page_shapes = [page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:] for page in pages]
+
+        # Detect document rotation and rotate pages
+        if self.detect_orientation:
+            origin_page_orientations = [estimate_orientation(page) for page in pages]  # type: ignore[arg-type]
+            orientations = [
+                {"value": orientation_page, "confidence": 1.0} for orientation_page in origin_page_orientations
+            ]
+        else:
+            orientations = None
+        if self.straighten_pages:
+            origin_page_orientations = (
+                origin_page_orientations
+                if self.detect_orientation
+                else [estimate_orientation(page) for page in pages]  # type: ignore[arg-type]
+            )
+            pages = [
+                rotate_image(page, -angle, expand=True)  # type: ignore[arg-type]
+                for page, angle in zip(pages, origin_page_orientations)
+            ]
+
+        # Localize text elements
+        loc_preds = self.det_predictor(pages, **kwargs)
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_data_structure(loc_preds)  # type: ignore[assignment]
+        # Check whether crop mode should be switched to channels first
+        channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
+
+        # Rectify crops if aspect ratio
+        dict_loc_preds = {
+            k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()  # type: ignore[arg-type]
+        }
+
+        # Crop images
+        crops = {}
+        for class_name in dict_loc_preds.keys():
+            crops[class_name], dict_loc_preds[class_name] = self._prepare_crops(
+                pages,  # type: ignore[arg-type]
+                dict_loc_preds[class_name],
+                channels_last=channels_last,
+                assume_straight_pages=self.assume_straight_pages,
+            )
+        # Rectify crop orientation
+        if not self.assume_straight_pages:
+            for class_name in dict_loc_preds.keys():
+                crops[class_name], dict_loc_preds[class_name] = self._rectify_crops(
+                    crops[class_name], dict_loc_preds[class_name]
+                )
+        # Identify character sequences
+        word_preds = {
+            k: self.reco_predictor([crop for page_crops in crop_value for crop in page_crops], **kwargs)
+            for k, crop_value in crops.items()
+        }
+
+        boxes: Dict = {}
+        text_preds: Dict = {}
+        for class_name in dict_loc_preds.keys():
+            boxes[class_name], text_preds[class_name] = self._process_predictions(
+                dict_loc_preds[class_name], word_preds[class_name]
+            )
+
+        boxes_per_page: List[Dict] = invert_data_structure(boxes)  # type: ignore[assignment]
+        text_preds_per_page: List[Dict] = invert_data_structure(text_preds)  # type: ignore[assignment]
+        if self.detect_language:
+            languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
+            languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]
+        else:
+            languages_dict = None
+        # Rotate back pages and boxes while keeping original image size
+        if self.straighten_pages:
+            boxes_per_page = [
+                {
+                    k: rotate_boxes(
+                        page_boxes,
+                        angle,
+                        orig_shape=page.shape[:2]
+                        if isinstance(page, np.ndarray)
+                        else page.shape[1:],  # type: ignore[arg-type]
+                        target_shape=mask,  # type: ignore[arg-type]
+                    )
+                    for k, page_boxes in page_boxes_dict.items()
+                }
+                for page_boxes_dict, page, angle, mask in zip(
+                    boxes_per_page, pages, origin_page_orientations, origin_page_shapes
+                )
+            ]
+
+        out = self.doc_builder(
+            boxes_per_page,
+            text_preds_per_page,
+            [page.shape[:2] if channels_last else page.shape[-2:] for page in pages],  # type: ignore[misc]
+            orientations,
+            languages_dict,
+        )
+        return out
+
+    @staticmethod
+    def get_text(text_pred: Dict) -> str:
+        text = []
+        for value in text_pred.values():
+            text += [item[0] for item in value]
+
+        return " ".join(text)

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022, Mindee.
+# Copyright (C) 2022, Mindee.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -1,0 +1,163 @@
+# Copyright (C) 2021-2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from typing import Any, Dict, List, Union
+
+import numpy as np
+import tensorflow as tf
+
+from doctr.io.elements import Document
+from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
+from doctr.models.detection.predictor import DetectionPredictor
+from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.utils.geometry import rotate_boxes, rotate_image
+from doctr.utils.repr import NestedObject
+
+from .base import _KIEPredictor
+
+__all__ = ["KIEPredictor"]
+
+
+class KIEPredictor(NestedObject, _KIEPredictor):
+    """Implements an object able to localize and identify text elements in a set of documents
+
+    Args:
+        det_predictor: detection module
+        reco_predictor: recognition module
+        assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
+            without rotated textual elements.
+        straighten_pages: if True, estimates the page general orientation based on the median line orientation.
+            Then, rotates page before passing it to the deep learning modules. The final predictions will be remapped
+            accordingly. Doing so will improve performances for documents with page-uniform rotations.
+        detect_orientation: if True, the estimated general page orientation will be added to the predictions for each
+            page. Doing so will slightly deteriorate the overall latency.
+        detect_language: if True, the language prediction will be added to the predictions for each
+            page. Doing so will slightly deteriorate the overall latency.
+        kwargs: keyword args of `DocumentBuilder`
+    """
+
+    _children_names = ["det_predictor", "reco_predictor", "doc_builder"]
+
+    def __init__(
+        self,
+        det_predictor: DetectionPredictor,
+        reco_predictor: RecognitionPredictor,
+        assume_straight_pages: bool = True,
+        straighten_pages: bool = False,
+        preserve_aspect_ratio: bool = False,
+        symmetric_pad: bool = True,
+        detect_orientation: bool = False,
+        detect_language: bool = False,
+        **kwargs: Any,
+    ) -> None:
+
+        self.det_predictor = det_predictor
+        self.reco_predictor = reco_predictor
+        _KIEPredictor.__init__(
+            self, assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, **kwargs
+        )
+        self.detect_orientation = detect_orientation
+        self.detect_language = detect_language
+
+    def __call__(
+        self,
+        pages: List[Union[np.ndarray, tf.Tensor]],
+        **kwargs: Any,
+    ) -> Document:
+
+        # Dimension check
+        if any(page.ndim != 3 for page in pages):
+            raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")
+
+        origin_page_shapes = [page.shape[:2] for page in pages]
+
+        # Detect document rotation and rotate pages
+        if self.detect_orientation:
+            origin_page_orientations = [estimate_orientation(page) for page in pages]
+            orientations = [
+                {"value": orientation_page, "confidence": 1.0} for orientation_page in origin_page_orientations
+            ]
+        else:
+            orientations = None
+        if self.straighten_pages:
+            origin_page_orientations = (
+                origin_page_orientations if self.detect_orientation else [estimate_orientation(page) for page in pages]
+            )
+            pages = [rotate_image(page, -angle, expand=True) for page, angle in zip(pages, origin_page_orientations)]
+
+        # Localize text elements
+        loc_preds = self.det_predictor(pages, **kwargs)
+
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_data_structure(loc_preds)  # type: ignore[assignment]
+        # Rectify crops if aspect ratio
+        dict_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()}
+
+        # Crop images
+        crops = {}
+        for class_name in dict_loc_preds.keys():
+            crops[class_name], dict_loc_preds[class_name] = self._prepare_crops(
+                pages, dict_loc_preds[class_name], channels_last=True, assume_straight_pages=self.assume_straight_pages
+            )
+        # Rectify crop orientation
+        if not self.assume_straight_pages:
+            for class_name in dict_loc_preds.keys():
+                crops[class_name], dict_loc_preds[class_name] = self._rectify_crops(
+                    crops[class_name], dict_loc_preds[class_name]
+                )
+
+        # Identify character sequences
+        word_preds = {
+            k: self.reco_predictor([crop for page_crops in crop_value for crop in page_crops], **kwargs)
+            for k, crop_value in crops.items()
+        }
+
+        boxes: Dict = {}
+        text_preds: Dict = {}
+        for class_name in dict_loc_preds.keys():
+            boxes[class_name], text_preds[class_name] = self._process_predictions(
+                dict_loc_preds[class_name], word_preds[class_name]
+            )
+
+        boxes_per_page: List[Dict] = invert_data_structure(boxes)  # type: ignore[assignment]
+        text_preds_per_page: List[Dict] = invert_data_structure(text_preds)  # type: ignore[assignment]
+
+        if self.detect_language:
+            languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
+            languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]
+        else:
+            languages_dict = None
+        # Rotate back pages and boxes while keeping original image size
+        if self.straighten_pages:
+            boxes_per_page = [
+                {
+                    k: rotate_boxes(
+                        page_boxes,
+                        angle,
+                        orig_shape=page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:],
+                        target_shape=mask,  # type: ignore[arg-type]
+                    )
+                    for k, page_boxes in page_boxes_dict.items()
+                }
+                for page_boxes_dict, page, angle, mask in zip(
+                    boxes_per_page, pages, origin_page_orientations, origin_page_shapes
+                )
+            ]
+
+        out = self.doc_builder(
+            boxes_per_page,
+            text_preds_per_page,
+            origin_page_shapes,  # type: ignore[arg-type]
+            orientations,
+            languages_dict,
+        )
+        return out
+
+    @staticmethod
+    def get_text(text_pred: Dict) -> str:
+        text = []
+        for value in text_pred.values():
+            text += [item[0] for item in value]
+
+        return " ".join(text)

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -3,14 +3,19 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 import numpy as np
 import torch
 from torch import nn
 
 from doctr.io.elements import Document
-from doctr.models._utils import estimate_orientation, get_language
+from doctr.models._utils import (
+    estimate_orientation,
+    get_language,
+    invert_dict_list_to_list_dict,
+    invert_list_dict_to_dict_list,
+)
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.utils.geometry import rotate_boxes, rotate_image
@@ -94,51 +99,82 @@ class OCRPredictor(nn.Module, _OCRPredictor):
 
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_list_dict_to_dict_list(loc_preds)
         # Check whether crop mode should be switched to channels first
         channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
 
         # Rectify crops if aspect ratio
-        loc_preds = self._remove_padding(pages, loc_preds)  # type: ignore[arg-type]
+        dict_loc_preds = {
+            k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()  # type: ignore[arg-type]
+        }
 
         # Crop images
-        crops, loc_preds = self._prepare_crops(
-            pages,  # type: ignore[arg-type]
-            loc_preds,
-            channels_last=channels_last,
-            assume_straight_pages=self.assume_straight_pages,
-        )
+        crops = {}
+        for class_name in dict_loc_preds.keys():
+            crops[class_name], dict_loc_preds[class_name] = self._prepare_crops(
+                pages,  # type: ignore[arg-type]
+                dict_loc_preds[class_name],
+                channels_last=channels_last,
+                assume_straight_pages=self.assume_straight_pages,
+            )
         # Rectify crop orientation
         if not self.assume_straight_pages:
-            crops, loc_preds = self._rectify_crops(crops, loc_preds)
+            for class_name in dict_loc_preds.keys():
+                crops[class_name], dict_loc_preds[class_name] = self._rectify_crops(
+                    crops[class_name], dict_loc_preds[class_name]
+                )
         # Identify character sequences
-        word_preds = self.reco_predictor([crop for page_crops in crops for crop in page_crops], **kwargs)
+        word_preds = {
+            k: self.reco_predictor([crop for page_crops in crop_value for crop in page_crops], **kwargs)
+            for k, crop_value in crops.items()
+        }
 
-        boxes, text_preds = self._process_predictions(loc_preds, word_preds)
+        boxes: Dict = {}
+        text_preds: Dict = {}
+        for class_name in dict_loc_preds.keys():
+            boxes[class_name], text_preds[class_name] = self._process_predictions(
+                dict_loc_preds[class_name], word_preds[class_name]
+            )
 
+        boxes_per_page: List[Dict] = invert_dict_list_to_list_dict(boxes)
+        text_preds_per_page: List[Dict] = invert_dict_list_to_list_dict(text_preds)
         if self.detect_language:
-            languages = [get_language(" ".join([item[0] for item in text_pred])) for text_pred in text_preds]
+            languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
             languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]
         else:
             languages_dict = None
         # Rotate back pages and boxes while keeping original image size
         if self.straighten_pages:
-            boxes = [
-                rotate_boxes(
-                    page_boxes,
-                    angle,
-                    orig_shape=page.shape[:2]
-                    if isinstance(page, np.ndarray)
-                    else page.shape[1:],  # type: ignore[arg-type]
-                    target_shape=mask,  # type: ignore[arg-type]
+            boxes_per_page = [
+                {
+                    k: rotate_boxes(
+                        page_boxes,
+                        angle,
+                        orig_shape=page.shape[:2]
+                        if isinstance(page, np.ndarray)
+                        else page.shape[1:],  # type: ignore[arg-type]
+                        target_shape=mask,  # type: ignore[arg-type]
+                    )
+                    for k, page_boxes in page_boxes_dict.items()
+                }
+                for page_boxes_dict, page, angle, mask in zip(
+                    boxes_per_page, pages, origin_page_orientations, origin_page_shapes
                 )
-                for page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations, origin_page_shapes)
             ]
 
-        out = self.doc_builder.torch_call(
-            boxes,
-            text_preds,
+        out = self.doc_builder(
+            boxes_per_page,
+            text_preds_per_page,
             [page.shape[:2] if channels_last else page.shape[-2:] for page in pages],  # type: ignore[misc]
             orientations,
             languages_dict,
         )
         return out
+
+    @staticmethod
+    def get_text(text_pred: Dict) -> str:
+        text = []
+        for value in text_pred.values():
+            text += [item[0] for item in value]
+
+        return " ".join(text)

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -10,7 +10,7 @@ import torch
 from torch import nn
 
 from doctr.io.elements import Document
-from doctr.models._utils import estimate_orientation, get_language, invert_between_dict_of_lists_and_list_of_dicts
+from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.utils.geometry import rotate_boxes, rotate_image
@@ -94,9 +94,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
 
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
-        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_between_dict_of_lists_and_list_of_dicts(
-            loc_preds
-        )  # type: ignore[assignment]
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_data_structure(loc_preds)  # type: ignore[assignment]
         # Check whether crop mode should be switched to channels first
         channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
 
@@ -133,10 +131,8 @@ class OCRPredictor(nn.Module, _OCRPredictor):
                 dict_loc_preds[class_name], word_preds[class_name]
             )
 
-        boxes_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(boxes)  # type: ignore[assignment]
-        text_preds_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(
-            text_preds
-        )  # type: ignore[assignment]
+        boxes_per_page: List[Dict] = invert_data_structure(boxes)  # type: ignore[assignment]
+        text_preds_per_page: List[Dict] = invert_data_structure(text_preds)  # type: ignore[assignment]
         if self.detect_language:
             languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
             languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -11,10 +11,10 @@ from torch import nn
 
 from doctr.io.elements import Document
 from doctr.models._utils import (
+    convert_dict_list_to_list_dict,
+    convert_list_dict_to_dict_list,
     estimate_orientation,
     get_language,
-    invert_dict_list_to_list_dict,
-    invert_list_dict_to_dict_list,
 )
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
@@ -99,7 +99,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
 
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
-        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_list_dict_to_dict_list(loc_preds)
+        dict_loc_preds: Dict[str, List[np.ndarray]] = convert_list_dict_to_dict_list(loc_preds)
         # Check whether crop mode should be switched to channels first
         channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
 
@@ -136,8 +136,8 @@ class OCRPredictor(nn.Module, _OCRPredictor):
                 dict_loc_preds[class_name], word_preds[class_name]
             )
 
-        boxes_per_page: List[Dict] = invert_dict_list_to_list_dict(boxes)
-        text_preds_per_page: List[Dict] = invert_dict_list_to_list_dict(text_preds)
+        boxes_per_page: List[Dict] = convert_dict_list_to_list_dict(boxes)
+        text_preds_per_page: List[Dict] = convert_dict_list_to_list_dict(text_preds)
         if self.detect_language:
             languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
             languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -10,11 +10,7 @@ import torch
 from torch import nn
 
 from doctr.io.elements import Document
-from doctr.models._utils import (
-    invert_between_dict_of_lists_and_list_of_dicts,
-    estimate_orientation,
-    get_language,
-)
+from doctr.models._utils import estimate_orientation, get_language, invert_between_dict_of_lists_and_list_of_dicts
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.utils.geometry import rotate_boxes, rotate_image
@@ -98,7 +94,9 @@ class OCRPredictor(nn.Module, _OCRPredictor):
 
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
-        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_between_dict_of_lists_and_list_of_dicts(loc_preds)
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_between_dict_of_lists_and_list_of_dicts(
+            loc_preds
+        )  # type: ignore[assignment]
         # Check whether crop mode should be switched to channels first
         channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
 
@@ -135,8 +133,10 @@ class OCRPredictor(nn.Module, _OCRPredictor):
                 dict_loc_preds[class_name], word_preds[class_name]
             )
 
-        boxes_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(boxes)
-        text_preds_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(text_preds)
+        boxes_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(boxes)  # type: ignore[assignment]
+        text_preds_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(
+            text_preds
+        )  # type: ignore[assignment]
         if self.detect_language:
             languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
             languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -134,7 +134,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
                 for page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations, origin_page_shapes)
             ]
 
-        out = self.doc_builder(
+        out = self.doc_builder.torch_call(
             boxes,
             text_preds,
             [page.shape[:2] if channels_last else page.shape[-2:] for page in pages],  # type: ignore[misc]

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -11,8 +11,7 @@ from torch import nn
 
 from doctr.io.elements import Document
 from doctr.models._utils import (
-    convert_dict_list_to_list_dict,
-    convert_list_dict_to_dict_list,
+    invert_between_dict_of_lists_and_list_of_dicts,
     estimate_orientation,
     get_language,
 )
@@ -99,7 +98,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
 
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
-        dict_loc_preds: Dict[str, List[np.ndarray]] = convert_list_dict_to_dict_list(loc_preds)
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_between_dict_of_lists_and_list_of_dicts(loc_preds)
         # Check whether crop mode should be switched to channels first
         channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
 
@@ -136,8 +135,8 @@ class OCRPredictor(nn.Module, _OCRPredictor):
                 dict_loc_preds[class_name], word_preds[class_name]
             )
 
-        boxes_per_page: List[Dict] = convert_dict_list_to_list_dict(boxes)
-        text_preds_per_page: List[Dict] = convert_dict_list_to_list_dict(text_preds)
+        boxes_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(boxes)
+        text_preds_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(text_preds)
         if self.detect_language:
             languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
             languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -3,14 +3,14 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 import numpy as np
 import torch
 from torch import nn
 
 from doctr.io.elements import Document
-from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
+from doctr.models._utils import estimate_orientation, get_language
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.utils.geometry import rotate_boxes, rotate_image
@@ -94,82 +94,56 @@ class OCRPredictor(nn.Module, _OCRPredictor):
 
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
-        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_data_structure(loc_preds)  # type: ignore[assignment]
+        assert all(
+            len(loc_pred) == 1 for loc_pred in loc_preds
+        ), "Detection Model in ocr_predictor should output only one class"
+
+        loc_preds = [list(loc_pred.values())[0] for loc_pred in loc_preds]
         # Check whether crop mode should be switched to channels first
         channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
 
         # Rectify crops if aspect ratio
-        dict_loc_preds = {
-            k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()  # type: ignore[arg-type]
-        }
+        loc_preds = self._remove_padding(pages, loc_preds)  # type: ignore[arg-type]
 
         # Crop images
-        crops = {}
-        for class_name in dict_loc_preds.keys():
-            crops[class_name], dict_loc_preds[class_name] = self._prepare_crops(
-                pages,  # type: ignore[arg-type]
-                dict_loc_preds[class_name],
-                channels_last=channels_last,
-                assume_straight_pages=self.assume_straight_pages,
-            )
+        crops, loc_preds = self._prepare_crops(
+            pages,  # type: ignore[arg-type]
+            loc_preds,
+            channels_last=channels_last,
+            assume_straight_pages=self.assume_straight_pages,
+        )
         # Rectify crop orientation
         if not self.assume_straight_pages:
-            for class_name in dict_loc_preds.keys():
-                crops[class_name], dict_loc_preds[class_name] = self._rectify_crops(
-                    crops[class_name], dict_loc_preds[class_name]
-                )
+            crops, loc_preds = self._rectify_crops(crops, loc_preds)
         # Identify character sequences
-        word_preds = {
-            k: self.reco_predictor([crop for page_crops in crop_value for crop in page_crops], **kwargs)
-            for k, crop_value in crops.items()
-        }
+        word_preds = self.reco_predictor([crop for page_crops in crops for crop in page_crops], **kwargs)
 
-        boxes: Dict = {}
-        text_preds: Dict = {}
-        for class_name in dict_loc_preds.keys():
-            boxes[class_name], text_preds[class_name] = self._process_predictions(
-                dict_loc_preds[class_name], word_preds[class_name]
-            )
+        boxes, text_preds = self._process_predictions(loc_preds, word_preds)
 
-        boxes_per_page: List[Dict] = invert_data_structure(boxes)  # type: ignore[assignment]
-        text_preds_per_page: List[Dict] = invert_data_structure(text_preds)  # type: ignore[assignment]
         if self.detect_language:
-            languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
+            languages = [get_language(" ".join([item[0] for item in text_pred])) for text_pred in text_preds]
             languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]
         else:
             languages_dict = None
         # Rotate back pages and boxes while keeping original image size
         if self.straighten_pages:
-            boxes_per_page = [
-                {
-                    k: rotate_boxes(
-                        page_boxes,
-                        angle,
-                        orig_shape=page.shape[:2]
-                        if isinstance(page, np.ndarray)
-                        else page.shape[1:],  # type: ignore[arg-type]
-                        target_shape=mask,  # type: ignore[arg-type]
-                    )
-                    for k, page_boxes in page_boxes_dict.items()
-                }
-                for page_boxes_dict, page, angle, mask in zip(
-                    boxes_per_page, pages, origin_page_orientations, origin_page_shapes
+            boxes = [
+                rotate_boxes(
+                    page_boxes,
+                    angle,
+                    orig_shape=page.shape[:2]
+                    if isinstance(page, np.ndarray)
+                    else page.shape[1:],  # type: ignore[arg-type]
+                    target_shape=mask,  # type: ignore[arg-type]
                 )
+                for page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations, origin_page_shapes)
             ]
 
         out = self.doc_builder(
-            boxes_per_page,
-            text_preds_per_page,
+            boxes,
+            text_preds,
             [page.shape[:2] if channels_last else page.shape[-2:] for page in pages],  # type: ignore[misc]
             orientations,
             languages_dict,
         )
         return out
-
-    @staticmethod
-    def get_text(text_pred: Dict) -> str:
-        text = []
-        for value in text_pred.values():
-            text += [item[0] for item in value]
-
-        return " ".join(text)

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -9,11 +9,7 @@ import numpy as np
 import tensorflow as tf
 
 from doctr.io.elements import Document
-from doctr.models._utils import (
-    invert_between_dict_of_lists_and_list_of_dicts,
-    estimate_orientation,
-    get_language,
-)
+from doctr.models._utils import estimate_orientation, get_language, invert_between_dict_of_lists_and_list_of_dicts
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.utils.geometry import rotate_boxes, rotate_image
@@ -94,7 +90,9 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
 
-        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_between_dict_of_lists_and_list_of_dicts(loc_preds)
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_between_dict_of_lists_and_list_of_dicts(
+            loc_preds
+        )  # type: ignore[assignment]
         # Rectify crops if aspect ratio
         dict_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()}
 
@@ -124,8 +122,10 @@ class OCRPredictor(NestedObject, _OCRPredictor):
                 dict_loc_preds[class_name], word_preds[class_name]
             )
 
-        boxes_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(boxes)
-        text_preds_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(text_preds)
+        boxes_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(boxes)  # type: ignore[assignment]
+        text_preds_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(
+            text_preds
+        )  # type: ignore[assignment]
 
         if self.detect_language:
             languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 import numpy as np
 import tensorflow as tf
@@ -90,44 +90,80 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
 
+        new_loc_preds: Dict[str, List[np.ndarray]] = {k: [] for k in loc_preds[0].keys()}
+        for loc_pred in loc_preds:
+            for k, v in loc_pred.items():
+                new_loc_preds[k].append(v)
         # Rectify crops if aspect ratio
-        loc_preds = self._remove_padding(pages, loc_preds)
+        new_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in new_loc_preds.items()}
 
         # Crop images
-        crops, loc_preds = self._prepare_crops(
-            pages, loc_preds, channels_last=True, assume_straight_pages=self.assume_straight_pages
-        )
+        crops = {}
+        for class_name in new_loc_preds.keys():
+            crops[class_name], new_loc_preds[class_name] = self._prepare_crops(
+                pages, new_loc_preds[class_name], channels_last=True, assume_straight_pages=self.assume_straight_pages
+            )
         # Rectify crop orientation
         if not self.assume_straight_pages:
-            crops, loc_preds = self._rectify_crops(crops, loc_preds)
+            for class_name in new_loc_preds.keys():
+                crops[class_name], new_loc_preds[class_name] = self._rectify_crops(
+                    crops[class_name], new_loc_preds[class_name]
+                )
 
         # Identify character sequences
-        word_preds = self.reco_predictor([crop for page_crops in crops for crop in page_crops], **kwargs)
+        word_preds = {
+            k: self.reco_predictor([crop for page_crops in crop_value for crop in page_crops], **kwargs)
+            for k, crop_value in crops.items()
+        }
 
-        boxes, text_preds = self._process_predictions(loc_preds, word_preds)
+        boxes = {}
+        text_preds = {}
+        for class_name in new_loc_preds.keys():
+            boxes[class_name], text_preds[class_name] = self._process_predictions(
+                new_loc_preds[class_name], word_preds[class_name]
+            )
+
+        boxes_per_page: List[Dict] = []
+        text_preds_per_page: List[Dict] = []
+        for i in range(len(pages)):
+            boxes_per_page.append({k: v[i] for k, v in boxes.items()})
+            text_preds_per_page.append({k: v[i] for k, v in text_preds.items()})
 
         if self.detect_language:
-            languages = [get_language(" ".join([item[0] for item in text_pred])) for text_pred in text_preds]
+            languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
             languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]
         else:
             languages_dict = None
         # Rotate back pages and boxes while keeping original image size
         if self.straighten_pages:
-            boxes = [
-                rotate_boxes(
-                    page_boxes,
-                    angle,
-                    orig_shape=page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:],
-                    target_shape=mask,  # type: ignore[arg-type]
+            boxes_per_page = [
+                {
+                    k: rotate_boxes(
+                        page_boxes,
+                        angle,
+                        orig_shape=page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:],
+                        target_shape=mask,  # type: ignore[arg-type]
+                    )
+                    for k, page_boxes in page_boxes_dict.items()
+                }
+                for page_boxes_dict, page, angle, mask in zip(
+                    boxes_per_page, pages, origin_page_orientations, origin_page_shapes
                 )
-                for page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations, origin_page_shapes)
             ]
 
-        out = self.doc_builder(
-            boxes,
-            text_preds,
+        out = self.doc_builder.tf_call(
+            boxes_per_page,
+            text_preds_per_page,
             origin_page_shapes,  # type: ignore[arg-type]
             orientations,
             languages_dict,
         )
         return out
+
+    @staticmethod
+    def get_text(text_pred: Dict) -> str:
+        text = []
+        for value in text_pred.values():
+            text += [item[0] for item in value]
+
+        return " ".join(text)

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -10,8 +10,7 @@ import tensorflow as tf
 
 from doctr.io.elements import Document
 from doctr.models._utils import (
-    convert_dict_list_to_list_dict,
-    convert_list_dict_to_dict_list,
+    invert_between_dict_of_lists_and_list_of_dicts,
     estimate_orientation,
     get_language,
 )
@@ -95,7 +94,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
 
-        dict_loc_preds: Dict[str, List[np.ndarray]] = convert_list_dict_to_dict_list(loc_preds)
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_between_dict_of_lists_and_list_of_dicts(loc_preds)
         # Rectify crops if aspect ratio
         dict_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()}
 
@@ -125,8 +124,8 @@ class OCRPredictor(NestedObject, _OCRPredictor):
                 dict_loc_preds[class_name], word_preds[class_name]
             )
 
-        boxes_per_page: List[Dict] = convert_dict_list_to_list_dict(boxes)
-        text_preds_per_page: List[Dict] = convert_dict_list_to_list_dict(text_preds)
+        boxes_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(boxes)
+        text_preds_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(text_preds)
 
         if self.detect_language:
             languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -3,13 +3,13 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 import numpy as np
 import tensorflow as tf
 
 from doctr.io.elements import Document
-from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
+from doctr.models._utils import estimate_orientation, get_language
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.utils.geometry import rotate_boxes, rotate_image
@@ -88,76 +88,51 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             pages = [rotate_image(page, -angle, expand=True) for page, angle in zip(pages, origin_page_orientations)]
 
         # Localize text elements
-        loc_preds = self.det_predictor(pages, **kwargs)
+        loc_preds_dict = self.det_predictor(pages, **kwargs)
+        assert all(
+            len(loc_pred) == 1 for loc_pred in loc_preds_dict
+        ), "Detection Model in ocr_predictor should output only one class"
 
-        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_data_structure(loc_preds)  # type: ignore[assignment]
+        loc_preds: List[np.ndarray] = [list(loc_pred.values())[0] for loc_pred in loc_preds_dict]
+
         # Rectify crops if aspect ratio
-        dict_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()}
+        loc_preds = self._remove_padding(pages, loc_preds)
 
         # Crop images
-        crops = {}
-        for class_name in dict_loc_preds.keys():
-            crops[class_name], dict_loc_preds[class_name] = self._prepare_crops(
-                pages, dict_loc_preds[class_name], channels_last=True, assume_straight_pages=self.assume_straight_pages
-            )
+        crops, loc_preds = self._prepare_crops(
+            pages, loc_preds, channels_last=True, assume_straight_pages=self.assume_straight_pages
+        )
         # Rectify crop orientation
         if not self.assume_straight_pages:
-            for class_name in dict_loc_preds.keys():
-                crops[class_name], dict_loc_preds[class_name] = self._rectify_crops(
-                    crops[class_name], dict_loc_preds[class_name]
-                )
+            crops, loc_preds = self._rectify_crops(crops, loc_preds)
 
         # Identify character sequences
-        word_preds = {
-            k: self.reco_predictor([crop for page_crops in crop_value for crop in page_crops], **kwargs)
-            for k, crop_value in crops.items()
-        }
+        word_preds = self.reco_predictor([crop for page_crops in crops for crop in page_crops], **kwargs)
 
-        boxes: Dict = {}
-        text_preds: Dict = {}
-        for class_name in dict_loc_preds.keys():
-            boxes[class_name], text_preds[class_name] = self._process_predictions(
-                dict_loc_preds[class_name], word_preds[class_name]
-            )
-
-        boxes_per_page: List[Dict] = invert_data_structure(boxes)  # type: ignore[assignment]
-        text_preds_per_page: List[Dict] = invert_data_structure(text_preds)  # type: ignore[assignment]
+        boxes, text_preds = self._process_predictions(loc_preds, word_preds)
 
         if self.detect_language:
-            languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]
+            languages = [get_language(" ".join([item[0] for item in text_pred])) for text_pred in text_preds]
             languages_dict = [{"value": lang[0], "confidence": lang[1]} for lang in languages]
         else:
             languages_dict = None
         # Rotate back pages and boxes while keeping original image size
         if self.straighten_pages:
-            boxes_per_page = [
-                {
-                    k: rotate_boxes(
-                        page_boxes,
-                        angle,
-                        orig_shape=page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:],
-                        target_shape=mask,  # type: ignore[arg-type]
-                    )
-                    for k, page_boxes in page_boxes_dict.items()
-                }
-                for page_boxes_dict, page, angle, mask in zip(
-                    boxes_per_page, pages, origin_page_orientations, origin_page_shapes
+            boxes = [
+                rotate_boxes(
+                    page_boxes,
+                    angle,
+                    orig_shape=page.shape[:2] if isinstance(page, np.ndarray) else page.shape[-2:],
+                    target_shape=mask,  # type: ignore[arg-type]
                 )
+                for page_boxes, page, angle, mask in zip(boxes, pages, origin_page_orientations, origin_page_shapes)
             ]
 
         out = self.doc_builder(
-            boxes_per_page,
-            text_preds_per_page,
+            boxes,
+            text_preds,
             origin_page_shapes,  # type: ignore[arg-type]
             orientations,
             languages_dict,
         )
         return out
-
-    @staticmethod
-    def get_text(text_pred: Dict) -> str:
-        text = []
-        for value in text_pred.values():
-            text += [item[0] for item in value]
-
-        return " ".join(text)

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -10,10 +10,10 @@ import tensorflow as tf
 
 from doctr.io.elements import Document
 from doctr.models._utils import (
+    convert_dict_list_to_list_dict,
+    convert_list_dict_to_dict_list,
     estimate_orientation,
     get_language,
-    invert_dict_list_to_list_dict,
-    invert_list_dict_to_dict_list,
 )
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
@@ -95,7 +95,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
 
-        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_list_dict_to_dict_list(loc_preds)
+        dict_loc_preds: Dict[str, List[np.ndarray]] = convert_list_dict_to_dict_list(loc_preds)
         # Rectify crops if aspect ratio
         dict_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()}
 
@@ -125,8 +125,8 @@ class OCRPredictor(NestedObject, _OCRPredictor):
                 dict_loc_preds[class_name], word_preds[class_name]
             )
 
-        boxes_per_page: List[Dict] = invert_dict_list_to_list_dict(boxes)
-        text_preds_per_page: List[Dict] = invert_dict_list_to_list_dict(text_preds)
+        boxes_per_page: List[Dict] = convert_dict_list_to_list_dict(boxes)
+        text_preds_per_page: List[Dict] = convert_dict_list_to_list_dict(text_preds)
 
         if self.detect_language:
             languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -9,7 +9,7 @@ import numpy as np
 import tensorflow as tf
 
 from doctr.io.elements import Document
-from doctr.models._utils import estimate_orientation, get_language, invert_between_dict_of_lists_and_list_of_dicts
+from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
 from doctr.utils.geometry import rotate_boxes, rotate_image
@@ -90,9 +90,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         # Localize text elements
         loc_preds = self.det_predictor(pages, **kwargs)
 
-        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_between_dict_of_lists_and_list_of_dicts(
-            loc_preds
-        )  # type: ignore[assignment]
+        dict_loc_preds: Dict[str, List[np.ndarray]] = invert_data_structure(loc_preds)  # type: ignore[assignment]
         # Rectify crops if aspect ratio
         dict_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()}
 
@@ -122,10 +120,8 @@ class OCRPredictor(NestedObject, _OCRPredictor):
                 dict_loc_preds[class_name], word_preds[class_name]
             )
 
-        boxes_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(boxes)  # type: ignore[assignment]
-        text_preds_per_page: List[Dict] = invert_between_dict_of_lists_and_list_of_dicts(
-            text_preds
-        )  # type: ignore[assignment]
+        boxes_per_page: List[Dict] = invert_data_structure(boxes)  # type: ignore[assignment]
+        text_preds_per_page: List[Dict] = invert_data_structure(text_preds)  # type: ignore[assignment]
 
         if self.detect_language:
             languages = [get_language(self.get_text(text_pred)) for text_pred in text_preds_per_page]

--- a/doctr/models/zoo.py
+++ b/doctr/models/zoo.py
@@ -6,10 +6,11 @@
 from typing import Any
 
 from .detection.zoo import detection_predictor
+from .kie_predictor import KIEPredictor
 from .predictor import OCRPredictor
 from .recognition.zoo import recognition_predictor
 
-__all__ = ["ocr_predictor"]
+__all__ = ["ocr_predictor", "kie_predictor"]
 
 
 def _predictor(
@@ -101,6 +102,109 @@ def ocr_predictor(
     """
 
     return _predictor(
+        det_arch,
+        reco_arch,
+        pretrained,
+        pretrained_backbone=pretrained_backbone,
+        assume_straight_pages=assume_straight_pages,
+        preserve_aspect_ratio=preserve_aspect_ratio,
+        symmetric_pad=symmetric_pad,
+        export_as_straight_boxes=export_as_straight_boxes,
+        detect_orientation=detect_orientation,
+        detect_language=detect_language,
+        **kwargs,
+    )
+
+
+def _kie_predictor(
+    det_arch: Any,
+    reco_arch: Any,
+    pretrained: bool,
+    pretrained_backbone: bool = True,
+    assume_straight_pages: bool = True,
+    preserve_aspect_ratio: bool = False,
+    symmetric_pad: bool = True,
+    det_bs: int = 2,
+    reco_bs: int = 128,
+    detect_orientation: bool = False,
+    detect_language: bool = False,
+    **kwargs,
+) -> KIEPredictor:
+
+    # Detection
+    det_predictor = detection_predictor(
+        det_arch,
+        pretrained=pretrained,
+        pretrained_backbone=pretrained_backbone,
+        batch_size=det_bs,
+        assume_straight_pages=assume_straight_pages,
+        preserve_aspect_ratio=preserve_aspect_ratio,
+        symmetric_pad=symmetric_pad,
+    )
+
+    # Recognition
+    reco_predictor = recognition_predictor(
+        reco_arch, pretrained=pretrained, pretrained_backbone=pretrained_backbone, batch_size=reco_bs
+    )
+
+    return KIEPredictor(
+        det_predictor,
+        reco_predictor,
+        assume_straight_pages=assume_straight_pages,
+        preserve_aspect_ratio=preserve_aspect_ratio,
+        symmetric_pad=symmetric_pad,
+        detect_orientation=detect_orientation,
+        detect_language=detect_language,
+        **kwargs,
+    )
+
+
+def kie_predictor(
+    det_arch: Any = "db_resnet50",
+    reco_arch: Any = "crnn_vgg16_bn",
+    pretrained: bool = False,
+    pretrained_backbone: bool = True,
+    assume_straight_pages: bool = True,
+    preserve_aspect_ratio: bool = False,
+    symmetric_pad: bool = True,
+    export_as_straight_boxes: bool = False,
+    detect_orientation: bool = False,
+    detect_language: bool = False,
+    **kwargs: Any,
+) -> KIEPredictor:
+    """End-to-end KIE architecture using one model for localization, and another for text recognition.
+
+    >>> import numpy as np
+    >>> from doctr.models import ocr_predictor
+    >>> model = ocr_predictor('db_resnet50', 'crnn_vgg16_bn', pretrained=True)
+    >>> input_page = (255 * np.random.rand(600, 800, 3)).astype(np.uint8)
+    >>> out = model([input_page])
+
+    Args:
+        det_arch: name of the detection architecture or the model itself to use
+            (e.g. 'db_resnet50', 'db_mobilenet_v3_large')
+        reco_arch: name of the recognition architecture or the model itself to use
+            (e.g. 'crnn_vgg16_bn', 'sar_resnet31')
+        pretrained: If True, returns a model pre-trained on our OCR dataset
+        pretrained_backbone: If True, returns a model with a pretrained backbone
+        assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
+            without rotated textual elements.
+        preserve_aspect_ratio: If True, pad the input document image to preserve the aspect ratio before
+            running the detection model on it.
+        symmetric_pad: if True, pad the image symmetrically instead of padding at the bottom-right.
+        export_as_straight_boxes: when assume_straight_pages is set to False, export final predictions
+            (potentially rotated) as straight bounding boxes.
+        detect_orientation: if True, the estimated general page orientation will be added to the predictions for each
+            page. Doing so will slightly deteriorate the overall latency.
+        detect_language: if True, the language prediction will be added to the predictions for each
+            page. Doing so will slightly deteriorate the overall latency.
+        kwargs: keyword args of `OCRPredictor`
+
+    Returns:
+        KIE predictor
+    """
+
+    return _kie_predictor(
         det_arch,
         reco_arch,
         pretrained,

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -20,6 +20,8 @@ from .fonts import get_font
 
 __all__ = ["visualize_page", "synthesize_page", "draw_boxes"]
 
+from ..file_utils import CLASS_NAME
+
 
 def rect_patch(
     geometry: BoundingBox,
@@ -183,7 +185,7 @@ def visualize_page(
         artists: List[patches.Patch] = []  # instantiate an empty list of patches (to be drawn on the page)
 
     if isinstance(page["blocks"], list):
-        page["blocks"] = {"words": page["blocks"]}
+        page["blocks"] = {CLASS_NAME: page["blocks"]}
 
     for key, value in page["blocks"].items():
         for block in value:

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -141,7 +141,7 @@ def create_obj_patch(
     raise ValueError("invalid geometry format")
 
 
-def get_colors(num_colors: int) -> List:
+def get_colors(num_colors: int) -> List[Tuple[float, float, float]]:
     """Generate num_colors color for matplotlib
 
     Args:

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -2,7 +2,7 @@
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
-
+import colorsys
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -141,6 +141,24 @@ def create_obj_patch(
     raise ValueError("invalid geometry format")
 
 
+def get_colors(num_colors: int) -> List:
+    """Generate num_colors color for matplotlib
+
+    Args:
+        num_colors: number of colors to generate
+
+    Returns:
+        colors: list of generated colors
+    """
+    colors = []
+    for i in np.arange(0.0, 360.0, 360.0 / num_colors):
+        hue = i / 360.0
+        lightness = (50 + np.random.rand() * 10) / 100.0
+        saturation = (90 + np.random.rand() * 10) / 100.0
+        colors.append(colorsys.hls_to_rgb(hue, lightness, saturation))
+    return colors
+
+
 def visualize_page(
     page: Dict[str, Any],
     image: np.ndarray,
@@ -187,11 +205,17 @@ def visualize_page(
     if isinstance(page["blocks"], list):
         page["blocks"] = {CLASS_NAME: page["blocks"]}
 
+    colors = {k: color for color, k in zip(get_colors(len(page["blocks"])), page["blocks"])}
     for key, value in page["blocks"].items():
         for block in value:
             if not words_only:
                 rect = create_obj_patch(
-                    block["geometry"], page["dimensions"], label=f"block_{key}", linewidth=1, **kwargs
+                    block["geometry"],
+                    page["dimensions"],
+                    label=f"block_{key}",
+                    color=colors[key],
+                    linewidth=1,
+                    **kwargs,
                 )
                 # add patch on figure
                 ax.add_patch(rect)

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -182,72 +182,76 @@ def visualize_page(
     if interactive:
         artists: List[patches.Patch] = []  # instantiate an empty list of patches (to be drawn on the page)
 
-    for block in page["blocks"]:
-        if not words_only:
-            rect = create_obj_patch(
-                block["geometry"], page["dimensions"], label="block", color=(0, 1, 0), linewidth=1, **kwargs
-            )
-            # add patch on figure
-            ax.add_patch(rect)
-            if interactive:
-                # add patch to cursor's artists
-                artists.append(rect)
+    if isinstance(page["blocks"], list):
+        page["blocks"] = {"words": page["blocks"]}
 
-        for line in block["lines"]:
+    for key, value in page["blocks"].items():
+        for block in value:
             if not words_only:
                 rect = create_obj_patch(
-                    line["geometry"], page["dimensions"], label="line", color=(1, 0, 0), linewidth=1, **kwargs
+                    block["geometry"], page["dimensions"], label=f"block_{key}", linewidth=1, **kwargs
                 )
+                # add patch on figure
                 ax.add_patch(rect)
                 if interactive:
+                    # add patch to cursor's artists
                     artists.append(rect)
 
-            for word in line["words"]:
-                rect = create_obj_patch(
-                    word["geometry"],
-                    page["dimensions"],
-                    label=f"{word['value']} (confidence: {word['confidence']:.2%})",
-                    color=(0, 0, 1),
-                    **kwargs,
-                )
-                ax.add_patch(rect)
-                if interactive:
-                    artists.append(rect)
-                elif add_labels:
-                    if len(word["geometry"]) == 5:
-                        text_loc = (
-                            int(page["dimensions"][1] * (word["geometry"][0] - word["geometry"][2] / 2)),
-                            int(page["dimensions"][0] * (word["geometry"][1] - word["geometry"][3] / 2)),
-                        )
-                    else:
-                        text_loc = (
-                            int(page["dimensions"][1] * word["geometry"][0][0]),
-                            int(page["dimensions"][0] * word["geometry"][0][1]),
-                        )
+            for line in block["lines"]:
+                if not words_only:
+                    rect = create_obj_patch(
+                        line["geometry"], page["dimensions"], label="line", color=(1, 0, 0), linewidth=1, **kwargs
+                    )
+                    ax.add_patch(rect)
+                    if interactive:
+                        artists.append(rect)
 
-                    if len(word["geometry"]) == 2:
-                        # We draw only if boxes are in straight format
-                        ax.text(
-                            *text_loc,
-                            word["value"],
-                            size=10,
-                            alpha=0.5,
-                            color=(0, 0, 1),
-                        )
+                for word in line["words"]:
+                    rect = create_obj_patch(
+                        word["geometry"],
+                        page["dimensions"],
+                        label=f"{word['value']} (confidence: {word['confidence']:.2%})",
+                        color=(0, 0, 1),
+                        **kwargs,
+                    )
+                    ax.add_patch(rect)
+                    if interactive:
+                        artists.append(rect)
+                    elif add_labels:
+                        if len(word["geometry"]) == 5:
+                            text_loc = (
+                                int(page["dimensions"][1] * (word["geometry"][0] - word["geometry"][2] / 2)),
+                                int(page["dimensions"][0] * (word["geometry"][1] - word["geometry"][3] / 2)),
+                            )
+                        else:
+                            text_loc = (
+                                int(page["dimensions"][1] * word["geometry"][0][0]),
+                                int(page["dimensions"][0] * word["geometry"][0][1]),
+                            )
 
-        if display_artefacts:
-            for artefact in block["artefacts"]:
-                rect = create_obj_patch(
-                    artefact["geometry"],
-                    page["dimensions"],
-                    label="artefact",
-                    color=(0.5, 0.5, 0.5),
-                    linewidth=1,
-                    **kwargs,
-                )
-                ax.add_patch(rect)
-                if interactive:
-                    artists.append(rect)
+                        if len(word["geometry"]) == 2:
+                            # We draw only if boxes are in straight format
+                            ax.text(
+                                *text_loc,
+                                word["value"],
+                                size=10,
+                                alpha=0.5,
+                                color=(0, 0, 1),
+                            )
+
+            if display_artefacts:
+                for artefact in block["artefacts"]:
+                    rect = create_obj_patch(
+                        artefact["geometry"],
+                        page["dimensions"],
+                        label="artefact",
+                        color=(0.5, 0.5, 0.5),
+                        linewidth=1,
+                        **kwargs,
+                    )
+                    ax.add_patch(rect)
+                    if interactive:
+                        artists.append(rect)
 
     if interactive:
         # Create mlp Cursor to hover patches in artists

--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -283,36 +283,37 @@ def synthesize_page(
     response = 255 * np.ones((h, w, 3), dtype=np.int32)
 
     # Draw each word
-    for block in page["blocks"]:
-        for line in block["lines"]:
-            for word in line["words"]:
-                # Get aboslute word geometry
-                (xmin, ymin), (xmax, ymax) = word["geometry"]
-                xmin, xmax = int(round(w * xmin)), int(round(w * xmax))
-                ymin, ymax = int(round(h * ymin)), int(round(h * ymax))
+    for blocks in page["blocks"].values():
+        for block in blocks:
+            for line in block["lines"]:
+                for word in line["words"]:
+                    # Get aboslute word geometry
+                    (xmin, ymin), (xmax, ymax) = word["geometry"]
+                    xmin, xmax = int(round(w * xmin)), int(round(w * xmax))
+                    ymin, ymax = int(round(h * ymin)), int(round(h * ymax))
 
-                # White drawing context adapted to font size, 0.75 factor to convert pts --> pix
-                font = get_font(font_family, int(0.75 * (ymax - ymin)))
-                img = Image.new("RGB", (xmax - xmin, ymax - ymin), color=(255, 255, 255))
-                d = ImageDraw.Draw(img)
-                # Draw in black the value of the word
-                try:
-                    d.text((0, 0), word["value"], font=font, fill=(0, 0, 0))
-                except UnicodeEncodeError:
-                    # When character cannot be encoded, use its unidecode version
-                    d.text((0, 0), unidecode(word["value"]), font=font, fill=(0, 0, 0))
+                    # White drawing context adapted to font size, 0.75 factor to convert pts --> pix
+                    font = get_font(font_family, int(0.75 * (ymax - ymin)))
+                    img = Image.new("RGB", (xmax - xmin, ymax - ymin), color=(255, 255, 255))
+                    d = ImageDraw.Draw(img)
+                    # Draw in black the value of the word
+                    try:
+                        d.text((0, 0), word["value"], font=font, fill=(0, 0, 0))
+                    except UnicodeEncodeError:
+                        # When character cannot be encoded, use its unidecode version
+                        d.text((0, 0), unidecode(word["value"]), font=font, fill=(0, 0, 0))
 
-                # Colorize if draw_proba
-                if draw_proba:
-                    p = int(255 * word["confidence"])
-                    mask = np.where(np.array(img) == 0, 1, 0)
-                    proba: np.ndarray = np.array([255 - p, 0, p])
-                    color = mask * proba[np.newaxis, np.newaxis, :]
-                    white_mask = 255 * (1 - mask)
-                    img = color + white_mask
+                    # Colorize if draw_proba
+                    if draw_proba:
+                        p = int(255 * word["confidence"])
+                        mask = np.where(np.array(img) == 0, 1, 0)
+                        proba: np.ndarray = np.array([255 - p, 0, p])
+                        color = mask * proba[np.newaxis, np.newaxis, :]
+                        white_mask = 255 * (1 - mask)
+                        img = color + white_mask
 
-                # Write to response page
-                response[ymin:ymax, xmin:xmax, :] = np.array(img)
+                    # Write to response page
+                    response[ymin:ymax, xmin:xmax, :] = np.array(img)
 
     return response
 

--- a/references/detection/README.md
+++ b/references/detection/README.md
@@ -57,7 +57,30 @@ labels.json
      ...
 }
 ```
+If you want to train a model with multiple classes, you can use the following format
 
+labels.json
+```shell
+{
+    "sample_img_01.png": {
+        'img_dimensions': (900, 600),
+        'img_hash': "theimagedumpmyhash",
+        'polygons': {
+            "class_name_1": [[[x10, y10], [x20, y20], [x30, y30], [x40, y40]], ...],
+            "class_name_2": [[[x11, y11], [x21, y21], [x31, y31], [x41, y41]], ...]
+        }
+    },
+    "sample_img_02.png": {
+        'img_dimensions': (900, 600),
+        'img_hash': "thisisahash",
+        'polygons': {
+            "class_name_1": [[[x12, y12], [x22, y22], [x32, y32], [x42, y42]], ...],
+            "class_name_2": [[[x13, y13], [x23, y23], [x33, y33], [x43, y43]], ...]
+        }
+    },
+    ...
+}
+```
 ## Advanced options
 
 Feel free to inspect the multiple script option to customize your training to your own needs!

--- a/references/detection/README.md
+++ b/references/detection/README.md
@@ -57,7 +57,7 @@ labels.json
      ...
 }
 ```
-If you want to train a model with multiple classes, you can use the following format
+If you want to train a model with multiple classes, you can use the following format where polygons is a dictionnary where each key represents one class and has all the polygons representing that class.
 
 labels.json
 ```shell

--- a/references/detection/evaluate_pytorch.py
+++ b/references/detection/evaluate_pytorch.py
@@ -5,6 +5,10 @@
 
 import os
 
+import numpy as np
+
+from doctr.file_utils import CLASS_NAME
+
 os.environ["USE_TORCH"] = "1"
 
 import logging
@@ -44,9 +48,12 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
             out = model(images, targets, return_preds=True)
         # Compute metric
         loc_preds = out["preds"]
-        for boxes_gt, boxes_pred in zip(targets, loc_preds):
-            # Remove scores
-            val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :-1])
+        for target, loc_pred in zip(targets, loc_preds):
+            if isinstance(target, np.ndarray):
+                target = {CLASS_NAME: target}
+            for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
+                # Remove scores
+                val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :-1])
 
         val_loss += out["loss"].item()
         batch_cnt += 1

--- a/references/detection/evaluate_pytorch.py
+++ b/references/detection/evaluate_pytorch.py
@@ -5,8 +5,6 @@
 
 import os
 
-import numpy as np
-
 from doctr.file_utils import CLASS_NAME
 
 os.environ["USE_TORCH"] = "1"
@@ -40,7 +38,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
         if torch.cuda.is_available():
             images = images.cuda()
         images = batch_transforms(images)
-        targets = [t["boxes"] for t in targets]
+        targets = [{CLASS_NAME: t["boxes"]} for t in targets]
         if amp:
             with torch.cuda.amp.autocast():
                 out = model(images, targets, return_preds=True)
@@ -49,8 +47,6 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
         # Compute metric
         loc_preds = out["preds"]
         for target, loc_pred in zip(targets, loc_preds):
-            if isinstance(target, np.ndarray):
-                target = {CLASS_NAME: target}
             for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
                 # Remove scores
                 val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :-1])

--- a/references/detection/evaluate_tensorflow.py
+++ b/references/detection/evaluate_tensorflow.py
@@ -5,8 +5,6 @@
 
 import os
 
-import numpy as np
-
 from doctr.file_utils import CLASS_NAME
 
 os.environ["USE_TF"] = "1"
@@ -39,13 +37,11 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
     val_loss, batch_cnt = 0, 0
     for images, targets in tqdm(val_loader):
         images = batch_transforms(images)
-        targets = [t["boxes"] for t in targets]
+        targets = [{CLASS_NAME: t["boxes"]} for t in targets]
         out = model(images, targets, training=False, return_preds=True)
         # Compute metric
         loc_preds = out["preds"]
         for target, loc_pred in zip(targets, loc_preds):
-            if isinstance(target, np.ndarray):
-                target = {CLASS_NAME: target}
             for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
                 # Remove scores
                 val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :-1])

--- a/references/detection/evaluate_tensorflow.py
+++ b/references/detection/evaluate_tensorflow.py
@@ -5,6 +5,10 @@
 
 import os
 
+import numpy as np
+
+from doctr.file_utils import CLASS_NAME
+
 os.environ["USE_TF"] = "1"
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
@@ -39,9 +43,12 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         out = model(images, targets, training=False, return_preds=True)
         # Compute metric
         loc_preds = out["preds"]
-        for boxes_gt, boxes_pred in zip(targets, loc_preds):
-            # Remove scores
-            val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :-1])
+        for target, loc_pred in zip(targets, loc_preds):
+            if isinstance(target, np.ndarray):
+                target = {CLASS_NAME: target}
+            for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
+                # Remove scores
+                val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :-1])
 
         val_loss += out["loss"].numpy()
         batch_cnt += 1

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -228,7 +228,6 @@ def main(args):
     model = detection.__dict__[args.arch](
         pretrained=args.pretrained,
         assume_straight_pages=not args.rotation,
-        num_classes=len(val_set.class_names),
         class_names=val_set.class_names,
     )
 

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -5,8 +5,6 @@
 
 import os
 
-from doctr.file_utils import CLASS_NAME
-
 os.environ["USE_TORCH"] = "1"
 
 import datetime
@@ -158,8 +156,6 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
         # Compute metric
         loc_preds = out["preds"]
         for target, loc_pred in zip(targets, loc_preds):
-            if isinstance(target, np.ndarray):
-                target = {CLASS_NAME: target}
             for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
                 if args.rotation and args.eval_straight:
                     # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -5,6 +5,8 @@
 
 import os
 
+from doctr.file_utils import CLASS_NAME
+
 os.environ["USE_TORCH"] = "1"
 
 import datetime
@@ -157,7 +159,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
         loc_preds = out["preds"]
         for target, loc_pred in zip(targets, loc_preds):
             if isinstance(target, np.ndarray):
-                target = {"words": target}
+                target = {CLASS_NAME: target}
             for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
                 if args.rotation and args.eval_straight:
                     # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -197,7 +197,6 @@ def main(args):
         pretrained=args.pretrained,
         input_shape=(args.input_size, args.input_size, 3),
         assume_straight_pages=not args.rotation,
-        num_classes=len(val_set.class_names),
         class_names=val_set.class_names,
     )
 

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -115,20 +115,14 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         out = model(images, targets, training=False, return_preds=True)
         # Compute metric
         loc_preds = out["preds"]
-        # for target, loc_pred in zip(targets, loc_preds):
-        #     if isinstance(target, np.ndarray):
-        #         target = [target]
-        #     for boxes_gt, boxes_pred in zip(target, loc_pred):
-        #         if args.rotation and args.eval_straight:
-        #             # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4
-        #             boxes_pred = np.concatenate((boxes_pred.min(axis=1), boxes_pred.max(axis=1)), axis=-1)
-        #         val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :4])
-        #
-        for boxes_gt, boxes_pred in zip(targets, loc_preds):
-            if args.rotation and args.eval_straight:
-                # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4
-                boxes_pred = np.concatenate((boxes_pred.min(axis=1), boxes_pred.max(axis=1)), axis=-1)
-            val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :4])
+        for target, loc_pred in zip(targets, loc_preds):
+            if isinstance(target, np.ndarray):
+                target = {"words": target}
+            for boxes_gt, boxes_pred in zip(target.values(), loc_pred):
+                if args.rotation and args.eval_straight:
+                    # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4
+                    boxes_pred = np.concatenate((boxes_pred.min(axis=1), boxes_pred.max(axis=1)), axis=-1)
+                val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :4])
 
         val_loss += out["loss"].numpy()
         batch_cnt += 1

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -115,6 +115,15 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         out = model(images, targets, training=False, return_preds=True)
         # Compute metric
         loc_preds = out["preds"]
+        # for target, loc_pred in zip(targets, loc_preds):
+        #     if isinstance(target, np.ndarray):
+        #         target = [target]
+        #     for boxes_gt, boxes_pred in zip(target, loc_pred):
+        #         if args.rotation and args.eval_straight:
+        #             # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4
+        #             boxes_pred = np.concatenate((boxes_pred.min(axis=1), boxes_pred.max(axis=1)), axis=-1)
+        #         val_metric.update(gts=boxes_gt, preds=boxes_pred[:, :4])
+        #
         for boxes_gt, boxes_pred in zip(targets, loc_preds):
             if args.rotation and args.eval_straight:
                 # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4
@@ -192,6 +201,7 @@ def main(args):
         pretrained=args.pretrained,
         input_shape=(args.input_size, args.input_size, 3),
         assume_straight_pages=not args.rotation,
+        num_classes=len(val_set.class_names),
     )
 
     # Resume weights

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -118,7 +118,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         for target, loc_pred in zip(targets, loc_preds):
             if isinstance(target, np.ndarray):
                 target = {"words": target}
-            for boxes_gt, boxes_pred in zip(target.values(), loc_pred):
+            for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
                 if args.rotation and args.eval_straight:
                     # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4
                     boxes_pred = np.concatenate((boxes_pred.min(axis=1), boxes_pred.max(axis=1)), axis=-1)
@@ -196,6 +196,7 @@ def main(args):
         input_shape=(args.input_size, args.input_size, 3),
         assume_straight_pages=not args.rotation,
         num_classes=len(val_set.class_names),
+        class_names=val_set.class_names,
     )
 
     # Resume weights

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -5,6 +5,8 @@
 
 import os
 
+from doctr.file_utils import CLASS_NAME
+
 os.environ["USE_TF"] = "1"
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
@@ -117,7 +119,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         loc_preds = out["preds"]
         for target, loc_pred in zip(targets, loc_preds):
             if isinstance(target, np.ndarray):
-                target = {"words": target}
+                target = {CLASS_NAME: target}
             for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
                 if args.rotation and args.eval_straight:
                     # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -5,8 +5,6 @@
 
 import os
 
-from doctr.file_utils import CLASS_NAME
-
 os.environ["USE_TF"] = "1"
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
@@ -118,8 +116,6 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
         # Compute metric
         loc_preds = out["preds"]
         for target, loc_pred in zip(targets, loc_preds):
-            if isinstance(target, np.ndarray):
-                target = {CLASS_NAME: target}
             for boxes_gt, boxes_pred in zip(target.values(), loc_pred.values()):
                 if args.rotation and args.eval_straight:
                     # Convert pred to boxes [xmin, ymin, xmax, ymax]  N, 4, 2 --> N, 4

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -30,7 +30,7 @@ from doctr import transforms as T
 from doctr.datasets import DataLoader, DetectionDataset
 from doctr.models import detection
 from doctr.utils.metrics import LocalizationConfusion
-from utils import plot_recorder, plot_samples
+from utils import load_backbone, plot_recorder, plot_samples
 
 
 def record_lr(
@@ -200,6 +200,11 @@ def main(args):
     if isinstance(args.resume, str):
         model.load_weights(args.resume)
 
+    if isinstance(args.pretrained_backbone, str):
+        print("Loading backbone weights.")
+        model = load_backbone(model, args.pretrained_backbone)
+        print("Done.")
+
     # Metrics
     val_metric = LocalizationConfusion(
         use_polygons=args.rotation and not args.eval_straight,
@@ -368,6 +373,7 @@ def parse_args():
     parser.add_argument("--lr", type=float, default=0.001, help="learning rate for the optimizer (Adam)")
     parser.add_argument("-j", "--workers", type=int, default=None, help="number of workers used for dataloading")
     parser.add_argument("--resume", type=str, default=None, help="Path to your checkpoint")
+    parser.add_argument("--pretrained-backbone", type=str, default=None, help="Path to your backbone weights")
     parser.add_argument("--test-only", dest="test_only", action="store_true", help="Run the validation loop")
     parser.add_argument(
         "--freeze-backbone", dest="freeze_backbone", action="store_true", help="freeze model backbone for fine-tuning"

--- a/references/detection/utils.py
+++ b/references/detection/utils.py
@@ -20,16 +20,17 @@ def plot_samples(images, targets: List[Dict[str, np.ndarray]]) -> None:
             img = img.transpose(1, 2, 0)
 
         target = np.zeros(img.shape[:2], np.uint8)
-        boxes = targets[idx].copy()
-        boxes[:, [0, 2]] = boxes[:, [0, 2]] * img.shape[1]
-        boxes[:, [1, 3]] = boxes[:, [1, 3]] * img.shape[0]
-        boxes[:, :4] = boxes[:, :4].round().astype(int)
+        tgts = targets[idx].copy()
+        for key, boxes in tgts.items():
+            boxes[:, [0, 2]] = boxes[:, [0, 2]] * img.shape[1]
+            boxes[:, [1, 3]] = boxes[:, [1, 3]] * img.shape[0]
+            boxes[:, :4] = boxes[:, :4].round().astype(int)
 
-        for box in boxes:
-            if boxes.ndim == 3:
-                cv2.fillPoly(target, [np.int0(box)], 1)
-            else:
-                target[int(box[1]) : int(box[3]) + 1, int(box[0]) : int(box[2]) + 1] = 1
+            for box in boxes:
+                if boxes.ndim == 3:
+                    cv2.fillPoly(target, [np.int0(box)], 1)
+                else:
+                    target[int(box[1]) : int(box[3]) + 1, int(box[0]) : int(box[2]) + 1] = 1
         if nb_samples > 1:
             axes[0][idx].imshow(img)
             axes[1][idx].imshow(target.astype(bool))

--- a/references/detection/utils.py
+++ b/references/detection/utils.py
@@ -3,6 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
+import pickle
 from typing import Dict, List
 
 import cv2
@@ -82,3 +83,11 @@ def plot_recorder(lr_recorder, loss_recorder, beta: float = 0.95, **kwargs) -> N
     plt.ylim(vals[min_idx] - 0.1 * delta, max_val + 0.2 * delta)
     plt.grid(True, linestyle="--", axis="x")
     plt.show(**kwargs)
+
+
+def load_backbone(model, weights_path):
+
+    pretrained_backbone_weights = pickle.load(open(weights_path, "rb"))
+    model.feat_extractor.set_weights(pretrained_backbone_weights[0])
+    model.fpn.set_weights(pretrained_backbone_weights[1])
+    return model

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -104,58 +104,59 @@ def main(args):
             pred_labels = []
             for page in out.pages:
                 height, width = page.dimensions
-                for block in page.blocks:
-                    for line in block.lines:
-                        for word in line.words:
-                            if not args.rotation:
-                                (a, b), (c, d) = word.geometry
-                            else:
-                                (
-                                    [x1, y1],
-                                    [x2, y2],
-                                    [x3, y3],
-                                    [x4, y4],
-                                ) = word.geometry
-                            if gt_boxes.dtype == int:
+                for blocks in page.blocks.values():
+                    for block in blocks:
+                        for line in block.lines:
+                            for word in line.words:
                                 if not args.rotation:
-                                    pred_boxes.append(
-                                        [int(a * width), int(b * height), int(c * width), int(d * height)]
-                                    )
+                                    (a, b), (c, d) = word.geometry
                                 else:
-                                    if args.eval_straight:
+                                    (
+                                        [x1, y1],
+                                        [x2, y2],
+                                        [x3, y3],
+                                        [x4, y4],
+                                    ) = word.geometry
+                                if gt_boxes.dtype == int:
+                                    if not args.rotation:
                                         pred_boxes.append(
-                                            [
-                                                int(width * min(x1, x2, x3, x4)),
-                                                int(height * min(y1, y2, y3, y4)),
-                                                int(width * max(x1, x2, x3, x4)),
-                                                int(height * max(y1, y2, y3, y4)),
-                                            ]
+                                            [int(a * width), int(b * height), int(c * width), int(d * height)]
                                         )
                                     else:
-                                        pred_boxes.append(
-                                            [
-                                                [int(x1 * width), int(y1 * height)],
-                                                [int(x2 * width), int(y2 * height)],
-                                                [int(x3 * width), int(y3 * height)],
-                                                [int(x4 * width), int(y4 * height)],
-                                            ]
-                                        )
-                            else:
-                                if not args.rotation:
-                                    pred_boxes.append([a, b, c, d])
+                                        if args.eval_straight:
+                                            pred_boxes.append(
+                                                [
+                                                    int(width * min(x1, x2, x3, x4)),
+                                                    int(height * min(y1, y2, y3, y4)),
+                                                    int(width * max(x1, x2, x3, x4)),
+                                                    int(height * max(y1, y2, y3, y4)),
+                                                ]
+                                            )
+                                        else:
+                                            pred_boxes.append(
+                                                [
+                                                    [int(x1 * width), int(y1 * height)],
+                                                    [int(x2 * width), int(y2 * height)],
+                                                    [int(x3 * width), int(y3 * height)],
+                                                    [int(x4 * width), int(y4 * height)],
+                                                ]
+                                            )
                                 else:
-                                    if args.eval_straight:
-                                        pred_boxes.append(
-                                            [
-                                                min(x1, x2, x3, x4),
-                                                min(y1, y2, y3, y4),
-                                                max(x1, x2, x3, x4),
-                                                max(y1, y2, y3, y4),
-                                            ]
-                                        )
+                                    if not args.rotation:
+                                        pred_boxes.append([a, b, c, d])
                                     else:
-                                        pred_boxes.append([[x1, y1], [x2, y2], [x3, y3], [x4, y4]])
-                            pred_labels.append(word.value)
+                                        if args.eval_straight:
+                                            pred_boxes.append(
+                                                [
+                                                    min(x1, x2, x3, x4),
+                                                    min(y1, y2, y3, y4),
+                                                    max(x1, x2, x3, x4),
+                                                    max(y1, y2, y3, y4),
+                                                ]
+                                            )
+                                        else:
+                                            pred_boxes.append([[x1, y1], [x2, y2], [x3, y3], [x4, y4]])
+                                pred_labels.append(word.value)
 
             # Update the metric
             det_metric.update(gt_boxes, np.asarray(pred_boxes))

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -104,59 +104,58 @@ def main(args):
             pred_labels = []
             for page in out.pages:
                 height, width = page.dimensions
-                for blocks in page.blocks.values():
-                    for block in blocks:
-                        for line in block.lines:
-                            for word in line.words:
+                for block in page.blocks:
+                    for line in block.lines:
+                        for word in line.words:
+                            if not args.rotation:
+                                (a, b), (c, d) = word.geometry
+                            else:
+                                (
+                                    [x1, y1],
+                                    [x2, y2],
+                                    [x3, y3],
+                                    [x4, y4],
+                                ) = word.geometry
+                            if gt_boxes.dtype == int:
                                 if not args.rotation:
-                                    (a, b), (c, d) = word.geometry
+                                    pred_boxes.append(
+                                        [int(a * width), int(b * height), int(c * width), int(d * height)]
+                                    )
                                 else:
-                                    (
-                                        [x1, y1],
-                                        [x2, y2],
-                                        [x3, y3],
-                                        [x4, y4],
-                                    ) = word.geometry
-                                if gt_boxes.dtype == int:
-                                    if not args.rotation:
+                                    if args.eval_straight:
                                         pred_boxes.append(
-                                            [int(a * width), int(b * height), int(c * width), int(d * height)]
+                                            [
+                                                int(width * min(x1, x2, x3, x4)),
+                                                int(height * min(y1, y2, y3, y4)),
+                                                int(width * max(x1, x2, x3, x4)),
+                                                int(height * max(y1, y2, y3, y4)),
+                                            ]
                                         )
                                     else:
-                                        if args.eval_straight:
-                                            pred_boxes.append(
-                                                [
-                                                    int(width * min(x1, x2, x3, x4)),
-                                                    int(height * min(y1, y2, y3, y4)),
-                                                    int(width * max(x1, x2, x3, x4)),
-                                                    int(height * max(y1, y2, y3, y4)),
-                                                ]
-                                            )
-                                        else:
-                                            pred_boxes.append(
-                                                [
-                                                    [int(x1 * width), int(y1 * height)],
-                                                    [int(x2 * width), int(y2 * height)],
-                                                    [int(x3 * width), int(y3 * height)],
-                                                    [int(x4 * width), int(y4 * height)],
-                                                ]
-                                            )
+                                        pred_boxes.append(
+                                            [
+                                                [int(x1 * width), int(y1 * height)],
+                                                [int(x2 * width), int(y2 * height)],
+                                                [int(x3 * width), int(y3 * height)],
+                                                [int(x4 * width), int(y4 * height)],
+                                            ]
+                                        )
+                            else:
+                                if not args.rotation:
+                                    pred_boxes.append([a, b, c, d])
                                 else:
-                                    if not args.rotation:
-                                        pred_boxes.append([a, b, c, d])
+                                    if args.eval_straight:
+                                        pred_boxes.append(
+                                            [
+                                                min(x1, x2, x3, x4),
+                                                min(y1, y2, y3, y4),
+                                                max(x1, x2, x3, x4),
+                                                max(y1, y2, y3, y4),
+                                            ]
+                                        )
                                     else:
-                                        if args.eval_straight:
-                                            pred_boxes.append(
-                                                [
-                                                    min(x1, x2, x3, x4),
-                                                    min(y1, y2, y3, y4),
-                                                    max(x1, x2, x3, x4),
-                                                    max(y1, y2, y3, y4),
-                                                ]
-                                            )
-                                        else:
-                                            pred_boxes.append([[x1, y1], [x2, y2], [x3, y3], [x4, y4]])
-                                pred_labels.append(word.value)
+                                        pred_boxes.append([[x1, y1], [x2, y2], [x3, y3], [x4, y4]])
+                            pred_labels.append(word.value)
 
             # Update the metric
             det_metric.update(gt_boxes, np.asarray(pred_boxes))

--- a/scripts/evaluate_kie.py
+++ b/scripts/evaluate_kie.py
@@ -1,0 +1,221 @@
+# Copyright (C) 2021-2022, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+import os
+
+from doctr.io.elements import KIEDocument
+
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+
+import numpy as np
+from tqdm import tqdm
+
+from doctr import datasets
+from doctr.file_utils import is_tf_available
+from doctr.models import kie_predictor
+from doctr.utils.geometry import extract_crops, extract_rcrops
+from doctr.utils.metrics import LocalizationConfusion, OCRMetric, TextMatch
+
+# Enable GPU growth if using TF
+if is_tf_available():
+    import tensorflow as tf
+
+    gpu_devices = tf.config.experimental.list_physical_devices("GPU")
+    if any(gpu_devices):
+        tf.config.experimental.set_memory_growth(gpu_devices[0], True)
+else:
+    import torch
+
+
+def _pct(val):
+    return "N/A" if val is None else f"{val:.2%}"
+
+
+def main(args):
+
+    if not args.rotation:
+        args.eval_straight = True
+
+    predictor = kie_predictor(
+        args.detection,
+        args.recognition,
+        pretrained=True,
+        reco_bs=args.batch_size,
+        assume_straight_pages=not args.rotation,
+    )
+
+    if args.img_folder and args.label_file:
+        testset = datasets.OCRDataset(
+            img_folder=args.img_folder,
+            label_file=args.label_file,
+        )
+        sets = [testset]
+    else:
+        train_set = datasets.__dict__[args.dataset](train=True, download=True, use_polygons=not args.eval_straight)
+        val_set = datasets.__dict__[args.dataset](train=False, download=True, use_polygons=not args.eval_straight)
+        sets = [train_set, val_set]
+
+    reco_metric = TextMatch()
+    if args.mask_shape:
+        det_metric = LocalizationConfusion(
+            iou_thresh=args.iou, use_polygons=not args.eval_straight, mask_shape=(args.mask_shape, args.mask_shape)
+        )
+        e2e_metric = OCRMetric(
+            iou_thresh=args.iou, use_polygons=not args.eval_straight, mask_shape=(args.mask_shape, args.mask_shape)
+        )
+    else:
+        det_metric = LocalizationConfusion(iou_thresh=args.iou, use_polygons=not args.eval_straight)
+        e2e_metric = OCRMetric(iou_thresh=args.iou, use_polygons=not args.eval_straight)
+
+    sample_idx = 0
+    extraction_fn = extract_crops if args.eval_straight else extract_rcrops
+
+    for dataset in sets:
+        for page, target in tqdm(dataset):
+            # GT
+            gt_boxes = target["boxes"]
+            gt_labels = target["labels"]
+
+            if args.img_folder and args.label_file:
+                x, y, w, h = gt_boxes[:, 0], gt_boxes[:, 1], gt_boxes[:, 2], gt_boxes[:, 3]
+                xmin, ymin = np.clip(x - w / 2, 0, 1), np.clip(y - h / 2, 0, 1)
+                xmax, ymax = np.clip(x + w / 2, 0, 1), np.clip(y + h / 2, 0, 1)
+                gt_boxes = np.stack([xmin, ymin, xmax, ymax], axis=-1)
+
+            # Forward
+            out: KIEDocument
+            if is_tf_available():
+                out = predictor(page[None, ...])
+                crops = extraction_fn(page, gt_boxes)
+                reco_out = predictor.reco_predictor(crops)
+            else:
+                with torch.no_grad():
+                    out = predictor(page[None, ...])
+                    # We directly crop on PyTorch tensors, which are in channels_first
+                    crops = extraction_fn(page, gt_boxes, channels_last=False)
+                    reco_out = predictor.reco_predictor(crops)
+
+            if len(reco_out):
+                reco_words, _ = zip(*reco_out)
+            else:
+                reco_words = []
+
+            # Unpack preds
+            pred_boxes = []
+            pred_labels = []
+            for page in out.pages:
+                height, width = page.dimensions
+                for blocks in page.predictions.values():
+                    for block in blocks:
+                        for line in block.lines:
+                            for word in line.words:
+                                if not args.rotation:
+                                    (a, b), (c, d) = word.geometry
+                                else:
+                                    (
+                                        [x1, y1],
+                                        [x2, y2],
+                                        [x3, y3],
+                                        [x4, y4],
+                                    ) = word.geometry
+                                if gt_boxes.dtype == int:
+                                    if not args.rotation:
+                                        pred_boxes.append(
+                                            [int(a * width), int(b * height), int(c * width), int(d * height)]
+                                        )
+                                    else:
+                                        if args.eval_straight:
+                                            pred_boxes.append(
+                                                [
+                                                    int(width * min(x1, x2, x3, x4)),
+                                                    int(height * min(y1, y2, y3, y4)),
+                                                    int(width * max(x1, x2, x3, x4)),
+                                                    int(height * max(y1, y2, y3, y4)),
+                                                ]
+                                            )
+                                        else:
+                                            pred_boxes.append(
+                                                [
+                                                    [int(x1 * width), int(y1 * height)],
+                                                    [int(x2 * width), int(y2 * height)],
+                                                    [int(x3 * width), int(y3 * height)],
+                                                    [int(x4 * width), int(y4 * height)],
+                                                ]
+                                            )
+                                else:
+                                    if not args.rotation:
+                                        pred_boxes.append([a, b, c, d])
+                                    else:
+                                        if args.eval_straight:
+                                            pred_boxes.append(
+                                                [
+                                                    min(x1, x2, x3, x4),
+                                                    min(y1, y2, y3, y4),
+                                                    max(x1, x2, x3, x4),
+                                                    max(y1, y2, y3, y4),
+                                                ]
+                                            )
+                                        else:
+                                            pred_boxes.append([[x1, y1], [x2, y2], [x3, y3], [x4, y4]])
+                                pred_labels.append(word.value)
+
+            # Update the metric
+            det_metric.update(gt_boxes, np.asarray(pred_boxes))
+            reco_metric.update(gt_labels, reco_words)
+            e2e_metric.update(gt_boxes, np.asarray(pred_boxes), gt_labels, pred_labels)
+
+            # Loop break
+            sample_idx += 1
+            if isinstance(args.samples, int) and args.samples == sample_idx:
+                break
+        if isinstance(args.samples, int) and args.samples == sample_idx:
+            break
+
+    # Unpack aggregated metrics
+    print(
+        f"Model Evaluation (model= {args.detection} + {args.recognition}, "
+        f"dataset={'OCRDataset' if args.img_folder else args.dataset})"
+    )
+    recall, precision, mean_iou = det_metric.summary()
+    print(f"Text Detection - Recall: {_pct(recall)}, Precision: {_pct(precision)}, Mean IoU: {_pct(mean_iou)}")
+    acc = reco_metric.summary()
+    print(f"Text Recognition - Accuracy: {_pct(acc['raw'])} (unicase: {_pct(acc['unicase'])})")
+    recall, precision, mean_iou = e2e_metric.summary()
+    print(
+        f"OCR - Recall: {_pct(recall['raw'])} (unicase: {_pct(recall['unicase'])}), "
+        f"Precision: {_pct(precision['raw'])} (unicase: {_pct(precision['unicase'])}), Mean IoU: {_pct(mean_iou)}"
+    )
+
+
+def parse_args():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="DocTR end-to-end evaluation", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("detection", type=str, help="Text detection model to use for analysis")
+    parser.add_argument("recognition", type=str, help="Text recognition model to use for analysis")
+    parser.add_argument("--iou", type=float, default=0.5, help="IoU threshold to match a pair of boxes")
+    parser.add_argument("--dataset", type=str, default="FUNSD", help="choose a dataset: FUNSD, CORD")
+    parser.add_argument("--img_folder", type=str, default=None, help="Only for local sets, path to images")
+    parser.add_argument("--label_file", type=str, default=None, help="Only for local sets, path to labels")
+    parser.add_argument("--rotation", dest="rotation", action="store_true", help="run rotated OCR + postprocessing")
+    parser.add_argument("-b", "--batch_size", type=int, default=32, help="batch size for recognition")
+    parser.add_argument("--mask_shape", type=int, default=None, help="mask shape for mask iou (only for rotation)")
+    parser.add_argument("--samples", type=int, default=None, help="evaluate only on the N first samples")
+    parser.add_argument(
+        "--eval-straight",
+        action="store_true",
+        help="evaluate on straight pages with straight bbox (to use the quick and light metric)",
+    )
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from setuptools import setup
 
 PKG_NAME = "python-doctr"
-VERSION = os.getenv("BUILD_VERSION", "0.6.1a0")
+VERSION = os.getenv("BUILD_VERSION", "1.0.1a0")
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from setuptools import setup
 
 PKG_NAME = "python-doctr"
-VERSION = os.getenv("BUILD_VERSION", "1.0.1a0")
+VERSION = os.getenv("BUILD_VERSION", "0.7.1a0")
 
 
 if __name__ == "__main__":

--- a/tests/common/test_io_elements.py
+++ b/tests/common/test_io_elements.py
@@ -3,6 +3,7 @@ from xml.etree.ElementTree import ElementTree
 import numpy as np
 import pytest
 
+from doctr.file_utils import CLASS_NAME
 from doctr.io import elements
 
 
@@ -58,14 +59,14 @@ def _mock_blocks(size=(1, 1), offset=(0, 0)):
 def _mock_pages(block_size=(1, 1), block_offset=(0, 0)):
     return [
         elements.Page(
-            {"words": _mock_blocks(block_size, block_offset)},
+            {CLASS_NAME: _mock_blocks(block_size, block_offset)},
             0,
             (300, 200),
             {"value": 0.0, "confidence": 1.0},
             {"value": "EN", "confidence": 0.8},
         ),
         elements.Page(
-            {"words": _mock_blocks(block_size, block_offset)},
+            {CLASS_NAME: _mock_blocks(block_size, block_offset)},
             1,
             (500, 1000),
             {"value": 0.15, "confidence": 0.8},
@@ -188,7 +189,7 @@ def test_page():
     page_size = (300, 200)
     orientation = {"value": 0.0, "confidence": 0.0}
     language = {"value": "EN", "confidence": 0.8}
-    blocks = {"words": _mock_blocks()}
+    blocks = {CLASS_NAME: _mock_blocks()}
     page = elements.Page(blocks, page_idx, page_size, orientation, language)
 
     class_names = list(blocks.keys())

--- a/tests/common/test_io_elements.py
+++ b/tests/common/test_io_elements.py
@@ -58,14 +58,14 @@ def _mock_blocks(size=(1, 1), offset=(0, 0)):
 def _mock_pages(block_size=(1, 1), block_offset=(0, 0)):
     return [
         elements.Page(
-            _mock_blocks(block_size, block_offset),
+            {"words": _mock_blocks(block_size, block_offset)},
             0,
             (300, 200),
             {"value": 0.0, "confidence": 1.0},
             {"value": "EN", "confidence": 0.8},
         ),
         elements.Page(
-            _mock_blocks(block_size, block_offset),
+            {"words": _mock_blocks(block_size, block_offset)},
             1,
             (500, 1000),
             {"value": 0.15, "confidence": 0.8},
@@ -188,12 +188,13 @@ def test_page():
     page_size = (300, 200)
     orientation = {"value": 0.0, "confidence": 0.0}
     language = {"value": "EN", "confidence": 0.8}
-    blocks = _mock_blocks()
+    blocks = {"words": _mock_blocks()}
     page = elements.Page(blocks, page_idx, page_size, orientation, language)
 
+    class_names = list(blocks.keys())
     # Attribute checks
     assert len(page.blocks) == len(blocks)
-    assert all(isinstance(b, elements.Block) for b in page.blocks)
+    assert all(isinstance(b, elements.Block) for b in page.blocks[class_names[0]])
     assert page.page_idx == page_idx
     assert page.dimensions == page_size
     assert page.orientation == orientation
@@ -204,7 +205,7 @@ def test_page():
 
     # Export
     assert page.export() == {
-        "blocks": [b.export() for b in blocks],
+        "blocks": {class_name: [b.export() for b in blocks[class_name]] for class_name in class_names},
         "page_idx": page_idx,
         "dimensions": page_size,
         "orientation": orientation,

--- a/tests/common/test_io_elements.py
+++ b/tests/common/test_io_elements.py
@@ -42,6 +42,19 @@ def _mock_lines(size=(1, 1), offset=(0, 0)):
     ]
 
 
+def _mock_prediction(size=(1.0, 1.0), offset=(0, 0), confidence=0.9):
+    return [
+        elements.Prediction(
+            "hello", confidence, ((offset[0], offset[1]), (size[0] / 2 + offset[0], size[1] / 2 + offset[1]))
+        ),
+        elements.Prediction(
+            "world",
+            confidence,
+            ((size[0] / 2 + offset[0], size[1] / 2 + offset[1]), (size[0] + offset[0], size[1] + offset[1])),
+        ),
+    ]
+
+
 def _mock_blocks(size=(1, 1), offset=(0, 0)):
     sub_size = (size[0] / 4, size[1] / 4)
     return [
@@ -75,17 +88,17 @@ def _mock_pages(block_size=(1, 1), block_offset=(0, 0)):
     ]
 
 
-def _mock_kie_pages(block_size=(1, 1), block_offset=(0, 0)):
+def _mock_kie_pages(prediction_size=(1, 1), prediction_offset=(0, 0)):
     return [
         elements.KIEPage(
-            {CLASS_NAME: _mock_blocks(block_size, block_offset)},
+            {CLASS_NAME: _mock_prediction(prediction_size, prediction_offset)},
             0,
             (300, 200),
             {"value": 0.0, "confidence": 1.0},
             {"value": "EN", "confidence": 0.8},
         ),
         elements.KIEPage(
-            {CLASS_NAME: _mock_blocks(block_size, block_offset)},
+            {CLASS_NAME: _mock_prediction(prediction_size, prediction_offset)},
             1,
             (500, 1000),
             {"value": 0.15, "confidence": 0.8},
@@ -178,6 +191,32 @@ def test_artefact():
     assert artefact.__repr__() == f"Artefact(type='{artefact_type}', confidence={conf:.2})"
 
 
+def test_prediction():
+    prediction_str = "hello"
+    conf = 0.8
+    geom = ((0, 0), (1, 1))
+    prediction = elements.Prediction(prediction_str, conf, geom)
+
+    # Attribute checks
+    assert prediction.value == prediction_str
+    assert prediction.confidence == conf
+    assert prediction.geometry == geom
+
+    # Render
+    assert prediction.render() == prediction_str
+
+    # Export
+    assert prediction.export() == {"value": prediction_str, "confidence": conf, "geometry": geom}
+
+    # Repr
+    assert prediction.__repr__() == f"Prediction(value='hello', confidence={conf:.2}, bounding_box={geom})"
+
+    # Class method
+    state_dict = {"value": "there", "confidence": 0.1, "geometry": ((0, 0), (0.5, 0.5))}
+    prediction = elements.Prediction.from_dict(state_dict)
+    assert prediction.export() == state_dict
+
+
 def test_block():
     geom = ((0, 0), (1, 1))
     sub_size = (geom[1][0] / 2, geom[1][0] / 2)
@@ -255,19 +294,19 @@ def test_kiepage():
     page_size = (300, 200)
     orientation = {"value": 0.0, "confidence": 0.0}
     language = {"value": "EN", "confidence": 0.8}
-    predictions = {CLASS_NAME: _mock_blocks()}
+    predictions = {CLASS_NAME: _mock_prediction()}
     kie_page = elements.KIEPage(predictions, page_idx, page_size, orientation, language)
 
     # Attribute checks
     assert len(kie_page.predictions) == len(predictions)
-    assert all(isinstance(b, elements.Block) for b in kie_page.predictions[CLASS_NAME])
+    assert all(isinstance(b, elements.Prediction) for b in kie_page.predictions[CLASS_NAME])
     assert kie_page.page_idx == page_idx
     assert kie_page.dimensions == page_size
     assert kie_page.orientation == orientation
     assert kie_page.language == language
 
     # Render
-    assert kie_page.render() == "hello world\nhello world\n\nhello world\nhello world"
+    assert kie_page.render() == "words: hello\n\nwords: world"
 
     # Export
     assert kie_page.export() == {
@@ -307,6 +346,32 @@ def test_document():
 
     # Render
     page_export = "hello world\nhello world\n\nhello world\nhello world"
+    assert doc.render() == f"{page_export}\n\n\n\n{page_export}"
+
+    # Export
+    assert doc.export() == {"pages": [p.export() for p in pages]}
+
+    # Export XML
+    assert isinstance(doc.export_as_xml(), list) and len(doc.export_as_xml()) == len(pages)
+
+    # Show
+    doc.show([np.zeros((256, 256, 3), dtype=np.uint8) for _ in range(len(pages))], block=False)
+
+    # Synthesize
+    img_list = doc.synthesize()
+    assert isinstance(img_list, list) and len(img_list) == len(pages)
+
+
+def test_kie_document():
+    pages = _mock_kie_pages()
+    doc = elements.KIEDocument(pages)
+
+    # Attribute checks
+    assert len(doc.pages) == len(pages)
+    assert all(isinstance(p, elements.KIEPage) for p in doc.pages)
+
+    # Render
+    page_export = "words: hello\n\nwords: world"
     assert doc.render() == f"{page_export}\n\n\n\n{page_export}"
 
     # Export

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -6,7 +6,13 @@ import pytest
 import requests
 
 from doctr.io import reader
-from doctr.models._utils import estimate_orientation, get_bitmap_angle, get_language
+from doctr.models._utils import (
+    convert_dict_list_to_list_dict,
+    convert_list_dict_to_dict_list,
+    estimate_orientation,
+    get_bitmap_angle,
+    get_language,
+)
 from doctr.utils import geometry
 
 
@@ -63,3 +69,14 @@ def test_get_lang():
     lang = get_language("a")
     assert lang[0] == "unknown"
     assert lang[1] == 0.0
+
+
+def test_convert_list_dict():
+    dic = {"k1": [[0], [0], [0]], "k2": [[1], [1], [1]]}
+    L = [{"k1": [0], "k2": [1]}, {"k1": [0], "k2": [1]}, {"k1": [0], "k2": [1]}]
+
+    converted_dic = convert_dict_list_to_list_dict(dic)
+    converted_list = convert_list_dict_to_dict_list(L)
+
+    assert converted_dic == L
+    assert converted_list == dic

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -7,8 +7,7 @@ import requests
 
 from doctr.io import reader
 from doctr.models._utils import (
-    convert_dict_list_to_list_dict,
-    convert_list_dict_to_dict_list,
+    invert_between_dict_of_lists_and_list_of_dicts,
     estimate_orientation,
     get_bitmap_angle,
     get_language,
@@ -75,8 +74,8 @@ def test_convert_list_dict():
     dic = {"k1": [[0], [0], [0]], "k2": [[1], [1], [1]]}
     L = [{"k1": [0], "k2": [1]}, {"k1": [0], "k2": [1]}, {"k1": [0], "k2": [1]}]
 
-    converted_dic = convert_dict_list_to_list_dict(dic)
-    converted_list = convert_list_dict_to_dict_list(L)
+    converted_dic = invert_between_dict_of_lists_and_list_of_dicts(dic)
+    converted_list = invert_between_dict_of_lists_and_list_of_dicts(L)
 
     assert converted_dic == L
     assert converted_list == dic

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -7,10 +7,10 @@ import requests
 
 from doctr.io import reader
 from doctr.models._utils import (
-    invert_between_dict_of_lists_and_list_of_dicts,
     estimate_orientation,
     get_bitmap_angle,
     get_language,
+    invert_between_dict_of_lists_and_list_of_dicts,
 )
 from doctr.utils import geometry
 

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -6,12 +6,7 @@ import pytest
 import requests
 
 from doctr.io import reader
-from doctr.models._utils import (
-    estimate_orientation,
-    get_bitmap_angle,
-    get_language,
-    invert_between_dict_of_lists_and_list_of_dicts,
-)
+from doctr.models._utils import estimate_orientation, get_bitmap_angle, get_language, invert_data_structure
 from doctr.utils import geometry
 
 
@@ -74,8 +69,8 @@ def test_convert_list_dict():
     dic = {"k1": [[0], [0], [0]], "k2": [[1], [1], [1]]}
     L = [{"k1": [0], "k2": [1]}, {"k1": [0], "k2": [1]}, {"k1": [0], "k2": [1]}]
 
-    converted_dic = invert_between_dict_of_lists_and_list_of_dicts(dic)
-    converted_list = invert_between_dict_of_lists_and_list_of_dicts(L)
+    converted_dic = invert_data_structure(dic)
+    converted_list = invert_data_structure(L)
 
     assert converted_dic == L
     assert converted_list == dic

--- a/tests/common/test_models_builder.py
+++ b/tests/common/test_models_builder.py
@@ -3,6 +3,7 @@ import pytest
 
 from doctr.file_utils import CLASS_NAME
 from doctr.io import Document
+from doctr.io.elements import KIEDocument
 from doctr.models import builder
 
 words_per_page = 10
@@ -14,38 +15,88 @@ boxes_2 = np.random.rand(words_per_page, 6)  # array format
 boxes_2[:2] *= boxes_2[2:4]
 
 
-@pytest.mark.parametrize("boxes", [boxes_1, boxes_2])
-def test_documentbuilder(boxes):
+def test_documentbuilder():
 
     num_pages = 2
 
     # Don't resolve lines
     doc_builder = builder.DocumentBuilder(resolve_lines=False, resolve_blocks=False)
+    boxes = np.random.rand(words_per_page, 6)  # array format
+    boxes[:2] *= boxes[2:4]
     # Arg consistency check
     with pytest.raises(ValueError):
-        doc_builder([boxes, boxes], [{CLASS_NAME: ("hello", 1.0)}] * 3, [(100, 200), (100, 200)])
-    out = doc_builder(
-        [boxes, boxes], [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
-    )
+        doc_builder([boxes, boxes], [("hello", 1.0)] * 3, [(100, 200), (100, 200)])
+    out = doc_builder([boxes, boxes], [[("hello", 1.0)] * words_per_page] * num_pages, [(100, 200), (100, 200)])
     assert isinstance(out, Document)
     assert len(out.pages) == num_pages
     # 1 Block & 1 line per page
-    assert len(out.pages[0].blocks) == 1 and len(out.pages[0].blocks[CLASS_NAME][0].lines) == 1
-    assert len(out.pages[0].blocks[CLASS_NAME][0].lines[0].words) == words_per_page
+    assert len(out.pages[0].blocks) == 1 and len(out.pages[0].blocks[0].lines) == 1
+    assert len(out.pages[0].blocks[0].lines[0].words) == words_per_page
 
     # Resolve lines
     doc_builder = builder.DocumentBuilder(resolve_lines=True, resolve_blocks=True)
+    out = doc_builder([boxes, boxes], [[("hello", 1.0)] * words_per_page] * num_pages, [(100, 200), (100, 200)])
+
+    # No detection
+    boxes = np.zeros((0, 5))
+    out = doc_builder([boxes, boxes], [[], []], [(100, 200), (100, 200)])
+    assert len(out.pages[0].blocks) == 0
+
+    # Rotated boxes to export as straight boxes
+    boxes = np.array(
+        [
+            [[0.1, 0.1], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15]],
+            [[0.5, 0.5], [0.6, 0.6], [0.55, 0.65], [0.45, 0.55]],
+        ]
+    )
+    doc_builder_2 = builder.DocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
+    out = doc_builder_2([boxes], [[("hello", 0.99), (CLASS_NAME, 0.99)]], [(100, 100)])
+    assert out.pages[0].blocks[0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
+
+    # Repr
+    assert (
+        repr(doc_builder) == "DocumentBuilder(resolve_lines=True, "
+        "resolve_blocks=True, paragraph_break=0.035, export_as_straight_boxes=False)"
+    )
+
+
+def test_kiedocumentbuilder():
+
+    num_pages = 2
+
+    # Don't resolve lines
+    doc_builder = builder.KIEDocumentBuilder(resolve_lines=False, resolve_blocks=False)
+    predictions = {CLASS_NAME: np.random.rand(words_per_page, 6)}  # dict format
+    predictions[CLASS_NAME][:2] *= predictions[CLASS_NAME][2:4]
+    # Arg consistency check
+    with pytest.raises(ValueError):
+        doc_builder([predictions, predictions], [{CLASS_NAME: ("hello", 1.0)}] * 3, [(100, 200), (100, 200)])
     out = doc_builder(
-        [boxes, boxes], [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
+        [predictions, predictions],
+        [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages,
+        [(100, 200), (100, 200)],
+    )
+    assert isinstance(out, KIEDocument)
+    assert len(out.pages) == num_pages
+    # 1 Block & 1 line per page
+    assert len(out.pages[0].predictions) == 1 and len(out.pages[0].predictions[CLASS_NAME][0].lines) == 1
+    assert len(out.pages[0].predictions[CLASS_NAME][0].lines[0].words) == words_per_page
+
+    # Resolve lines
+    doc_builder = builder.KIEDocumentBuilder(resolve_lines=True, resolve_blocks=True)
+    out = doc_builder(
+        [predictions, predictions],
+        [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages,
+        [(100, 200), (100, 200)],
     )
 
     # No detection
-    boxes = {CLASS_NAME: np.zeros((0, 5))}
-    out = doc_builder([boxes, boxes], [{CLASS_NAME: []}, {CLASS_NAME: []}], [(100, 200), (100, 200)])
-    assert len(out.pages[0].blocks[CLASS_NAME]) == 0
+    predictions = {CLASS_NAME: np.zeros((0, 5))}
+    out = doc_builder([predictions, predictions], [{CLASS_NAME: []}, {CLASS_NAME: []}], [(100, 200), (100, 200)])
+    assert len(out.pages[0].predictions[CLASS_NAME]) == 0
 
     # Rotated boxes to export as straight boxes
-    boxes = {
+    predictions = {
         CLASS_NAME: np.array(
             [
                 [[0.1, 0.1], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15]],
@@ -53,13 +104,13 @@ def test_documentbuilder(boxes):
             ]
         )
     }
-    doc_builder_2 = builder.DocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
-    out = doc_builder_2([boxes], [{CLASS_NAME: [("hello", 0.99), (CLASS_NAME, 0.99)]}], [(100, 100)])
-    assert out.pages[0].blocks[CLASS_NAME][0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
+    doc_builder_2 = builder.KIEDocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
+    out = doc_builder_2([predictions], [{CLASS_NAME: [("hello", 0.99), (CLASS_NAME, 0.99)]}], [(100, 100)])
+    assert out.pages[0].predictions[CLASS_NAME][0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
 
     # Repr
     assert (
-        repr(doc_builder) == "DocumentBuilder(resolve_lines=True, "
+        repr(doc_builder) == "KIEDocumentBuilder(resolve_lines=True, "
         "resolve_blocks=True, paragraph_break=0.035, export_as_straight_boxes=False)"
     )
 

--- a/tests/common/test_models_builder.py
+++ b/tests/common/test_models_builder.py
@@ -1,8 +1,62 @@
 import numpy as np
 import pytest
 
+from doctr.file_utils import CLASS_NAME
 from doctr.io import Document
 from doctr.models import builder
+
+
+def test_documentbuilder_dict_blocks():
+
+    words_per_page = 10
+    num_pages = 2
+
+    # Don't resolve lines
+    doc_builder = builder.DocumentBuilder(resolve_lines=False, resolve_blocks=False)
+    boxes = {CLASS_NAME: np.random.rand(words_per_page, 6)}
+    boxes[CLASS_NAME][:2] *= boxes[CLASS_NAME][2:4]
+
+    # Arg consistency check
+    with pytest.raises(ValueError):
+        doc_builder([boxes, boxes], [{CLASS_NAME: ("hello", 1.0)}] * 3, [(100, 200), (100, 200)])
+    out = doc_builder(
+        [boxes, boxes], [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
+    )
+    assert isinstance(out, Document)
+    assert len(out.pages) == num_pages
+    # 1 Block & 1 line per page
+    assert len(out.pages[0].blocks) == 1 and len(out.pages[0].blocks[CLASS_NAME][0].lines) == 1
+    assert len(out.pages[0].blocks[CLASS_NAME][0].lines[0].words) == words_per_page
+
+    # Resolve lines
+    doc_builder = builder.DocumentBuilder(resolve_lines=True, resolve_blocks=True)
+    out = doc_builder(
+        [boxes, boxes], [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
+    )
+
+    # No detection
+    boxes = {CLASS_NAME: np.zeros((0, 5))}
+    out = doc_builder([boxes, boxes], [{CLASS_NAME: []}, {CLASS_NAME: []}], [(100, 200), (100, 200)])
+    assert len(out.pages[0].blocks[CLASS_NAME]) == 0
+
+    # Rotated boxes to export as straight boxes
+    boxes = {
+        CLASS_NAME: np.array(
+            [
+                [[0.1, 0.1], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15]],
+                [[0.5, 0.5], [0.6, 0.6], [0.55, 0.65], [0.45, 0.55]],
+            ]
+        )
+    }
+    doc_builder_2 = builder.DocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
+    out = doc_builder_2([boxes], [{CLASS_NAME: [("hello", 0.99), (CLASS_NAME, 0.99)]}], [(100, 100)])
+    assert out.pages[0].blocks[CLASS_NAME][0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
+
+    # Repr
+    assert (
+        repr(doc_builder) == "DocumentBuilder(resolve_lines=True, "
+        "resolve_blocks=True, paragraph_break=0.035, export_as_straight_boxes=False)"
+    )
 
 
 def test_documentbuilder():
@@ -12,35 +66,35 @@ def test_documentbuilder():
 
     # Don't resolve lines
     doc_builder = builder.DocumentBuilder(resolve_lines=False, resolve_blocks=False)
-    boxes = {"words": np.random.rand(words_per_page, 6)}
-    boxes["words"][:2] *= boxes["words"][2:4]
+    boxes = np.random.rand(words_per_page, 6)
+    boxes[:2] *= boxes[2:4]
 
     # Arg consistency check
     with pytest.raises(ValueError):
-        doc_builder([boxes, boxes], [{"words": ("hello", 1.0)}] * 3, [(100, 200), (100, 200)])
+        doc_builder([boxes, boxes], [{CLASS_NAME: ("hello", 1.0)}] * 3, [(100, 200), (100, 200)])
     out = doc_builder(
-        [boxes, boxes], [{"words": [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
+        [boxes, boxes], [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
     )
     assert isinstance(out, Document)
     assert len(out.pages) == num_pages
     # 1 Block & 1 line per page
-    assert len(out.pages[0].blocks) == 1 and len(out.pages[0].blocks["words"][0].lines) == 1
-    assert len(out.pages[0].blocks["words"][0].lines[0].words) == words_per_page
+    assert len(out.pages[0].blocks) == 1 and len(out.pages[0].blocks[CLASS_NAME][0].lines) == 1
+    assert len(out.pages[0].blocks[CLASS_NAME][0].lines[0].words) == words_per_page
 
     # Resolve lines
     doc_builder = builder.DocumentBuilder(resolve_lines=True, resolve_blocks=True)
     out = doc_builder(
-        [boxes, boxes], [{"words": [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
+        [boxes, boxes], [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
     )
 
     # No detection
-    boxes = {"words": np.zeros((0, 5))}
-    out = doc_builder([boxes, boxes], [{"words": []}, {"words": []}], [(100, 200), (100, 200)])
-    assert len(out.pages[0].blocks["words"]) == 0
+    boxes = {CLASS_NAME: np.zeros((0, 5))}
+    out = doc_builder([boxes, boxes], [{CLASS_NAME: []}, {CLASS_NAME: []}], [(100, 200), (100, 200)])
+    assert len(out.pages[0].blocks[CLASS_NAME]) == 0
 
     # Rotated boxes to export as straight boxes
     boxes = {
-        "words": np.array(
+        CLASS_NAME: np.array(
             [
                 [[0.1, 0.1], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15]],
                 [[0.5, 0.5], [0.6, 0.6], [0.55, 0.65], [0.45, 0.55]],
@@ -48,8 +102,8 @@ def test_documentbuilder():
         )
     }
     doc_builder_2 = builder.DocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
-    out = doc_builder_2([boxes], [{"words": [("hello", 0.99), ("world", 0.99)]}], [(100, 100)])
-    assert out.pages[0].blocks["words"][0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
+    out = doc_builder_2([boxes], [{CLASS_NAME: [("hello", 0.99), (CLASS_NAME, 0.99)]}], [(100, 100)])
+    assert out.pages[0].blocks[CLASS_NAME][0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
 
     # Repr
     assert (

--- a/tests/common/test_models_builder.py
+++ b/tests/common/test_models_builder.py
@@ -5,69 +5,24 @@ from doctr.file_utils import CLASS_NAME
 from doctr.io import Document
 from doctr.models import builder
 
+words_per_page = 10
 
-def test_documentbuilder_dict_blocks():
+boxes_1 = {CLASS_NAME: np.random.rand(words_per_page, 6)}  # dict format
+boxes_1[CLASS_NAME][:2] *= boxes_1[CLASS_NAME][2:4]
 
-    words_per_page = 10
+boxes_2 = np.random.rand(words_per_page, 6)  # array format
+boxes_2[:2] *= boxes_2[2:4]
+
+
+@pytest.mark.parametrize("boxes", [boxes_1, boxes_2])
+def test_documentbuilder(boxes):
+
     num_pages = 2
 
     # Don't resolve lines
     doc_builder = builder.DocumentBuilder(resolve_lines=False, resolve_blocks=False)
     boxes = {CLASS_NAME: np.random.rand(words_per_page, 6)}
     boxes[CLASS_NAME][:2] *= boxes[CLASS_NAME][2:4]
-
-    # Arg consistency check
-    with pytest.raises(ValueError):
-        doc_builder([boxes, boxes], [{CLASS_NAME: ("hello", 1.0)}] * 3, [(100, 200), (100, 200)])
-    out = doc_builder(
-        [boxes, boxes], [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
-    )
-    assert isinstance(out, Document)
-    assert len(out.pages) == num_pages
-    # 1 Block & 1 line per page
-    assert len(out.pages[0].blocks) == 1 and len(out.pages[0].blocks[CLASS_NAME][0].lines) == 1
-    assert len(out.pages[0].blocks[CLASS_NAME][0].lines[0].words) == words_per_page
-
-    # Resolve lines
-    doc_builder = builder.DocumentBuilder(resolve_lines=True, resolve_blocks=True)
-    out = doc_builder(
-        [boxes, boxes], [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages, [(100, 200), (100, 200)]
-    )
-
-    # No detection
-    boxes = {CLASS_NAME: np.zeros((0, 5))}
-    out = doc_builder([boxes, boxes], [{CLASS_NAME: []}, {CLASS_NAME: []}], [(100, 200), (100, 200)])
-    assert len(out.pages[0].blocks[CLASS_NAME]) == 0
-
-    # Rotated boxes to export as straight boxes
-    boxes = {
-        CLASS_NAME: np.array(
-            [
-                [[0.1, 0.1], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15]],
-                [[0.5, 0.5], [0.6, 0.6], [0.55, 0.65], [0.45, 0.55]],
-            ]
-        )
-    }
-    doc_builder_2 = builder.DocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
-    out = doc_builder_2([boxes], [{CLASS_NAME: [("hello", 0.99), (CLASS_NAME, 0.99)]}], [(100, 100)])
-    assert out.pages[0].blocks[CLASS_NAME][0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
-
-    # Repr
-    assert (
-        repr(doc_builder) == "DocumentBuilder(resolve_lines=True, "
-        "resolve_blocks=True, paragraph_break=0.035, export_as_straight_boxes=False)"
-    )
-
-
-def test_documentbuilder():
-
-    words_per_page = 10
-    num_pages = 2
-
-    # Don't resolve lines
-    doc_builder = builder.DocumentBuilder(resolve_lines=False, resolve_blocks=False)
-    boxes = np.random.rand(words_per_page, 6)
-    boxes[:2] *= boxes[2:4]
 
     # Arg consistency check
     with pytest.raises(ValueError):

--- a/tests/common/test_models_builder.py
+++ b/tests/common/test_models_builder.py
@@ -21,9 +21,6 @@ def test_documentbuilder(boxes):
 
     # Don't resolve lines
     doc_builder = builder.DocumentBuilder(resolve_lines=False, resolve_blocks=False)
-    boxes = {CLASS_NAME: np.random.rand(words_per_page, 6)}
-    boxes[CLASS_NAME][:2] *= boxes[CLASS_NAME][2:4]
-
     # Arg consistency check
     with pytest.raises(ValueError):
         doc_builder([boxes, boxes], [{CLASS_NAME: ("hello", 1.0)}] * 3, [(100, 200), (100, 200)])

--- a/tests/common/test_models_builder.py
+++ b/tests/common/test_models_builder.py
@@ -50,7 +50,7 @@ def test_documentbuilder():
         ]
     )
     doc_builder_2 = builder.DocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
-    out = doc_builder_2([boxes], [[("hello", 0.99), (CLASS_NAME, 0.99)]], [(100, 100)])
+    out = doc_builder_2([boxes], [[("hello", 0.99), ("word", 0.99)]], [(100, 100)])
     assert out.pages[0].blocks[0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
 
     # Repr
@@ -79,8 +79,8 @@ def test_kiedocumentbuilder():
     assert isinstance(out, KIEDocument)
     assert len(out.pages) == num_pages
     # 1 Block & 1 line per page
-    assert len(out.pages[0].predictions) == 1 and len(out.pages[0].predictions[CLASS_NAME][0].lines) == 1
-    assert len(out.pages[0].predictions[CLASS_NAME][0].lines[0].words) == words_per_page
+    assert len(out.pages[0].predictions) == 1
+    assert len(out.pages[0].predictions[CLASS_NAME]) == words_per_page
 
     # Resolve lines
     doc_builder = builder.KIEDocumentBuilder(resolve_lines=True, resolve_blocks=True)
@@ -105,8 +105,9 @@ def test_kiedocumentbuilder():
         )
     }
     doc_builder_2 = builder.KIEDocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
-    out = doc_builder_2([predictions], [{CLASS_NAME: [("hello", 0.99), (CLASS_NAME, 0.99)]}], [(100, 100)])
-    assert out.pages[0].predictions[CLASS_NAME][0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
+    out = doc_builder_2([predictions], [{CLASS_NAME: [("hello", 0.99), ("word", 0.99)]}], [(100, 100)])
+    assert out.pages[0].predictions[CLASS_NAME][0].geometry == ((0.05, 0.1), (0.2, 0.25))
+    assert out.pages[0].predictions[CLASS_NAME][1].geometry == ((0.45, 0.5), (0.6, 0.65))
 
     # Repr
     assert (

--- a/tests/pytorch/test_models_detection_pt.py
+++ b/tests/pytorch/test_models_detection_pt.py
@@ -44,10 +44,11 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     if out_prob:
         assert torch.all((out["out_map"] >= 0) & (out["out_map"] <= 1))
     # Check boxes
-    for boxes in out["preds"]:
-        assert boxes.shape[1] == 5
-        assert np.all(boxes[:, :2] < boxes[:, 2:4])
-        assert np.all(boxes[:, :4] >= 0) and np.all(boxes[:, :4] <= 1)
+    for boxes_dict in out["preds"]:
+        for boxes in boxes_dict.values():
+            assert boxes.shape[1] == 5
+            assert np.all(boxes[:, :2] < boxes[:, 2:4])
+            assert np.all(boxes[:, :4] >= 0) and np.all(boxes[:, :4] <= 1)
     # Check loss
     assert isinstance(out["loss"], torch.Tensor)
     # Check the rotated case (same targets)
@@ -87,7 +88,7 @@ def test_detection_zoo(arch_name):
 
     with torch.no_grad():
         out = predictor(input_tensor)
-    assert all(isinstance(boxes, np.ndarray) and boxes.shape[1] == 5 for boxes in out)
+    assert all(isinstance(boxes, dict) and boxes["words"].shape[1] == 5 for boxes in out)
 
 
 def test_erode():

--- a/tests/pytorch/test_models_detection_pt.py
+++ b/tests/pytorch/test_models_detection_pt.py
@@ -30,8 +30,8 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     assert isinstance(model, torch.nn.Module)
     input_tensor = torch.rand((batch_size, *input_shape))
     target = [
-        np.array([[0.5, 0.5, 1, 1], [0.5, 0.5, 0.8, 0.8]], dtype=np.float32),
-        np.array([[0.5, 0.5, 1, 1], [0.5, 0.5, 0.8, 0.9]], dtype=np.float32),
+        {CLASS_NAME: np.array([[0.5, 0.5, 1, 1], [0.5, 0.5, 0.8, 0.8]], dtype=np.float32)},
+        {CLASS_NAME: np.array([[0.5, 0.5, 1, 1], [0.5, 0.5, 0.8, 0.9]], dtype=np.float32)},
     ]
     if torch.cuda.is_available():
         model.cuda()
@@ -54,14 +54,18 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     assert isinstance(out["loss"], torch.Tensor)
     # Check the rotated case (same targets)
     target = [
-        np.array(
-            [[[0.5, 0.5], [1, 0.5], [1, 1], [0.5, 1]], [[0.5, 0.5], [0.8, 0.5], [0.8, 0.8], [0.5, 0.8]]],
-            dtype=np.float32,
-        ),
-        np.array(
-            [[[0.5, 0.5], [1, 0.5], [1, 1], [0.5, 1]], [[0.5, 0.5], [0.8, 0.5], [0.8, 0.9], [0.5, 0.9]]],
-            dtype=np.float32,
-        ),
+        {
+            CLASS_NAME: np.array(
+                [[[0.5, 0.5], [1, 0.5], [1, 1], [0.5, 1]], [[0.5, 0.5], [0.8, 0.5], [0.8, 0.8], [0.5, 0.8]]],
+                dtype=np.float32,
+            )
+        },
+        {
+            CLASS_NAME: np.array(
+                [[[0.5, 0.5], [1, 0.5], [1, 1], [0.5, 1]], [[0.5, 0.5], [0.8, 0.5], [0.8, 0.9], [0.5, 0.9]]],
+                dtype=np.float32,
+            )
+        },
     ]
     loss = model(input_tensor, target)["loss"]
     assert isinstance(loss, torch.Tensor) and ((loss - out["loss"]).abs() / loss).item() < 1e-1

--- a/tests/pytorch/test_models_detection_pt.py
+++ b/tests/pytorch/test_models_detection_pt.py
@@ -6,6 +6,7 @@ import onnxruntime
 import pytest
 import torch
 
+from doctr.file_utils import CLASS_NAME
 from doctr.models import detection
 from doctr.models.detection._utils import dilate, erode
 from doctr.models.detection.predictor import DetectionPredictor
@@ -88,7 +89,8 @@ def test_detection_zoo(arch_name):
 
     with torch.no_grad():
         out = predictor(input_tensor)
-    assert all(isinstance(boxes, dict) and boxes["words"].shape[1] == 5 for boxes in out)
+    assert all(isinstance(boxes, dict) for boxes in out)
+    assert all(isinstance(boxes[CLASS_NAME], np.ndarray) and boxes[CLASS_NAME].shape[1] == 5 for boxes in out)
 
 
 def test_erode():

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -4,8 +4,10 @@ from torch import nn
 
 from doctr import models
 from doctr.io import Document, DocumentFile
+from doctr.io.elements import KIEDocument
 from doctr.models import detection, recognition
 from doctr.models.detection.predictor import DetectionPredictor
+from doctr.models.kie_predictor import KIEPredictor
 from doctr.models.predictor import OCRPredictor
 from doctr.models.preprocessor import PreProcessor
 from doctr.models.recognition.predictor import RecognitionPredictor
@@ -68,6 +70,63 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
     assert out.pages[0].orientation["value"] == orientation
 
 
+@pytest.mark.parametrize(
+    "assume_straight_pages, straighten_pages",
+    [
+        [True, False],
+        [False, False],
+        [True, True],
+    ],
+)
+def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages):
+    det_bsize = 4
+    det_predictor = DetectionPredictor(
+        PreProcessor(output_size=(512, 512), batch_size=det_bsize),
+        detection.db_mobilenet_v3_large(
+            pretrained=False,
+            pretrained_backbone=False,
+            assume_straight_pages=assume_straight_pages,
+        ),
+    )
+
+    assert not det_predictor.model.training
+
+    reco_bsize = 32
+    reco_predictor = RecognitionPredictor(
+        PreProcessor(output_size=(32, 128), batch_size=reco_bsize, preserve_aspect_ratio=True),
+        recognition.crnn_vgg16_bn(pretrained=False, pretrained_backbone=False, vocab=mock_vocab),
+    )
+
+    assert not reco_predictor.model.training
+
+    doc = DocumentFile.from_pdf(mock_pdf)
+
+    predictor = KIEPredictor(
+        det_predictor,
+        reco_predictor,
+        assume_straight_pages=assume_straight_pages,
+        straighten_pages=straighten_pages,
+        detect_orientation=True,
+        detect_language=True,
+    )
+
+    if assume_straight_pages:
+        assert predictor.crop_orientation_predictor is None
+    else:
+        assert isinstance(predictor.crop_orientation_predictor, nn.Module)
+
+    out = predictor(doc)
+    assert isinstance(out, Document)
+    assert len(out.pages) == 2
+    # Dimension check
+    with pytest.raises(ValueError):
+        input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
+        _ = predictor([input_page])
+
+    orientation = 0
+    assert out.pages[0].orientation["value"] == orientation
+
+
 def _test_predictor(predictor):
     # Output checks
     assert isinstance(predictor, OCRPredictor)
@@ -76,6 +135,23 @@ def _test_predictor(predictor):
     out = predictor(doc)
     # Document
     assert isinstance(out, Document)
+
+    # The input doc has 1 page
+    assert len(out.pages) == 1
+    # Dimension check
+    with pytest.raises(ValueError):
+        input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
+        _ = predictor([input_page])
+
+
+def _test_kiepredictor(predictor):
+    # Output checks
+    assert isinstance(predictor, KIEPredictor)
+
+    doc = [np.zeros((512, 512, 3), dtype=np.uint8)]
+    out = predictor(doc)
+    # Document
+    assert isinstance(out, KIEDocument)
 
     # The input doc has 1 page
     assert len(out.pages) == 1
@@ -109,3 +185,21 @@ def test_zoo_models(det_arch, reco_arch):
     # passing detection model as recognition model
     with pytest.raises(ValueError):
         models.ocr_predictor(reco_arch=det_model, pretrained=True)
+
+    # KIE predictor
+    predictor = models.kie_predictor(det_arch, reco_arch, pretrained=True)
+    _test_kiepredictor(predictor)
+
+    # passing model instance directly
+    det_model = detection.__dict__[det_arch](pretrained=True)
+    reco_model = recognition.__dict__[reco_arch](pretrained=True)
+    predictor = models.kie_predictor(det_model, reco_model)
+    _test_kiepredictor(predictor)
+
+    # passing recognition model as detection model
+    with pytest.raises(ValueError):
+        models.kie_predictor(det_arch=reco_model, pretrained=True)
+
+    # passing detection model as recognition model
+    with pytest.raises(ValueError):
+        models.kie_predictor(reco_arch=det_model, pretrained=True)

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 
 from doctr import datasets
 from doctr.datasets import DataLoader
+from doctr.file_utils import CLASS_NAME
 from doctr.transforms import Resize
 
 
@@ -66,11 +67,13 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     )
 
     assert len(ds) == 5
-    img, target = ds[0]
+    img, target_dict = ds[0]
+    target = target_dict[CLASS_NAME]
     assert isinstance(img, tf.Tensor)
     assert img.shape[:2] == input_size
     assert img.dtype == tf.float32
     # Bounding boxes
+    assert isinstance(target_dict, dict)
     assert isinstance(target, np.ndarray) and target.dtype == np.float32
     assert np.all(np.logical_and(target[:, :4] >= 0, target[:, :4] <= 1))
     assert target.shape[1] == 4
@@ -78,7 +81,9 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
     loader = DataLoader(ds, batch_size=2)
     images, targets = next(iter(loader))
     assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
-    assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
+    assert isinstance(targets, list) and all(
+        isinstance(elt, np.ndarray) for target in targets for elt in target.values()
+    )
 
     # Rotated DS
     rotated_ds = datasets.DetectionDataset(
@@ -88,7 +93,7 @@ def test_detection_dataset(mock_image_folder, mock_detection_label):
         use_polygons=True,
     )
     _, r_target = rotated_ds[0]
-    assert r_target.shape[1:] == (4, 2)
+    assert r_target[CLASS_NAME].shape[1:] == (4, 2)
 
     # File existence check
     img_name, _ = ds.data[0]

--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -32,8 +32,8 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     assert isinstance(model, tf.keras.Model)
     input_tensor = tf.random.uniform(shape=[batch_size, *input_shape], minval=0, maxval=1)
     target = [
-        np.array([[0.5, 0.5, 1, 1], [0.5, 0.5, 0.8, 0.8]], dtype=np.float32),
-        np.array([[0.5, 0.5, 1, 1], [0.5, 0.5, 0.8, 0.9]], dtype=np.float32),
+        {CLASS_NAME: np.array([[0.5, 0.5, 1, 1], [0.5, 0.5, 0.8, 0.8]], dtype=np.float32)},
+        {CLASS_NAME: np.array([[0.5, 0.5, 1, 1], [0.5, 0.5, 0.8, 0.9]], dtype=np.float32)},
     ]
     # test training model
     out = model(input_tensor, target, return_model_output=True, return_preds=True, training=True)
@@ -56,23 +56,23 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     assert isinstance(out["loss"], tf.Tensor)
     # Target checks
     target = [
-        np.array([[0, 0, 1, 1]], dtype=np.uint8),
-        np.array([[0, 0, 1, 1]], dtype=np.uint8),
+        {CLASS_NAME: np.array([[0, 0, 1, 1]], dtype=np.uint8)},
+        {CLASS_NAME: np.array([[0, 0, 1, 1]], dtype=np.uint8)},
     ]
     with pytest.raises(AssertionError):
         out = model(input_tensor, target, training=True)
 
     target = [
-        np.array([[0, 0, 1.5, 1.5]], dtype=np.float32),
-        np.array([[-0.2, -0.3, 1, 1]], dtype=np.float32),
+        {CLASS_NAME: np.array([[0, 0, 1.5, 1.5]], dtype=np.float32)},
+        {CLASS_NAME: np.array([[-0.2, -0.3, 1, 1]], dtype=np.float32)},
     ]
     with pytest.raises(ValueError):
         out = model(input_tensor, target, training=True)
 
     # Check the rotated case
     target = [
-        np.array([[0.75, 0.75, 0.5, 0.5, 0], [0.65, 0.65, 0.3, 0.3, 0]], dtype=np.float32),
-        np.array([[0.75, 0.75, 0.5, 0.5, 0], [0.65, 0.7, 0.3, 0.4, 0]], dtype=np.float32),
+        {CLASS_NAME: np.array([[0.75, 0.75, 0.5, 0.5, 0], [0.65, 0.65, 0.3, 0.3, 0]], dtype=np.float32)},
+        {CLASS_NAME: np.array([[0.75, 0.75, 0.5, 0.5, 0], [0.65, 0.7, 0.3, 0.4, 0]], dtype=np.float32)},
     ]
     loss = model(input_tensor, target, training=True)["loss"]
     assert isinstance(loss, tf.Tensor) and ((loss - out["loss"]) / loss).numpy() < 25e-2

--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -46,10 +46,11 @@ def test_detection_models(arch_name, input_shape, output_size, out_prob):
     if out_prob:
         assert np.all(np.logical_and(seg_map >= 0, seg_map <= 1))
     # Check boxes
-    for boxes in out["preds"]:
-        assert boxes.shape[1] == 5
-        assert np.all(boxes[:, :2] < boxes[:, 2:4])
-        assert np.all(boxes[:, :4] >= 0) and np.all(boxes[:, :4] <= 1)
+    for boxes_dict in out["preds"]:
+        for boxes in boxes_dict.values():
+            assert boxes.shape[1] == 5
+            assert np.all(boxes[:, :2] < boxes[:, 2:4])
+            assert np.all(boxes[:, :4] >= 0) and np.all(boxes[:, :4] <= 1)
     # Check loss
     assert isinstance(out["loss"], tf.Tensor)
     # Target checks
@@ -136,7 +137,7 @@ def test_detection_zoo(arch_name):
     assert isinstance(predictor, DetectionPredictor)
     input_tensor = tf.random.uniform(shape=[2, 1024, 1024, 3], minval=0, maxval=1)
     out = predictor(input_tensor)
-    assert all(isinstance(boxes, np.ndarray) and boxes.shape[1] == 5 for boxes in out)
+    assert all(isinstance(boxes, dict) and boxes["words"].shape[1] == 5 for boxes in out)
 
 
 def test_detection_zoo_error():

--- a/tests/tensorflow/test_models_detection_tf.py
+++ b/tests/tensorflow/test_models_detection_tf.py
@@ -6,6 +6,7 @@ import onnxruntime
 import pytest
 import tensorflow as tf
 
+from doctr.file_utils import CLASS_NAME
 from doctr.io import DocumentFile
 from doctr.models import detection
 from doctr.models.detection._utils import dilate, erode
@@ -137,7 +138,8 @@ def test_detection_zoo(arch_name):
     assert isinstance(predictor, DetectionPredictor)
     input_tensor = tf.random.uniform(shape=[2, 1024, 1024, 3], minval=0, maxval=1)
     out = predictor(input_tensor)
-    assert all(isinstance(boxes, dict) and boxes["words"].shape[1] == 5 for boxes in out)
+    assert all(isinstance(boxes, dict) for boxes in out)
+    assert all(isinstance(boxes[CLASS_NAME], np.ndarray) and boxes[CLASS_NAME].shape[1] == 5 for boxes in out)
 
 
 def test_detection_zoo_error():

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -84,17 +84,17 @@ def test_trained_ocr_predictor(mock_tilted_payslip):
 
     out = predictor(doc)
 
-    assert out.pages[0].blocks[0].lines[0].words[0].value == "Mr."
+    assert out.pages[0].blocks["words"][0].lines[0].words[0].value == "Mr."
     geometry_mr = np.array(
         [[0.08844472, 0.35763523], [0.11625107, 0.34320644], [0.12588427, 0.35771032], [0.09807791, 0.37213911]]
     )
-    assert np.allclose(np.array(out.pages[0].blocks[0].lines[0].words[0].geometry), geometry_mr)
+    assert np.allclose(np.array(out.pages[0].blocks["words"][0].lines[0].words[0].geometry), geometry_mr)
 
-    assert out.pages[0].blocks[1].lines[0].words[-1].value == "revised"
+    assert out.pages[0].blocks["words"][1].lines[0].words[-1].value == "revised"
     geometry_revised = np.array(
         [[0.50422498, 0.19551784], [0.55741975, 0.16791493], [0.56705294, 0.18241881], [0.51385817, 0.21002172]]
     )
-    assert np.allclose(np.array(out.pages[0].blocks[1].lines[0].words[-1].geometry), geometry_revised)
+    assert np.allclose(np.array(out.pages[0].blocks["words"][1].lines[0].words[-1].geometry), geometry_revised)
 
     det_predictor = detection_predictor(
         "db_resnet50",
@@ -116,7 +116,7 @@ def test_trained_ocr_predictor(mock_tilted_payslip):
 
     out = predictor(doc)
 
-    assert out.pages[0].blocks[0].lines[0].words[0].value == "Mr."
+    assert out.pages[0].blocks["words"][0].lines[0].words[0].value == "Mr."
 
 
 def _test_predictor(predictor):

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -194,17 +194,17 @@ def test_trained_kie_predictor(mock_tilted_payslip):
     out = predictor(doc)
 
     assert isinstance(out, KIEDocument)
-    assert out.pages[0].predictions[CLASS_NAME][0].lines[0].words[0].value == "Mr."
+    assert out.pages[0].predictions[CLASS_NAME][0].value == "Mr."
     geometry_mr = np.array(
         [[0.08844472, 0.35763523], [0.11625107, 0.34320644], [0.12588427, 0.35771032], [0.09807791, 0.37213911]]
     )
-    assert np.allclose(np.array(out.pages[0].predictions[CLASS_NAME][0].lines[0].words[0].geometry), geometry_mr)
+    assert np.allclose(np.array(out.pages[0].predictions[CLASS_NAME][0].geometry), geometry_mr)
 
-    assert out.pages[0].predictions[CLASS_NAME][1].lines[0].words[-1].value == "revised"
+    assert out.pages[0].predictions[CLASS_NAME][-1].value == "Kabir)"
     geometry_revised = np.array(
-        [[0.50422498, 0.19551784], [0.55741975, 0.16791493], [0.56705294, 0.18241881], [0.51385817, 0.21002172]]
+        [[0.43725992, 0.67232439], [0.49045468, 0.64472149], [0.50570724, 0.66768597], [0.452512473, 0.69528887]]
     )
-    assert np.allclose(np.array(out.pages[0].predictions[CLASS_NAME][1].lines[0].words[-1].geometry), geometry_revised)
+    assert np.allclose(np.array(out.pages[0].predictions[CLASS_NAME][-1].geometry), geometry_revised)
 
     det_predictor = detection_predictor(
         "db_resnet50",
@@ -227,7 +227,7 @@ def test_trained_kie_predictor(mock_tilted_payslip):
     out = predictor(doc)
 
     assert isinstance(out, KIEDocument)
-    assert out.pages[0].predictions[CLASS_NAME][0].lines[0].words[0].value == "Mr."
+    assert out.pages[0].predictions[CLASS_NAME][0].value == "Mr."
 
 
 def _test_predictor(predictor):

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -4,9 +4,11 @@ import pytest
 from doctr import models
 from doctr.file_utils import CLASS_NAME
 from doctr.io import Document, DocumentFile
+from doctr.io.elements import KIEDocument
 from doctr.models import detection, recognition
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.detection.zoo import detection_predictor
+from doctr.models.kie_predictor import KIEPredictor
 from doctr.models.predictor import OCRPredictor
 from doctr.models.preprocessor import PreProcessor
 from doctr.models.recognition.predictor import RecognitionPredictor
@@ -85,17 +87,17 @@ def test_trained_ocr_predictor(mock_tilted_payslip):
 
     out = predictor(doc)
 
-    assert out.pages[0].blocks[CLASS_NAME][0].lines[0].words[0].value == "Mr."
+    assert out.pages[0].blocks[0].lines[0].words[0].value == "Mr."
     geometry_mr = np.array(
         [[0.08844472, 0.35763523], [0.11625107, 0.34320644], [0.12588427, 0.35771032], [0.09807791, 0.37213911]]
     )
-    assert np.allclose(np.array(out.pages[0].blocks[CLASS_NAME][0].lines[0].words[0].geometry), geometry_mr)
+    assert np.allclose(np.array(out.pages[0].blocks[0].lines[0].words[0].geometry), geometry_mr)
 
-    assert out.pages[0].blocks[CLASS_NAME][1].lines[0].words[-1].value == "revised"
+    assert out.pages[0].blocks[1].lines[0].words[-1].value == "revised"
     geometry_revised = np.array(
         [[0.50422498, 0.19551784], [0.55741975, 0.16791493], [0.56705294, 0.18241881], [0.51385817, 0.21002172]]
     )
-    assert np.allclose(np.array(out.pages[0].blocks[CLASS_NAME][1].lines[0].words[-1].geometry), geometry_revised)
+    assert np.allclose(np.array(out.pages[0].blocks[1].lines[0].words[-1].geometry), geometry_revised)
 
     det_predictor = detection_predictor(
         "db_resnet50",
@@ -117,7 +119,115 @@ def test_trained_ocr_predictor(mock_tilted_payslip):
 
     out = predictor(doc)
 
-    assert out.pages[0].blocks[CLASS_NAME][0].lines[0].words[0].value == "Mr."
+    assert out.pages[0].blocks[0].lines[0].words[0].value == "Mr."
+
+
+@pytest.mark.parametrize(
+    "assume_straight_pages, straighten_pages",
+    [
+        [True, False],
+        [False, False],
+        [True, True],
+    ],
+)
+def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages):
+    det_bsize = 4
+    det_predictor = DetectionPredictor(
+        PreProcessor(output_size=(512, 512), batch_size=det_bsize),
+        detection.db_mobilenet_v3_large(
+            pretrained=True,
+            pretrained_backbone=False,
+            input_shape=(512, 512, 3),
+            assume_straight_pages=assume_straight_pages,
+        ),
+    )
+
+    reco_bsize = 16
+    reco_predictor = RecognitionPredictor(
+        PreProcessor(output_size=(32, 128), batch_size=reco_bsize, preserve_aspect_ratio=True),
+        recognition.crnn_vgg16_bn(pretrained=False, pretrained_backbone=False, vocab=mock_vocab),
+    )
+
+    doc = DocumentFile.from_pdf(mock_pdf)
+
+    predictor = KIEPredictor(
+        det_predictor,
+        reco_predictor,
+        assume_straight_pages=assume_straight_pages,
+        straighten_pages=straighten_pages,
+        detect_orientation=True,
+        detect_language=True,
+    )
+
+    if assume_straight_pages:
+        assert predictor.crop_orientation_predictor is None
+    else:
+        assert isinstance(predictor.crop_orientation_predictor, NestedObject)
+
+    out = predictor(doc)
+    assert isinstance(out, KIEDocument)
+    assert len(out.pages) == 2
+    # Dimension check
+    with pytest.raises(ValueError):
+        input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
+        _ = predictor([input_page])
+
+    orientation = 0
+    assert out.pages[0].orientation["value"] == orientation
+    language = "unknown"
+    assert out.pages[0].language["value"] == language
+
+
+def test_trained_kie_predictor(mock_tilted_payslip):
+    doc = DocumentFile.from_images(mock_tilted_payslip)
+
+    det_predictor = detection_predictor("db_resnet50", pretrained=True, batch_size=2, assume_straight_pages=True)
+    reco_predictor = recognition_predictor("crnn_vgg16_bn", pretrained=True, batch_size=128)
+
+    predictor = KIEPredictor(
+        det_predictor,
+        reco_predictor,
+        assume_straight_pages=True,
+        straighten_pages=True,
+    )
+
+    out = predictor(doc)
+
+    assert isinstance(out, KIEDocument)
+    assert out.pages[0].predictions[CLASS_NAME][0].lines[0].words[0].value == "Mr."
+    geometry_mr = np.array(
+        [[0.08844472, 0.35763523], [0.11625107, 0.34320644], [0.12588427, 0.35771032], [0.09807791, 0.37213911]]
+    )
+    assert np.allclose(np.array(out.pages[0].predictions[CLASS_NAME][0].lines[0].words[0].geometry), geometry_mr)
+
+    assert out.pages[0].predictions[CLASS_NAME][1].lines[0].words[-1].value == "revised"
+    geometry_revised = np.array(
+        [[0.50422498, 0.19551784], [0.55741975, 0.16791493], [0.56705294, 0.18241881], [0.51385817, 0.21002172]]
+    )
+    assert np.allclose(np.array(out.pages[0].predictions[CLASS_NAME][1].lines[0].words[-1].geometry), geometry_revised)
+
+    det_predictor = detection_predictor(
+        "db_resnet50",
+        pretrained=True,
+        batch_size=2,
+        assume_straight_pages=True,
+        preserve_aspect_ratio=True,
+        symmetric_pad=True,
+    )
+
+    predictor = KIEPredictor(
+        det_predictor,
+        reco_predictor,
+        assume_straight_pages=True,
+        straighten_pages=True,
+        preserve_aspect_ratio=True,
+        symmetric_pad=True,
+    )
+
+    out = predictor(doc)
+
+    assert isinstance(out, KIEDocument)
+    assert out.pages[0].predictions[CLASS_NAME][0].lines[0].words[0].value == "Mr."
 
 
 def _test_predictor(predictor):
@@ -128,6 +238,23 @@ def _test_predictor(predictor):
     out = predictor(doc)
     # Document
     assert isinstance(out, Document)
+
+    # The input doc has 1 page
+    assert len(out.pages) == 1
+    # Dimension check
+    with pytest.raises(ValueError):
+        input_page = (255 * np.random.rand(1, 256, 512, 3)).astype(np.uint8)
+        _ = predictor([input_page])
+
+
+def _test_kiepredictor(predictor):
+    # Output checks
+    assert isinstance(predictor, KIEPredictor)
+
+    doc = [np.zeros((512, 512, 3), dtype=np.uint8)]
+    out = predictor(doc)
+    # Document
+    assert isinstance(out, KIEDocument)
 
     # The input doc has 1 page
     assert len(out.pages) == 1
@@ -161,3 +288,21 @@ def test_zoo_models(det_arch, reco_arch):
     # passing detection model as recognition model
     with pytest.raises(ValueError):
         models.ocr_predictor(reco_arch=det_model, pretrained=True)
+
+    # KIE predictor
+    predictor = models.kie_predictor(det_arch, reco_arch, pretrained=True)
+    _test_kiepredictor(predictor)
+
+    # passing model instance directly
+    det_model = detection.__dict__[det_arch](pretrained=True)
+    reco_model = recognition.__dict__[reco_arch](pretrained=True)
+    predictor = models.kie_predictor(det_model, reco_model)
+    _test_kiepredictor(predictor)
+
+    # passing recognition model as detection model
+    with pytest.raises(ValueError):
+        models.kie_predictor(det_arch=reco_model, pretrained=True)
+
+    # passing detection model as recognition model
+    with pytest.raises(ValueError):
+        models.kie_predictor(reco_arch=det_model, pretrained=True)

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from doctr import models
+from doctr.file_utils import CLASS_NAME
 from doctr.io import Document, DocumentFile
 from doctr.models import detection, recognition
 from doctr.models.detection.predictor import DetectionPredictor
@@ -84,17 +85,17 @@ def test_trained_ocr_predictor(mock_tilted_payslip):
 
     out = predictor(doc)
 
-    assert out.pages[0].blocks["words"][0].lines[0].words[0].value == "Mr."
+    assert out.pages[0].blocks[CLASS_NAME][0].lines[0].words[0].value == "Mr."
     geometry_mr = np.array(
         [[0.08844472, 0.35763523], [0.11625107, 0.34320644], [0.12588427, 0.35771032], [0.09807791, 0.37213911]]
     )
-    assert np.allclose(np.array(out.pages[0].blocks["words"][0].lines[0].words[0].geometry), geometry_mr)
+    assert np.allclose(np.array(out.pages[0].blocks[CLASS_NAME][0].lines[0].words[0].geometry), geometry_mr)
 
-    assert out.pages[0].blocks["words"][1].lines[0].words[-1].value == "revised"
+    assert out.pages[0].blocks[CLASS_NAME][1].lines[0].words[-1].value == "revised"
     geometry_revised = np.array(
         [[0.50422498, 0.19551784], [0.55741975, 0.16791493], [0.56705294, 0.18241881], [0.51385817, 0.21002172]]
     )
-    assert np.allclose(np.array(out.pages[0].blocks["words"][1].lines[0].words[-1].geometry), geometry_revised)
+    assert np.allclose(np.array(out.pages[0].blocks[CLASS_NAME][1].lines[0].words[-1].geometry), geometry_revised)
 
     det_predictor = detection_predictor(
         "db_resnet50",
@@ -116,7 +117,7 @@ def test_trained_ocr_predictor(mock_tilted_payslip):
 
     out = predictor(doc)
 
-    assert out.pages[0].blocks["words"][0].lines[0].words[0].value == "Mr."
+    assert out.pages[0].blocks[CLASS_NAME][0].lines[0].words[0].value == "Mr."
 
 
 def _test_predictor(predictor):


### PR DESCRIPTION
Hello, this PR is to make the detection part of DocTR multiclass.

:warning: This PR has a breaking change on the use of DocTR. The attribute `blocks` of class `Page` is no longer a list of blocks but a dictionnary with keys being the class names. 

- [x] Training detection model tf/torch working with new data format to include class and also old data format
- [x] Inference with ocr_predictor working tf/torch
- [x] visulization and export
- [x] middleware and hf api not changed should work without changes
- [x] minimal API: some changes in the docker file and doc to make it work 

A first review of the code was done on my fork. you can find it here: https://github.com/aminemindee/doctr/pull/4 


Any feedback is welcome!