### PR TITLE
[tests/TF/build] enable missing classification onnx tests and set tensorflow lower bound to 2.11

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "doctr-api"
-version = "0.7.1a0"
+version = "0.6.1a0"
 description = "Backend template for your OCR API with docTR"
 authors = ["Mindee <contact@mindee.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.2,<3.11"  # pypdfium2 needs a python version above 3.8.2
-tensorflow = ">=2.9.0,<3.0.0"
+tensorflow = ">=2.11.0,<3.0.0"
 tensorflow-addons = ">=0.17.1"
 python-doctr = {git = "https://github.com/mindee/doctr.git", extras = ['tf'], branch = "main" }
 # Fastapi: minimum version required to avoid pydantic error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,9 @@ docs = [
 ]
 dev = [
     # Tensorflow
-    "tensorflow>=2.11.0,<3.0.0",  # cf. https://github.com/mindee/doctr/issues/454
+    "tensorflow>=2.11.0,<3.0.0",  # cf. https://github.com/mindee/doctr/pull/1182
     "tensorflow-addons>=0.17.1",
-    "tf2onnx>=1.14.0",
+    "tf2onnx>=1.14.0,<2.0.0",
     # PyTorch
     "torch>=1.8.0",
     "torchvision>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,9 @@ docs = [
 ]
 dev = [
     # Tensorflow
-    "tensorflow>=2.9.0,<3.0.0",  # cf. https://github.com/mindee/doctr/issues/454
+    "tensorflow>=2.11.0,<3.0.0",  # cf. https://github.com/mindee/doctr/issues/454
     "tensorflow-addons>=0.17.1",
-    "tf2onnx>=1.9.2",
+    "tf2onnx>=1.14.0",
     # PyTorch
     "torch>=1.8.0",
     "torchvision>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ dependencies = [
 
 [project.optional-dependencies]
 tf = [
-    "tensorflow>=2.11.0,<3.0.0",  # cf. https://github.com/mindee/doctr/issues/454
+    "tensorflow>=2.11.0,<3.0.0",  # cf. https://github.com/mindee/doctr/pull/1182
     "tensorflow-addons>=0.17.1",
-    "tf2onnx>=1.14.0",
+    "tf2onnx>=1.14.0,<2.0.0",
 ]
 torch = [
     "torch>=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ dependencies = [
 
 [project.optional-dependencies]
 tf = [
-    "tensorflow>=2.9.0,<3.0.0",  # cf. https://github.com/mindee/doctr/issues/454
+    "tensorflow>=2.11.0,<3.0.0",  # cf. https://github.com/mindee/doctr/issues/454
     "tensorflow-addons>=0.17.1",
-    "tf2onnx>=1.9.2",
+    "tf2onnx>=1.14.0",
 ]
 torch = [
     "torch>=1.8.0",

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -98,10 +98,9 @@ def test_crop_orientation_model(mock_text_box):
         ["resnet50", (32, 32, 3), (126,)],
         ["magc_resnet31", (32, 32, 3), (126,)],
         ["vit_b", (32, 32, 3), (126,)],
-        # Disabled for now
-        # ["mobilenet_v3_small", (512, 512, 3), (126,)],
-        # ["mobilenet_v3_large", (512, 512, 3), (126,)],
-        # ["mobilenet_v3_small_orientation", (128, 128, 3), (4,)],
+        ["mobilenet_v3_small", (512, 512, 3), (126,)],
+        ["mobilenet_v3_large", (512, 512, 3), (126,)],
+        ["mobilenet_v3_small_orientation", (128, 128, 3), (4,)],
     ],
 )
 def test_models_onnx_export(arch_name, input_shape, output_size):


### PR DESCRIPTION
This PR:

- upgrades the minor version of tf2onnx to >=1.14 (which supports TF 2.11)
- upgrades the minor version of tensorflow to >= 2.11 (first version where the issue seems to be fixed)
- enables tests

Closes:
#978 and #790 🚀 