### PR TITLE
[PyTorch] replace no_grad with inference_mode

### DIFF
--- a/doctr/models/classification/predictor/pytorch.py
+++ b/doctr/models/classification/predictor/pytorch.py
@@ -33,7 +33,7 @@ class CropOrientationPredictor(nn.Module):
         self.pre_processor = pre_processor
         self.model = model.eval()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(
         self,
         crops: List[Union[np.ndarray, torch.Tensor]],

--- a/doctr/models/detection/predictor/pytorch.py
+++ b/doctr/models/detection/predictor/pytorch.py
@@ -32,7 +32,7 @@ class DetectionPredictor(nn.Module):
         self.pre_processor = pre_processor
         self.model = model.eval()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(
         self,
         pages: List[Union[np.ndarray, torch.Tensor]],

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -59,7 +59,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
         self.detect_orientation = detect_orientation
         self.detect_language = detect_language
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(
         self,
         pages: List[Union[np.ndarray, torch.Tensor]],

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -59,7 +59,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
         self.detect_orientation = detect_orientation
         self.detect_language = detect_language
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(
         self,
         pages: List[Union[np.ndarray, torch.Tensor]],

--- a/doctr/models/recognition/predictor/pytorch.py
+++ b/doctr/models/recognition/predictor/pytorch.py
@@ -40,7 +40,7 @@ class RecognitionPredictor(nn.Module):
         self.dil_factor = 1.4  # Dilation factor to overlap the crops
         self.target_ar = 6  # Target aspect ratio
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(
         self,
         crops: Sequence[Union[np.ndarray, torch.Tensor]],

--- a/references/classification/latency_pytorch.py
+++ b/references/classification/latency_pytorch.py
@@ -19,7 +19,7 @@ os.environ["USE_TORCH"] = "1"
 from doctr.models import classification
 
 
-@torch.no_grad()
+@torch.inference_mode()
 def main(args):
     device = torch.device("cuda:0" if args.gpu else "cpu")
 

--- a/references/detection/evaluate_pytorch.py
+++ b/references/detection/evaluate_pytorch.py
@@ -26,7 +26,7 @@ from doctr.models import detection
 from doctr.utils.metrics import LocalizationConfusion
 
 
-@torch.no_grad()
+@torch.inference_mode()
 def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
     # Model in eval mode
     model.eval()

--- a/references/detection/latency_pytorch.py
+++ b/references/detection/latency_pytorch.py
@@ -19,7 +19,7 @@ os.environ["USE_TORCH"] = "1"
 from doctr.models import detection
 
 
-@torch.no_grad()
+@torch.inference_mode()
 def main(args):
     device = torch.device("cuda:0" if args.gpu else "cpu")
 

--- a/references/obj_detection/latency_pytorch.py
+++ b/references/obj_detection/latency_pytorch.py
@@ -19,7 +19,7 @@ os.environ["USE_TORCH"] = "1"
 from doctr.models import obj_detection
 
 
-@torch.no_grad()
+@torch.inference_mode()
 def main(args):
     device = torch.device("cuda:0" if args.gpu else "cpu")
 

--- a/references/recognition/evaluate_pytorch.py
+++ b/references/recognition/evaluate_pytorch.py
@@ -22,7 +22,7 @@ from doctr.models import recognition
 from doctr.utils.metrics import TextMatch
 
 
-@torch.no_grad()
+@torch.inference_mode()
 def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
     # Model in eval mode
     model.eval()

--- a/references/recognition/latency_pytorch.py
+++ b/references/recognition/latency_pytorch.py
@@ -19,7 +19,7 @@ os.environ["USE_TORCH"] = "1"
 from doctr.models import recognition
 
 
-@torch.no_grad()
+@torch.inference_mode()
 def main(args):
     device = torch.device("cuda:0" if args.gpu else "cpu")
 

--- a/scripts/detect_artefacts.py
+++ b/scripts/detect_artefacts.py
@@ -37,7 +37,7 @@ def plot_predictions(image, boxes, labels):
     plt.show()
 
 
-@torch.no_grad()
+@torch.inference_mode()
 def main(args):
     print(args)
 


### PR DESCRIPTION
This PR:
- change from `no_grad` to `inference_mode`  (ref.: https://pytorch.org/docs/stable/generated/torch.inference_mode.html)
- ref: #1316 

```
from doctr.io import DocumentFile
from doctr.models import ocr_predictor
import time

doc_path = "/home/felix/Desktop/1.jpg"
start = time.time()
doc = DocumentFile.from_images([doc_path] * 10)
model = ocr_predictor(det_arch="db_resnet50", reco_arch="parseq", pretrained=True, det_bs=8, reco_bs=512).cuda().half()
result = model(doc)
print(time.time() - start)
```

```
# with torch.no_grad():
# cuda: VRAM: ~4400MB time: 15.616s
# cuda half: VRAM: ~2400MB time: 9.3s

# with torch.inference_mode():
# cuda: VRAM: ~4246MB time: 15.612s
# cuda half: VRAM: ~2340MB time: 9.14s
```