### PR TITLE
feat: :sparkles: ClearML support for TensorFlow

### DIFF
--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -252,7 +252,7 @@ jobs:
           unzip toy_detection_set-bbbb4243.zip -d det_set
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF)
-        run: python references/detection/train_tensorflow.py ./det_set ./det_set db_resnet50 -b 2 --epochs 1
+        run: python references/detection/train_tensorflow.py --train_path ./det_set --val_path ./det_set db_resnet50 -b 2 --epochs 1
       - if: matrix.framework == 'pytorch'
         name: Train for a short epoch (PT)
         run: python references/detection/train_pytorch.py ./det_set ./det_set db_mobilenet_v3_large -b 2 --epochs 1

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -14,7 +14,6 @@ import time
 
 import numpy as np
 import tensorflow as tf
-import wandb
 from fastprogress.fastprogress import master_bar, progress_bar
 from tensorflow.keras import mixed_precision
 
@@ -245,6 +244,7 @@ def main(args):
         decay_steps=args.epochs * len(train_loader),
         decay_rate=1 / (1e3),  # final lr as a fraction of initial lr
         staircase=False,
+        name="ExponentialDecay",
     )
     optimizer = tf.keras.optimizers.Adam(
         learning_rate=scheduler,
@@ -268,19 +268,20 @@ def main(args):
     config = {
         "learning_rate": args.lr,
         "epochs": args.epochs,
-        "weight_decay": 0.0,
         "batch_size": args.batch_size,
         "architecture": args.arch,
         "input_size": args.input_size,
-        "optimizer": "adam",
+        "optimizer": optimizer.name,
         "framework": "tensorflow",
         "vocab": args.vocab,
-        "scheduler": "exp_decay",
+        "scheduler": scheduler.name,
         "pretrained": args.pretrained,
     }
 
     # W&B
     if args.wb:
+        import wandb
+
         run = wandb.init(name=exp_name, project="character-classification", config=config)
     # ClearML
     if args.clearml:

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -286,7 +286,7 @@ def main(args):
     if args.clearml:
         from clearml import Task
 
-        task = Task.init(project_name="docTR/character-classification", task_name=exp_name)
+        task = Task.init(project_name="docTR/character-classification", task_name=exp_name, reuse_last_task_id=False)
         task.upload_artifact("config", config)
 
     # Create loss queue

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -318,8 +318,8 @@ def main(args):
             from clearml import Logger
 
             logger = Logger.current_logger()
-            logger.report_single_value(name="val_loss", value=val_loss)
-            logger.report_single_value(name="acc", value=acc)
+            logger.report_scalar(title="Validation Loss", series="val_loss", value=val_loss, iteration=epoch)
+            logger.report_scalar(title="Accuracy", series="acc", value=acc, iteration=epoch)
 
     if args.wb:
         run.finish()

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -265,25 +265,29 @@ def main(args):
     current_time = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
     exp_name = f"{args.arch}_{current_time}" if args.name is None else args.name
 
+    config = {
+        "learning_rate": args.lr,
+        "epochs": args.epochs,
+        "weight_decay": 0.0,
+        "batch_size": args.batch_size,
+        "architecture": args.arch,
+        "input_size": args.input_size,
+        "optimizer": "adam",
+        "framework": "tensorflow",
+        "vocab": args.vocab,
+        "scheduler": "exp_decay",
+        "pretrained": args.pretrained,
+    }
+
     # W&B
     if args.wb:
-        run = wandb.init(
-            name=exp_name,
-            project="character-classification",
-            config={
-                "learning_rate": args.lr,
-                "epochs": args.epochs,
-                "weight_decay": 0.0,
-                "batch_size": args.batch_size,
-                "architecture": args.arch,
-                "input_size": args.input_size,
-                "optimizer": "adam",
-                "framework": "tensorflow",
-                "vocab": args.vocab,
-                "scheduler": "exp_decay",
-                "pretrained": args.pretrained,
-            },
-        )
+        run = wandb.init(name=exp_name, project="character-classification", config=config)
+    # ClearML
+    if args.clearml:
+        from clearml import Task
+
+        task = Task.init(project_name="docTR/character-classification", task_name=exp_name)
+        task.upload_artifact("config", config)
 
     # Create loss queue
     min_loss = np.inf
@@ -308,6 +312,14 @@ def main(args):
                     "acc": acc,
                 }
             )
+
+        # ClearML
+        if args.clearml:
+            from clearml import Logger
+
+            logger = Logger.current_logger()
+            logger.report_single_value(name="val_loss", value=val_loss)
+            logger.report_single_value(name="acc", value=acc)
 
     if args.wb:
         run.finish()
@@ -366,6 +378,7 @@ def parse_args():
         "--show-samples", dest="show_samples", action="store_true", help="Display unormalized training samples"
     )
     parser.add_argument("--wb", dest="wb", action="store_true", help="Log to Weights & Biases")
+    parser.add_argument("--clearml", dest="clearml", action="store_true", help="Log to ClearML")
     parser.add_argument("--push-to-hub", dest="push_to_hub", action="store_true", help="Push to Huggingface Hub")
     parser.add_argument(
         "--pretrained",

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -313,7 +313,7 @@ def main(args):
     if args.clearml:
         from clearml import Task
 
-        task = Task.init(project_name="docTR/text-detection", task_name=exp_name)
+        task = Task.init(project_name="docTR/text-detection", task_name=exp_name, reuse_last_task_id=False)
         task.upload_artifact("config", config)
 
     if args.freeze_backbone:

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -354,10 +354,10 @@ def main(args):
             from clearml import Logger
 
             logger = Logger.current_logger()
-            logger.report_single_value(name="val_loss", value=val_loss)
-            logger.report_single_value(name="recall", value=recall)
-            logger.report_single_value(name="precision", value=precision)
-            logger.report_single_value(name="mean_iou", value=mean_iou)
+            logger.report_scalar(title="Validation Loss", series="val_loss", value=val_loss, iteration=epoch)
+            logger.report_scalar(title="Precision Recall", series="recall", value=recall, iteration=epoch)
+            logger.report_scalar(title="Precision Recall", series="precision", value=precision, iteration=epoch)
+            logger.report_scalar(title="Mean IoU", series="mean_iou", value=mean_iou, iteration=epoch)
 
     if args.wb:
         run.finish()

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 import numpy as np
 import tensorflow as tf
-import wandb
 from fastprogress.fastprogress import master_bar, progress_bar
 from tensorflow.keras import mixed_precision
 
@@ -287,6 +286,7 @@ def main(args):
         decay_steps=args.epochs * len(train_loader),
         decay_rate=1 / (25e4),  # final lr as a fraction of initial lr
         staircase=False,
+        name="ExponentialDecay",
     )
     optimizer = tf.keras.optimizers.Adam(learning_rate=scheduler, beta_1=0.95, beta_2=0.99, epsilon=1e-6, clipnorm=5)
     if args.amp:
@@ -304,13 +304,12 @@ def main(args):
     config = {
         "learning_rate": args.lr,
         "epochs": args.epochs,
-        "weight_decay": 0.0,
         "batch_size": args.batch_size,
         "architecture": args.arch,
         "input_size": args.input_size,
-        "optimizer": "adam",
+        "optimizer": optimizer.name,
         "framework": "tensorflow",
-        "scheduler": "exp_decay",
+        "scheduler": scheduler.name,
         "vocab": args.vocab,
         "train_hash": train_hash,
         "val_hash": val_hash,
@@ -319,6 +318,8 @@ def main(args):
 
     # W&B
     if args.wb:
+        import wandb
+
         run = wandb.init(
             name=exp_name,
             project="text-recognition",

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -329,7 +329,7 @@ def main(args):
     if args.clearml:
         from clearml import Task
 
-        task = Task.init(project_name="docTR/text-recognition", task_name=exp_name)
+        task = Task.init(project_name="docTR/text-recognition", task_name=exp_name, reuse_last_task_id=False)
         task.upload_artifact("config", config)
 
     min_loss = np.inf

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -364,9 +364,9 @@ def main(args):
             from clearml import Logger
 
             logger = Logger.current_logger()
-            logger.report_single_value(name="val_loss", value=val_loss)
-            logger.report_single_value(name="exact_match", value=exact_match)
-            logger.report_single_value(name="partial_match", value=partial_match)
+            logger.report_scalar(title="Validation Loss", series="val_loss", value=val_loss, iteration=epoch)
+            logger.report_scalar(title="Exact Match", series="exact_match", value=exact_match, iteration=epoch)
+            logger.report_scalar(title="Partial Match", series="partial_match", value=partial_match, iteration=epoch)
 
     if args.wb:
         run.finish()

--- a/references/requirements.txt
+++ b/references/requirements.txt
@@ -2,3 +2,4 @@
 fastprogress>=0.1.21
 wandb>=0.10.31
 psutil>=5.9.0
+clearml>=1.11.1


### PR DESCRIPTION
This PR introduces [ClearML](https://clear.ml/pricing/) support in references script, for TensorFlow only (PyTorch will be done in another PR).

At the moment, ClearML captures **everything**, meaning that logs, model checkpoints, etc. are tracked. Do we want to keep it like that or do we want to block everything [auto_connect_frameworks](https://clear.ml/docs/latest/docs/references/sdk/task/#taskinit) in `Task.init` by default ? If so, how do we expose parameters to users to tune this behavior ?