### PR TITLE
[build] drop py3.6/3.7 support and update CI default to py3.8/3.9

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python: ["3.8", "3.10"]
         framework: [tensorflow, pytorch]
     steps:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -17,9 +17,9 @@ jobs:
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2
-      - if: matrix.os == 'macos-latest'
-        name: Install MacOS prerequisites
-        run: brew install cairo pango gdk-pixbuf libffi
+      #- if: matrix.os == 'macos-latest'
+        #name: Install MacOS prerequisites
+        #run: brew install cairo pango gdk-pixbuf libffi
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: [3.7, 3.8]
+        python: ["3.8", "3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.8", "3.10"]
         framework: [tensorflow, pytorch]
     steps:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -16,24 +16,24 @@ jobs:
         python: ["3.8", "3.10"]
         framework: [tensorflow, pytorch]
     steps:
-      - uses: actions/checkout@v2
-      #- if: matrix.os == 'macos-latest'
-        #name: Install MacOS prerequisites
-        #run: brew install cairo pango gdk-pixbuf libffi
+      - uses: actions/checkout@v3
+      - if: matrix.os == 'macos-latest'
+        name: Install MacOS prerequisites
+        run: brew install cairo pango gdk-pixbuf libffi
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: ["3.8", "3.10"]
+        python: ["3.8", "3.9"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [tensorflow, pytorch]
     steps:
       - if: matrix.os == 'macos-latest'

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -19,21 +19,21 @@ jobs:
       - if: matrix.os == 'macos-latest'
         name: Install MacOS prerequisites
         run: brew install cairo pango gdk-pixbuf libffi
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('demo/tf-requirements.txt') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('demo/pt-requirements.txt') }}

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - if: matrix.os == 'macos-latest'
@@ -69,4 +69,3 @@ jobs:
           screen -dm streamlit run demo/app.py
           sleep 10
           curl http://localhost:8501/docs
-

--- a/.github/workflows/doc-status.yml
+++ b/.github/workflows/doc-status.yml
@@ -6,10 +6,10 @@ jobs:
   see-page-build-payload:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.10"
           architecture: x64
       - name: check status
         run: |

--- a/.github/workflows/doc-status.yml
+++ b/.github/workflows/doc-status.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           architecture: x64

--- a/.github/workflows/doc-status.yml
+++ b/.github/workflows/doc-status.yml
@@ -6,10 +6,10 @@ jobs:
   see-page-build-payload:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.10
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.8"
           architecture: x64
       - name: check status
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,16 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build docker image
-        run: docker build . -t doctr-tf-py3.8-slim
+        run: docker build . -t doctr-tf-py3.10-slim
       - name: Run docker container
-        run: docker run doctr-tf-py3.8-slim python -c 'import doctr'
+        run: docker run doctr-tf-py3.10-slim python -c 'import doctr'
 
   pytest-api:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,16 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build docker image
-        run: docker build . -t doctr-tf-py3.10-slim
+        run: docker build . -t doctr-tf-py3.8-slim
       - name: Run docker container
-        run: docker run doctr-tf-py3.10-slim python -c 'import doctr'
+        run: docker run doctr-tf-py3.8-slim python -c 'import doctr'
 
   pytest-api:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
   docker-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build docker image
         run: docker build . -t doctr-tf-py3.10-slim
       - name: Run docker container
@@ -23,8 +23,8 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Set up Python
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,16 +11,16 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Cache python modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Set up Python 3.10
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.7]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -45,11 +45,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.7]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -78,11 +78,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.7]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,14 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Cache python modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-tests
@@ -47,14 +47,14 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Cache python modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-tests
@@ -80,9 +80,9 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ pytest-common, pytest-tf, pytest-torch ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: Install requests
         run: pip install requests
       - name: Process commit and find merger responsible for labeling

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -8,14 +8,14 @@ jobs:
   docs-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           architecture: x64
       - name: Cache python modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-docs

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.8"
           architecture: x64
       - name: Cache python modules
         uses: actions/cache@v3

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.10"
           architecture: x64
       - name: Cache python modules
         uses: actions/cache@v2

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -16,15 +16,15 @@ jobs:
         python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('references/requirements.txt') }}
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}-${{ hashFiles('references/requirements.txt') }}
@@ -68,15 +68,15 @@ jobs:
         python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('references/requirements.txt') }}
@@ -84,7 +84,7 @@ jobs:
             ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}-${{ hashFiles('references/requirements.txt') }}
@@ -123,21 +123,21 @@ jobs:
         python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}
@@ -167,21 +167,21 @@ jobs:
         python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}
@@ -211,15 +211,15 @@ jobs:
         python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('references/requirements.txt') }}
@@ -227,7 +227,7 @@ jobs:
             ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}-${{ hashFiles('references/requirements.txt') }}
@@ -266,21 +266,21 @@ jobs:
         python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}
@@ -312,21 +312,21 @@ jobs:
         python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}
@@ -356,21 +356,21 @@ jobs:
         python: ["3.10"]
         framework: [pytorch]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v3
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v3
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v3
@@ -164,7 +164,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v3
@@ -208,7 +208,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v3
@@ -263,7 +263,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v3
@@ -309,7 +309,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v3
@@ -353,7 +353,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
         framework: [pytorch]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2
@@ -65,12 +65,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -120,12 +120,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -164,12 +164,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -208,12 +208,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -263,12 +263,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -309,12 +309,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -353,12 +353,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
         framework: [pytorch]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     needs: pypi-publish
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -50,11 +50,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     needs: pypi-publish
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Cache python modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
@@ -53,9 +53,9 @@ jobs:
         python: ["3.10"]
     needs: pypi-publish
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -19,21 +19,21 @@ jobs:
       - if: matrix.os == 'macos-latest'
         name: Install MacOS prerequisites
         run: brew install cairo pango gdk-pixbuf libffi
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
@@ -65,21 +65,21 @@ jobs:
       - if: matrix.os == 'macos-latest'
         name: Install MacOS prerequisites
         run: brew install cairo pango gdk-pixbuf libffi
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
@@ -111,21 +111,21 @@ jobs:
       - if: matrix.os == 'macos-latest'
         name: Install MacOS prerequisites
         run: brew install cairo pango gdk-pixbuf libffi
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - if: matrix.framework == 'tensorflow'
         name: Cache python modules (TF)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
       - if: matrix.framework == 'pytorch'
         name: Cache python modules (PT)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
@@ -152,9 +152,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.8", "3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.8", "3.10"]
+        python: ["3.8", "3.9"]
         framework: [tensorflow, pytorch]
     steps:
       - if: matrix.os == 'macos-latest'
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.8", "3.10"]
+        python: ["3.8", "3.9"]
         framework: [tensorflow, pytorch]
     steps:
       - if: matrix.os == 'macos-latest'
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.8", "3.10"]
+        python: ["3.8", "3.9"]
         framework: [tensorflow, pytorch]
     steps:
       - if: matrix.os == 'macos-latest'
@@ -150,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.8", "3.10"]
+        python: ["3.8", "3.9"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.7, 3.8]
+        python: ["3.8", "3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - if: matrix.os == 'macos-latest'
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.7, 3.8]
+        python: ["3.8", "3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - if: matrix.os == 'macos-latest'
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.7, 3.8]
+        python: ["3.8", "3.10"]
         framework: [tensorflow, pytorch]
     steps:
       - if: matrix.os == 'macos-latest'
@@ -150,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.7, 3.8]
+        python: ["3.8", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -33,9 +33,9 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -52,9 +52,9 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -72,14 +72,14 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Cache python modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
@@ -100,9 +100,9 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10"]
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The KIE predictor results per page are in a dictionary format with each key repr
 
 ### Prerequisites
 
-Python 3.6 (or higher) and [pip](https://pip.pypa.io/en/stable/) are required to install docTR.
+Python 3.8 (or higher) and [pip](https://pip.pypa.io/en/stable/) are required to install docTR.
 
 Since we use [weasyprint](https://weasyprint.readthedocs.io/), you will need extra dependencies if you are not running Linux.
 
@@ -328,4 +328,3 @@ You're in luck, we compiled a short guide (cf. [`CONTRIBUTING`](CONTRIBUTING.md)
 ## License
 
 Distributed under the Apache 2.0 License. See [`LICENSE`](LICENSE) for more information.
-

--- a/docs/source/getting_started/installing.rst
+++ b/docs/source/getting_started/installing.rst
@@ -3,7 +3,7 @@
 Installation
 ************
 
-This library requires `Python <https://www.python.org/downloads/>`_ 3.6 or higher.
+This library requires `Python <https://www.python.org/downloads/>`_ 3.8 or higher.
 
 
 Prerequisites

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
     {name = "Charles Gaillard"},
 ]
 readme = "README.md"
-requires-python = ">=3.6.0,<4"
+requires-python = ">=3.8.0,<4"
 license = {file = "LICENSE"}
 keywords=["OCR", "deep learning", "computer vision", "tensorflow", "pytorch", "text detection", "text recognition"]
 classifiers=[
@@ -23,9 +23,9 @@ classifiers=[
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dynamic = ["version"]
@@ -178,7 +178,7 @@ known_third_party = ["tensorflow", "torch", "torchvision", "wandb", "fastprogres
 ignore = ["E402", "F403", "E731"]
 exclude = [".git", "venv*", "build"]
 line-length = 120
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.per-file-ignores]
 "**/__init__.py" = ["F401"]
@@ -195,4 +195,4 @@ source = ["doctr"]
 
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py310']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ known_third_party = ["tensorflow", "torch", "torchvision", "wandb", "fastprogres
 ignore = ["E402", "F403", "E731"]
 exclude = [".git", "venv*", "build"]
 line-length = 120
-target-version = "py310"
+target-version = "py38"
 
 [tool.ruff.per-file-ignores]
 "**/__init__.py" = ["F401"]
@@ -195,4 +195,4 @@ source = ["doctr"]
 
 [tool.black]
 line-length = 120
-target-version = ['py310']
+target-version = ['py38']


### PR DESCRIPTION
This PR:

- drops support for python 3.6 and 3.7 (latest packages mostly have a mimum python version from 3.8 for example pytorch 2.0)
- update CI also to be up to date

Any feedback is welcome :)