### PR TITLE
[Fix] Prob comp in vitstr and parseq for empty words

### DIFF
--- a/doctr/models/recognition/parseq/pytorch.py
+++ b/doctr/models/recognition/parseq/pytorch.py
@@ -403,7 +403,9 @@ class PARSeqPostProcessor(_PARSeqPostProcessor):
             for encoded_seq in out_idxs.cpu().numpy()
         ]
         # compute probabilties for each word up to the EOS token
-        probs = [preds_prob[i, : len(word)].clip(0, 1).mean().item() for i, word in enumerate(word_values)]
+        probs = [
+            preds_prob[i, : len(word)].clip(0, 1).mean().item() if word else 0.0 for i, word in enumerate(word_values)
+        ]
 
         return list(zip(word_values, probs))
 

--- a/doctr/models/recognition/parseq/tensorflow.py
+++ b/doctr/models/recognition/parseq/tensorflow.py
@@ -432,7 +432,10 @@ class PARSeqPostProcessor(_PARSeqPostProcessor):
         word_values = [word.decode() for word in decoded_strings_pred.numpy().tolist()]
 
         # compute probabilties for each word up to the EOS token
-        probs = [preds_prob[i, : len(word)].numpy().clip(0, 1).mean().item() for i, word in enumerate(word_values)]
+        probs = [
+            preds_prob[i, : len(word)].numpy().clip(0, 1).mean().item() if word else 0.0
+            for i, word in enumerate(word_values)
+        ]
 
         return list(zip(word_values, probs))
 

--- a/doctr/models/recognition/vitstr/pytorch.py
+++ b/doctr/models/recognition/vitstr/pytorch.py
@@ -167,7 +167,9 @@ class ViTSTRPostProcessor(_ViTSTRPostProcessor):
             for encoded_seq in out_idxs.cpu().numpy()
         ]
         # compute probabilties for each word up to the EOS token
-        probs = [preds_prob[i, : len(word)].clip(0, 1).mean().item() for i, word in enumerate(word_values)]
+        probs = [
+            preds_prob[i, : len(word)].clip(0, 1).mean().item() if word else 0.0 for i, word in enumerate(word_values)
+        ]
 
         return list(zip(word_values, probs))
 

--- a/doctr/models/recognition/vitstr/tensorflow.py
+++ b/doctr/models/recognition/vitstr/tensorflow.py
@@ -175,7 +175,10 @@ class ViTSTRPostProcessor(_ViTSTRPostProcessor):
         word_values = [word.decode() for word in decoded_strings_pred.numpy().tolist()]
 
         # compute probabilties for each word up to the EOS token
-        probs = [preds_prob[i, : len(word)].numpy().clip(0, 1).mean().item() for i, word in enumerate(word_values)]
+        probs = [
+            preds_prob[i, : len(word)].numpy().clip(0, 1).mean().item() if word else 0.0
+            for i, word in enumerate(word_values)
+        ]
 
         return list(zip(word_values, probs))
 


### PR DESCRIPTION
This PR:

- Add `0.0` in prob comp if word is empty