### PR TITLE
[fix/chore] fix bug in tf det eval script / update dep version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pyclipper>=1.2.0,<2.0.0",
     "shapely>=1.6.0,<3.0.0",
     "langdetect>=1.0.9,<2.0.0",
+    "rapidfuzz>=3.0.0,<4.0.0",
     "matplotlib>=3.1.0",
     "weasyprint>=55.0",
     "Pillow>=8.3.2",  # cf. https://github.com/advisories/GHSA-98vv-pw6r-q6q4
@@ -48,8 +49,7 @@ dependencies = [
     "mplcursors>=0.3",
     "unidecode>=1.0.0",
     "tqdm>=4.30.0",
-    "rapidfuzz>=3.0.0",
-    "huggingface-hub>=0.4.0",
+    "huggingface-hub>=0.5.0",
 ]
 
 [project.optional-dependencies]

--- a/references/detection/evaluate_tensorflow.py
+++ b/references/detection/evaluate_tensorflow.py
@@ -70,7 +70,7 @@ def main(args):
 
     # Load docTR model
     model = detection.__dict__[args.arch](
-        pretrained=isinstance(args.resume, str),
+        pretrained=not isinstance(args.resume, str),
         assume_straight_pages=not args.rotation,
         input_shape=input_shape,
     )


### PR DESCRIPTION
This PR:

- fix minor bug in det eval script
- set upper bound for rapidfuzz to avoid lib breaks again
- update hf hub lib to 0.5.0 (to follow with our python < 3.8 non support)