### PR TITLE
[Fix] remove autogen version.py fix docs build and fix version identifier

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -5,7 +5,14 @@ function deploy_doc(){
     fi
     COMMIT=$(git rev-parse --short HEAD)
     echo "Creating doc at commit" $COMMIT "and pushing to folder $2"
-    pip install -U ..
+    # Hotfix
+    if [ "$1" \< "dcbb21f" ]
+        then
+            pip install -U ..
+            pip install rapidfuzz==2.15.1
+        else
+            pip install -U ..
+        fi
     if [ ! -z "$2" ]
     then
         if [ "$2" == "latest" ]; then

--- a/doctr/version.py
+++ b/doctr/version.py
@@ -1,6 +1,0 @@
-# Copyright (C) 2021-2023, Mindee.
-
-# This program is licensed under the Apache License 2.0.
-# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
-
-__version__ = '0.6.1a0'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from setuptools import setup
 
 PKG_NAME = "python-doctr"
-VERSION = os.getenv("BUILD_VERSION", "0.7.1a0")
+VERSION = os.getenv("BUILD_VERSION", "0.6.1a0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:

- remove version.py which is autogenerated
- fix for docs build after #1177 
- lower package identifier to patch and not minor + patch up