### PR TITLE
fix: :wrench: docker api use GitHub repository

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,4 @@ jobs:
         run: wget --spider --tries=12 http://localhost:8080/docs
       - name: Run docker test
         run: |
-          docker cp api/requirements-dev.txt api_web_1:/app/requirements-dev.txt
-          docker-compose -f api/docker-compose.yml exec -T web pip install -r requirements-dev.txt
-          docker cp api/tests api_web_1:/app/tests
-          docker-compose -f api/docker-compose.yml exec -T web pytest tests/
+          docker-compose -f api/docker-compose.yml exec --no-TTY web pytest tests/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH "${PYTHONPATH}:/app"
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends ffmpeg libsm6 libxext6 make -y \
+    && apt-get install --no-install-recommends git ffmpeg libsm6 libxext6 make -y \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 services:
   web:
+    container_name: api_web
     build:
       context: .
       dockerfile: Dockerfile

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 python = ">=3.8.2,<3.11"  # pypdfium2 needs a python version above 3.8.2
 tensorflow = ">=2.9.0,<3.0.0"
 tensorflow-addons = ">=0.17.1"
-python-doctr = { version = ">=0.7.0", extras = ['tf'] }
+python-doctr = {git = "https://github.com/mindee/doctr.git", extras = ['tf'], branch = "main" }
 # Fastapi: minimum version required to avoid pydantic error
 # cf. https://github.com/tiangolo/fastapi/issues/4168
 fastapi = ">=0.73.0"


### PR DESCRIPTION
Fix https://github.com/mindee/doctr/issues/1126

Now, the docker container in `api` folder uses directly DocTR GitHub repository instead of the wheel on PyPI. This is done until `0.7.0` is released.