### PR TITLE
Update pyproject.toml - Fix rapidfuzz version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyclipper>=1.2.0,<2.0.0",
     "shapely>=1.6.0,<3.0.0",
     "langdetect>=1.0.9,<2.0.0",
-    "rapidfuzz>=3.0.0,<4.0.0",
+    "rapidfuzz<3.0.0",
     "matplotlib>=3.1.0",
     "weasyprint>=55.0",
     "Pillow>=10.0.0",


### PR DESCRIPTION
Fix rapidfuzz version raising error when installing doctr . 

`ModuleNotFoundError: No module named 'rapidfuzz.string_metric'`
