### PR TITLE
Restrict rapidfuzz to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "mplcursors>=0.3",
     "unidecode>=1.0.0",
     "tqdm>=4.30.0",
-    "rapidfuzz>=1.6.0",
+    "rapidfuzz>=1.6.0,<3.0.0",
     "huggingface-hub>=0.4.0",
 ]
 


### PR DESCRIPTION
Attempt to install with `rapidfuzz-3.0.0` results in `ModuleNotFound` exception:
```python
>>> import doctr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/__init__.py", line 1, in <module>
    from . import datasets, io, models, transforms, utils
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/__init__.py", line 4, in <module>
    from .recognition import *
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/__init__.py", line 5, in <module>
    from .zoo import *
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/zoo.py", line 12, in <module>
    from .predictor import RecognitionPredictor
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/predictor/__init__.py", line 6, in <module>
    from .pytorch import *  # type: ignore[misc]
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/predictor/pytorch.py", line 14, in <module>
    from ._utils import remap_preds, split_crops
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/predictor/_utils.py", line 10, in <module>
    from ..utils import merge_multi_strings
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/utils.py", line 8, in <module>
    from rapidfuzz.string_metric import levenshtein
ModuleNotFoundError: No module named 'rapidfuzz.string_metric'
```