### PR TITLE
[Fix] PT - convert BF16 tensor to float before calling .numpy()

### DIFF
--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -212,7 +212,7 @@ class DBNet(_DBNet, nn.Module):
             # Post-process boxes (keep only text predictions)
             out["preds"] = [
                 dict(zip(self.class_names, preds))
-                for preds in self.postprocessor((prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy())
+                for preds in self.postprocessor(prob_map.detach().cpu().permute((0, 2, 3, 1)).numpy())
             ]
 
         if target is not None:

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -208,11 +208,8 @@ class DBNet(_DBNet, nn.Module):
         if return_model_output:
             out["out_map"] = prob_map
 
-        def need_conversion_to_float(dtype):
-            # pytorch: torch/csrc/utils/tensor_numpy.cpp:aten_to_numpy_dtype
-            return dtype in [torch.bfloat16]
-
-        numpy_dtype_converter = lambda x: x.float() if need_conversion_to_float(x.dtype) else x
+        # bfloat16 is not supported in .numpy(): torch/csrc/utils/tensor_numpy.cpp:aten_to_numpy_dtype
+        numpy_dtype_converter = lambda x: x.float() if x.dtype in [torch.bfloat16] else x
         if target is None or return_preds:
             # Post-process boxes (keep only text predictions)
             out["preds"] = [

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -16,7 +16,7 @@ from torchvision.ops.deform_conv import DeformConv2d
 from doctr.file_utils import CLASS_NAME
 
 from ...classification import mobilenet_v3_large
-from ...utils import load_pretrained_params, numpy_dtype_converter
+from ...utils import _bf16_to_numpy_dtype, load_pretrained_params
 from .base import DBPostProcessor, _DBNet
 
 __all__ = ["DBNet", "db_resnet50", "db_resnet34", "db_mobilenet_v3_large", "db_resnet50_rotation"]
@@ -203,7 +203,7 @@ class DBNet(_DBNet, nn.Module):
             return out
 
         if return_model_output or target is None or return_preds:
-            prob_map = torch.sigmoid(logits)
+            prob_map = _bf16_to_numpy_dtype(torch.sigmoid(logits))
 
         if return_model_output:
             out["out_map"] = prob_map
@@ -212,9 +212,7 @@ class DBNet(_DBNet, nn.Module):
             # Post-process boxes (keep only text predictions)
             out["preds"] = [
                 dict(zip(self.class_names, preds))
-                for preds in self.postprocessor(
-                    numpy_dtype_converter(prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy()
-                )
+                for preds in self.postprocessor((prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy())
             ]
 
         if target is not None:

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -16,7 +16,7 @@ from torchvision.ops.deform_conv import DeformConv2d
 from doctr.file_utils import CLASS_NAME
 
 from ...classification import mobilenet_v3_large
-from ...utils import load_pretrained_params
+from ...utils import load_pretrained_params, numpy_dtype_converter
 from .base import DBPostProcessor, _DBNet
 
 __all__ = ["DBNet", "db_resnet50", "db_resnet34", "db_mobilenet_v3_large", "db_resnet50_rotation"]
@@ -208,13 +208,13 @@ class DBNet(_DBNet, nn.Module):
         if return_model_output:
             out["out_map"] = prob_map
 
-        # bfloat16 is not supported in .numpy(): torch/csrc/utils/tensor_numpy.cpp:aten_to_numpy_dtype
-        numpy_dtype_converter = lambda x: x.float() if x.dtype in [torch.bfloat16] else x
         if target is None or return_preds:
             # Post-process boxes (keep only text predictions)
             out["preds"] = [
                 dict(zip(self.class_names, preds))
-                for preds in self.postprocessor(numpy_dtype_converter(prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy())
+                for preds in self.postprocessor(
+                    numpy_dtype_converter(prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy()
+                )
             ]
 
         if target is not None:

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -14,7 +14,7 @@ from torchvision.models._utils import IntermediateLayerGetter
 from doctr.file_utils import CLASS_NAME
 from doctr.models.classification import resnet18, resnet34, resnet50
 
-from ...utils import load_pretrained_params, numpy_dtype_converter
+from ...utils import _bf16_to_numpy_dtype, load_pretrained_params
 from .base import LinkNetPostProcessor, _LinkNet
 
 __all__ = ["LinkNet", "linknet_resnet18", "linknet_resnet34", "linknet_resnet50"]
@@ -175,7 +175,7 @@ class LinkNet(nn.Module, _LinkNet):
             return out
 
         if return_model_output or target is None or return_preds:
-            prob_map = torch.sigmoid(logits)
+            prob_map = _bf16_to_numpy_dtype(torch.sigmoid(logits))
         if return_model_output:
             out["out_map"] = prob_map
 
@@ -183,9 +183,7 @@ class LinkNet(nn.Module, _LinkNet):
             # Post-process boxes
             out["preds"] = [
                 dict(zip(self.class_names, preds))
-                for preds in self.postprocessor(
-                    numpy_dtype_converter(prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy()
-                )
+                for preds in self.postprocessor((prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy())
             ]
 
         if target is not None:

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -14,7 +14,7 @@ from torchvision.models._utils import IntermediateLayerGetter
 from doctr.file_utils import CLASS_NAME
 from doctr.models.classification import resnet18, resnet34, resnet50
 
-from ...utils import load_pretrained_params
+from ...utils import load_pretrained_params, numpy_dtype_converter
 from .base import LinkNetPostProcessor, _LinkNet
 
 __all__ = ["LinkNet", "linknet_resnet18", "linknet_resnet34", "linknet_resnet50"]
@@ -183,7 +183,9 @@ class LinkNet(nn.Module, _LinkNet):
             # Post-process boxes
             out["preds"] = [
                 dict(zip(self.class_names, preds))
-                for preds in self.postprocessor(prob_map.detach().cpu().permute((0, 2, 3, 1)).numpy())
+                for preds in self.postprocessor(
+                    numpy_dtype_converter(prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy()
+                )
             ]
 
         if target is not None:

--- a/doctr/models/detection/linknet/pytorch.py
+++ b/doctr/models/detection/linknet/pytorch.py
@@ -183,7 +183,7 @@ class LinkNet(nn.Module, _LinkNet):
             # Post-process boxes
             out["preds"] = [
                 dict(zip(self.class_names, preds))
-                for preds in self.postprocessor((prob_map.detach().cpu().permute((0, 2, 3, 1))).numpy())
+                for preds in self.postprocessor(prob_map.detach().cpu().permute((0, 2, 3, 1)).numpy())
             ]
 
         if target is not None:

--- a/doctr/models/recognition/master/pytorch.py
+++ b/doctr/models/recognition/master/pytorch.py
@@ -15,7 +15,7 @@ from doctr.datasets import VOCABS
 from doctr.models.classification import magc_resnet31
 from doctr.models.modules.transformer import Decoder, PositionalEncoding
 
-from ...utils.pytorch import load_pretrained_params
+from ...utils.pytorch import _bf16_to_numpy_dtype, load_pretrained_params
 from .base import _MASTER, _MASTERPostProcessor
 
 __all__ = ["MASTER", "master"]
@@ -194,6 +194,8 @@ class MASTER(_MASTER, nn.Module):
             logits = self.linear(output)
         else:
             logits = self.decode(encoded)
+
+        logits = _bf16_to_numpy_dtype(logits)
 
         if self.exportable:
             out["logits"] = logits

--- a/doctr/models/recognition/parseq/pytorch.py
+++ b/doctr/models/recognition/parseq/pytorch.py
@@ -18,7 +18,7 @@ from doctr.datasets import VOCABS
 from doctr.models.modules.transformer import MultiHeadAttention, PositionwiseFeedForward
 
 from ...classification import vit_s
-from ...utils.pytorch import load_pretrained_params
+from ...utils.pytorch import _bf16_to_numpy_dtype, load_pretrained_params
 from .base import _PARSeq, _PARSeqPostProcessor
 
 __all__ = ["PARSeq", "parseq"]
@@ -361,6 +361,8 @@ class PARSeq(_PARSeq, nn.Module):
                 loss = F.cross_entropy(logits.flatten(end_dim=1), gt.flatten(), ignore_index=self.vocab_size + 2)
         else:
             logits = self.decode_autoregressive(features)
+
+        logits = _bf16_to_numpy_dtype(logits)
 
         out: Dict[str, Any] = {}
         if self.exportable:

--- a/doctr/models/recognition/sar/pytorch.py
+++ b/doctr/models/recognition/sar/pytorch.py
@@ -14,7 +14,7 @@ from torchvision.models._utils import IntermediateLayerGetter
 from doctr.datasets import VOCABS
 
 from ...classification import resnet31
-from ...utils.pytorch import load_pretrained_params
+from ...utils.pytorch import _bf16_to_numpy_dtype, load_pretrained_params
 from ..core import RecognitionModel, RecognitionPostProcessor
 
 __all__ = ["SAR", "sar_resnet31"]
@@ -249,7 +249,7 @@ class SAR(nn.Module, RecognitionModel):
         if self.training and target is None:
             raise ValueError("Need to provide labels during training for teacher forcing")
 
-        decoded_features = self.decoder(features, encoded, gt=None if target is None else gt)
+        decoded_features = _bf16_to_numpy_dtype(self.decoder(features, encoded, gt=None if target is None else gt))
 
         out: Dict[str, Any] = {}
         if self.exportable:

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -14,7 +14,7 @@ from torchvision.models._utils import IntermediateLayerGetter
 from doctr.datasets import VOCABS
 
 from ...classification import vit_b, vit_s
-from ...utils.pytorch import load_pretrained_params
+from ...utils.pytorch import _bf16_to_numpy_dtype, load_pretrained_params
 from .base import _ViTSTR, _ViTSTRPostProcessor
 
 __all__ = ["ViTSTR", "vitstr_small", "vitstr_base"]
@@ -95,7 +95,7 @@ class ViTSTR(_ViTSTR, nn.Module):
         B, N, E = features.size()
         features = features.reshape(B * N, E)
         logits = self.head(features).view(B, N, len(self.vocab) + 1)  # (batch_size, max_length, vocab + 1)
-        decoded_features = logits[:, 1:]  # remove cls_token
+        decoded_features = _bf16_to_numpy_dtype(logits[:, 1:])  # remove cls_token
 
         out: Dict[str, Any] = {}
         if self.exportable:

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -17,7 +17,7 @@ __all__ = [
     "set_device_and_dtype",
     "export_model_to_onnx",
     "_copy_tensor",
-    "numpy_dtype_converter",
+    "_bf16_to_numpy_dtype",
 ]
 
 
@@ -159,6 +159,6 @@ def export_model_to_onnx(model: nn.Module, model_name: str, dummy_input: torch.T
     return f"{model_name}.onnx"
 
 
-def numpy_dtype_converter(input):
+def _bf16_to_numpy_dtype(x):
     # bfloat16 is not supported in .numpy(): torch/csrc/utils/tensor_numpy.cpp:aten_to_numpy_dtype
-    return input.float() if input.dtype in [torch.bfloat16] else input
+    return x.float() if x.dtype == torch.bfloat16 else x

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -11,7 +11,14 @@ from torch import nn
 
 from doctr.utils.data import download_from_url
 
-__all__ = ["load_pretrained_params", "conv_sequence_pt", "set_device_and_dtype", "export_model_to_onnx", "_copy_tensor"]
+__all__ = [
+    "load_pretrained_params",
+    "conv_sequence_pt",
+    "set_device_and_dtype",
+    "export_model_to_onnx",
+    "_copy_tensor",
+    "numpy_dtype_converter",
+]
 
 
 def _copy_tensor(x: torch.Tensor) -> torch.Tensor:
@@ -150,3 +157,8 @@ def export_model_to_onnx(model: nn.Module, model_name: str, dummy_input: torch.T
     )
     logging.info(f"Model exported to {model_name}.onnx")
     return f"{model_name}.onnx"
+
+
+def numpy_dtype_converter(input):
+    # bfloat16 is not supported in .numpy(): torch/csrc/utils/tensor_numpy.cpp:aten_to_numpy_dtype
+    return input.float() if input.dtype in [torch.bfloat16] else input

--- a/tests/pytorch/test_models_utils_pt.py
+++ b/tests/pytorch/test_models_utils_pt.py
@@ -5,10 +5,10 @@ import torch
 from torch import nn
 
 from doctr.models.utils import (
+    _bf16_to_numpy_dtype,
     _copy_tensor,
     conv_sequence_pt,
     load_pretrained_params,
-    numpy_dtype_converter,
     set_device_and_dtype,
 )
 
@@ -60,7 +60,7 @@ def test_set_device_and_dtype():
     assert batches[0].dtype == torch.float16
 
 
-def test_numpy_dtype_converter():
-    input = torch.randn([2, 2], dtype=torch.bfloat16)
-    converted_input = numpy_dtype_converter(input)
-    assert converted_input.dtype == torch.float32
+def test_bf16_to_numpy_dtype():
+    x = torch.randn([2, 2], dtype=torch.bfloat16)
+    converted_x = _bf16_to_numpy_dtype(x)
+    assert x.dtype == torch.bfloat16 and converted_x.dtype == torch.float32 and torch.equal(converted_x, x.float())

--- a/tests/pytorch/test_models_utils_pt.py
+++ b/tests/pytorch/test_models_utils_pt.py
@@ -4,7 +4,13 @@ import pytest
 import torch
 from torch import nn
 
-from doctr.models.utils import _copy_tensor, conv_sequence_pt, load_pretrained_params, set_device_and_dtype
+from doctr.models.utils import (
+    _copy_tensor,
+    conv_sequence_pt,
+    load_pretrained_params,
+    numpy_dtype_converter,
+    set_device_and_dtype,
+)
 
 
 def test_copy_tensor():
@@ -52,3 +58,9 @@ def test_set_device_and_dtype():
     model, batches = set_device_and_dtype(model, batches, device="cpu", dtype=torch.float16)
     assert model[0].weight.dtype == torch.float16
     assert batches[0].dtype == torch.float16
+
+
+def test_numpy_dtype_converter():
+    input = torch.randn([2, 2], dtype=torch.bfloat16)
+    converted_input = numpy_dtype_converter(input)
+    assert converted_input.dtype == torch.float32


### PR DESCRIPTION
`.numpy()` in PyTorch only supports limited scalar types: [aten_to_numpy_dtype](https://github.com/pytorch/pytorch/blob/de3ae93e9b7dd522a74e0f5fd33fc5eeed8836cc/torch/csrc/utils/tensor_numpy.cpp#L274-L301).
When running BF16 with autocast, an error will be thrown here when calling `.numpy()`: `TypeError: Got unsupported ScalarType BFloat16`.
Convert BF16 tensor to float before calling `.numpy()` to fix this error.