### PR TITLE
[build] update pytorch dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,9 @@ tf = [
     "tf2onnx>=1.9.2",
 ]
 torch = [
-    "torch>=1.8.0",
-    "torchvision>=0.9.0",
+    "torch>=1.12.0,<3.0.0",
+    "torchvision>=0.13.0",
+    "onnx>=1.12.0,<3.0.0",
 ]
 testing = [
     "pytest>=5.3.2",
@@ -93,8 +94,9 @@ dev = [
     "tensorflow-addons>=0.17.1",
     "tf2onnx>=1.9.2",
     # PyTorch
-    "torch>=1.8.0",
-    "torchvision>=0.9.0",
+    "torch>=1.12.0,<3.0.0",
+    "torchvision>=0.13.0",
+    "onnx>=1.12.0,<3.0.0",
     # Testing
     "pytest>=5.3.2",
     "coverage[toml]>=4.5.4",


### PR DESCRIPTION
This PR:

- update torch to  minimum to work also with py3.10 (related to: #1184)
- add onnx which is optional for torch>=2.0.0 but needed for our onnx exports