### PR TITLE
[CI] change old cache action and skip TF classification onnx export temporarily

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Cache python modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-tests

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,17 @@ style:
 # Run tests for the library
 test:
 	coverage run -m pytest tests/common/
-	USE_TF='1' SLOW='1' coverage run -m pytest tests/tensorflow/
-	USE_TORCH='1' SLOW='1' coverage run -m pytest tests/pytorch/
+	USE_TF='1' coverage run -m pytest tests/tensorflow/
+	USE_TORCH='1' coverage run -m pytest tests/pytorch/
 
 test-common:
 	coverage run -m pytest tests/common/
 
 test-tf:
-	USE_TF='1' SLOW='1' coverage run -m pytest tests/tensorflow/
+	USE_TF='1' coverage run -m pytest tests/tensorflow/
 
 test-torch:
-	USE_TORCH='1' SLOW='1' coverage run -m pytest tests/pytorch/
+	USE_TORCH='1' coverage run -m pytest tests/pytorch/
 
 # Check that docs can build
 docs-single-version:

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -116,7 +116,6 @@ def export_model_to_onnx(model: nn.Module, model_name: str, dummy_input: torch.T
         output_names=["logits"],
         dynamic_axes={"input": {0: "batch_size"}, "logits": {0: "batch_size"}},
         export_params=True,
-        opset_version=14,  # minimum opset which support all operators we use (v0.5.2)
         verbose=False,
         **kwargs,
     )

--- a/doctr/models/utils/tensorflow.py
+++ b/doctr/models/utils/tensorflow.py
@@ -141,6 +141,7 @@ def export_model_to_onnx(
     large_model = kwargs.get("large_model", False)
     model_proto, _ = tf2onnx.convert.from_keras(
         model,
+        opset=17,
         input_signature=dummy_input,
         output_path=f"{model_name}.zip" if large_model else f"{model_name}.onnx",
         **kwargs,

--- a/doctr/models/utils/tensorflow.py
+++ b/doctr/models/utils/tensorflow.py
@@ -141,7 +141,7 @@ def export_model_to_onnx(
     large_model = kwargs.get("large_model", False)
     model_proto, _ = tf2onnx.convert.from_keras(
         model,
-        opset=17,
+        opset=14,  # minimum opset which support all operators we use (v0.5.2)
         input_signature=dummy_input,
         output_path=f"{model_name}.zip" if large_model else f"{model_name}.onnx",
         **kwargs,

--- a/doctr/models/utils/tensorflow.py
+++ b/doctr/models/utils/tensorflow.py
@@ -141,7 +141,6 @@ def export_model_to_onnx(
     large_model = kwargs.get("large_model", False)
     model_proto, _ = tf2onnx.convert.from_keras(
         model,
-        opset=14,  # minimum opset which support all operators we use (v0.5.2)
         input_signature=dummy_input,
         output_path=f"{model_name}.zip" if large_model else f"{model_name}.onnx",
         **kwargs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ testing = [
     "hdf5storage>=0.1.18",
     "onnxruntime>=1.11.0",
     "requests>=2.20.0",
+    "psutil>=5.9.5"
 ]
 quality = [
     "ruff>=0.0.260",
@@ -103,6 +104,7 @@ dev = [
     "hdf5storage>=0.1.18",
     "onnxruntime>=1.11.0",
     "requests>=2.20.0",
+    "psutil>=5.9.5",
     # Quality
     "ruff>=0.0.260",
     "isort>=5.7.0",

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -99,17 +99,12 @@ def test_crop_orientation_model(mock_text_box):
         ["mobilenet_v3_small", (512, 512, 3), (126,)],
         ["mobilenet_v3_large", (512, 512, 3), (126,)],
         ["mobilenet_v3_small_orientation", (128, 128, 3), (4,)],
-        pytest.param(
-            "resnet18",
-            (32, 32, 3),
-            (126,),
-            marks=pytest.mark.skipif(system_available_memory > 16, reason="to less memory"),
-        ),
+        ["resnet18", (32, 32, 3), (126,)],
         pytest.param(
             "resnet31",
             (32, 32, 3),
             (126,),
-            marks=pytest.mark.skipif(system_available_memory > 16, reason="to less memory"),
+            marks=pytest.mark.skipif(system_available_memory < 16, reason="to less memory"),
         ),
         pytest.param(
             "resnet34",

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -87,7 +87,8 @@ def test_crop_orientation_model(mock_text_box):
     assert classifier([text_box_0, text_box_90, text_box_180, text_box_270]) == [0, 1, 2, 3]
 
 
-# temporary fix to avoid killing the CI (tf2onnx v1.14 memory leak issue)
+# temporarily fix to avoid killing the CI (tf2onnx v1.14 memory leak issue)
+# ref.: https://github.com/mindee/doctr/pull/1201
 @pytest.mark.skipif(os.getenv("SLOW", "0") == "0", reason="slow test")
 @pytest.mark.parametrize(
     "arch_name, input_shape, output_size",

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -4,12 +4,15 @@ import tempfile
 import cv2
 import numpy as np
 import onnxruntime
+import psutil
 import pytest
 import tensorflow as tf
 
 from doctr.models import classification
 from doctr.models.classification.predictor import CropOrientationPredictor
 from doctr.models.utils import export_model_to_onnx
+
+system_available_memory = int(psutil.virtual_memory().available / 1024**3)
 
 
 @pytest.mark.parametrize(
@@ -89,21 +92,55 @@ def test_crop_orientation_model(mock_text_box):
 
 # temporarily fix to avoid killing the CI (tf2onnx v1.14 memory leak issue)
 # ref.: https://github.com/mindee/doctr/pull/1201
-@pytest.mark.skipif(os.getenv("SLOW", "0") == "0", reason="slow test")
 @pytest.mark.parametrize(
     "arch_name, input_shape, output_size",
     [
         ["vgg16_bn_r", (32, 32, 3), (126,)],
-        ["resnet18", (32, 32, 3), (126,)],
-        ["resnet31", (32, 32, 3), (126,)],
-        ["resnet34", (32, 32, 3), (126,)],
-        ["resnet34_wide", (32, 32, 3), (126,)],
-        ["resnet50", (32, 32, 3), (126,)],
-        ["magc_resnet31", (32, 32, 3), (126,)],
-        ["vit_b", (32, 32, 3), (126,)],
         ["mobilenet_v3_small", (512, 512, 3), (126,)],
         ["mobilenet_v3_large", (512, 512, 3), (126,)],
         ["mobilenet_v3_small_orientation", (128, 128, 3), (4,)],
+        pytest.param(
+            "resnet18",
+            (32, 32, 3),
+            (126,),
+            marks=pytest.mark.skipif(system_available_memory > 16, reason="to less memory"),
+        ),
+        pytest.param(
+            "resnet31",
+            (32, 32, 3),
+            (126,),
+            marks=pytest.mark.skipif(system_available_memory > 16, reason="to less memory"),
+        ),
+        pytest.param(
+            "resnet34",
+            (32, 32, 3),
+            (126,),
+            marks=pytest.mark.skipif(system_available_memory < 16, reason="to less memory"),
+        ),
+        pytest.param(
+            "resnet34_wide",
+            (32, 32, 3),
+            (126,),
+            marks=pytest.mark.skipif(system_available_memory < 16, reason="to less memory"),
+        ),
+        pytest.param(
+            "resnet50",
+            (32, 32, 3),
+            (126,),
+            marks=pytest.mark.skipif(system_available_memory < 16, reason="to less memory"),
+        ),
+        pytest.param(
+            "magc_resnet31",
+            (32, 32, 3),
+            (126,),
+            marks=pytest.mark.skipif(system_available_memory < 16, reason="to less memory"),
+        ),
+        pytest.param(
+            "vit_b",
+            (32, 32, 3),
+            (126,),
+            marks=pytest.mark.skipif(system_available_memory < 16, reason="to less memory"),
+        ),
     ],
 )
 def test_models_onnx_export(arch_name, input_shape, output_size):

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -87,6 +87,8 @@ def test_crop_orientation_model(mock_text_box):
     assert classifier([text_box_0, text_box_90, text_box_180, text_box_270]) == [0, 1, 2, 3]
 
 
+# temporary fix to avoid killing the CI (tf2onnx v1.14 memory leak issue)
+@pytest.mark.skipif(os.getenv("SLOW", "0") == "0", reason="slow test")
 @pytest.mark.parametrize(
     "arch_name, input_shape, output_size",
     [

--- a/tests/tensorflow/test_models_recognition_tf.py
+++ b/tests/tensorflow/test_models_recognition_tf.py
@@ -4,6 +4,7 @@ import tempfile
 
 import numpy as np
 import onnxruntime
+import psutil
 import pytest
 import tensorflow as tf
 
@@ -17,6 +18,8 @@ from doctr.models.recognition.sar.tensorflow import SARPostProcessor
 from doctr.models.recognition.vitstr.tensorflow import ViTSTRPostProcessor
 from doctr.models.utils import export_model_to_onnx
 from doctr.utils.geometry import extract_crops
+
+system_available_memory = int(psutil.virtual_memory().available / 1024**3)
 
 
 @pytest.mark.parametrize(
@@ -154,15 +157,20 @@ def test_recognition_zoo_error():
         _ = recognition.zoo.recognition_predictor("my_fancy_model", pretrained=False)
 
 
-@pytest.mark.skipif(os.getenv("SLOW", "0") == "0", reason="slow test")
 @pytest.mark.parametrize(
     "arch_name, input_shape",
     [
         ["crnn_vgg16_bn", (32, 128, 3)],
         ["crnn_mobilenet_v3_small", (32, 128, 3)],
         ["crnn_mobilenet_v3_large", (32, 128, 3)],
-        ["sar_resnet31", (32, 128, 3)],
-        ["master", (32, 128, 3)],
+        pytest.param(
+            "sar_resnet31",
+            (32, 128, 3),
+            marks=pytest.mark.skipif(system_available_memory < 16, reason="to less memory"),
+        ),
+        pytest.param(
+            "master", (32, 128, 3), marks=pytest.mark.skipif(system_available_memory < 16, reason="to less memory")
+        ),
         ["vitstr_small", (32, 128, 3)],  # testing one vitstr version is enough
     ],
 )


### PR DESCRIPTION
This PR:

- update last missing cache action
- remove fixed opset version which are not more needed after changing the minimum pt / tf version)
- temporarily skip on CI for TF classification onnx export (tf2onnx 1.14 seems to raise a memory leak which kills the CI machine) - locally all tests passes for me, but yeah the tf resnet >= 31 now takes ~16GB RAM while converting 
Not sure if it comes from TF itself or tf2onnx

Maybe setting up a larger runner: @charlesmindee @odulcy-mindee (or we skip more tf onnx tests ..ftm)
https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners

Any feedback is welcome 🤗 