### PR TITLE
[Fix] PARSeq tensorflow fixes

### DIFF
--- a/doctr/models/recognition/parseq/tensorflow.py
+++ b/doctr/models/recognition/parseq/tensorflow.py
@@ -302,7 +302,7 @@ class PARSeq(_PARSeq, Model):
 
         sos = tf.fill((tf.shape(features)[0], 1), self.vocab_size + 1)
         ys = tf.concat([sos, tf.cast(tf.argmax(logits[:, :-1], axis=-1), dtype=tf.int32)], axis=1)
-        # Create padding mask for refined target input sequence
+        # Create padding mask for refined target input maskes all behind EOS token as False
         # (N, 1, 1, max_length)
         mask = tf.cast(tf.equal(ys, self.vocab_size), tf.float32)
         first_eos_indices = tf.argmax(mask, axis=1, output_type=tf.int32)


### PR DESCRIPTION
This PR:

- several fixes

- [x] test run

torch fail will be fixed if #1227 is merged

Validation set loaded in 0.002758s (2520 samples in 79 batches)
Train set loaded in 0.003837s (126000 samples in 3937 batches)
Validation loss decreased inf --> 4.64792: saving state...                                                                                                      
Epoch 1/20 - Validation loss: 4.64792 (Exact: 0.08% | Partial: 0.08%)
Validation loss decreased 4.64792 --> 4.37974: saving state...                                                                                                  
Epoch 2/20 - Validation loss: 4.37974 (Exact: 0.48% | Partial: 0.91%)
Validation loss decreased 4.37974 --> 4.3734: saving state...                                                                                                   
Epoch 3/20 - Validation loss: 4.3734 (Exact: 0.99% | Partial: 1.39%)
Validation loss decreased 4.3734 --> 4.32947: saving state...                                                                                                   
Epoch 4/20 - Validation loss: 4.32947 (Exact: 2.14% | Partial: 3.10%)