### PR TITLE
TF change antialias to true

### DIFF
--- a/doctr/models/preprocessor/tensorflow.py
+++ b/doctr/models/preprocessor/tensorflow.py
@@ -106,7 +106,7 @@ class PreProcessor(NestedObject):
                 x = tf.image.convert_image_dtype(x, dtype=tf.float32)
             # Resizing
             if (x.shape[1], x.shape[2]) != self.resize.output_size:
-                x = tf.image.resize(x, self.resize.output_size, method=self.resize.method)
+                x = tf.image.resize(x, self.resize.output_size, method=self.resize.method, antialias=True)
 
             batches = [x]
 

--- a/doctr/models/preprocessor/tensorflow.py
+++ b/doctr/models/preprocessor/tensorflow.py
@@ -106,7 +106,9 @@ class PreProcessor(NestedObject):
                 x = tf.image.convert_image_dtype(x, dtype=tf.float32)
             # Resizing
             if (x.shape[1], x.shape[2]) != self.resize.output_size:
-                x = tf.image.resize(x, self.resize.output_size, method=self.resize.method, antialias=True)
+                x = tf.image.resize(
+                    x, self.resize.output_size, method=self.resize.method, antialias=self.resize.antialias
+                )
 
             batches = [x]
 

--- a/doctr/transforms/modules/tensorflow.py
+++ b/doctr/transforms/modules/tensorflow.py
@@ -106,7 +106,7 @@ class Resize(NestedObject):
     ) -> Union[tf.Tensor, Tuple[tf.Tensor, np.ndarray]]:
         input_dtype = img.dtype
 
-        img = tf.image.resize(img, self.wanted_size, self.method, self.preserve_aspect_ratio)
+        img = tf.image.resize(img, self.wanted_size, self.method, self.preserve_aspect_ratio, antialias=True)
         # It will produce an un-padded resized image, with a side shorter than wanted if we preserve aspect ratio
         raw_shape = img.shape[:2]
         if self.preserve_aspect_ratio:

--- a/doctr/transforms/modules/tensorflow.py
+++ b/doctr/transforms/modules/tensorflow.py
@@ -85,6 +85,7 @@ class Resize(NestedObject):
         self.method = method
         self.preserve_aspect_ratio = preserve_aspect_ratio
         self.symmetric_pad = symmetric_pad
+        self.antialias = True
 
         if isinstance(self.output_size, int):
             self.wanted_size = (self.output_size, self.output_size)
@@ -106,7 +107,7 @@ class Resize(NestedObject):
     ) -> Union[tf.Tensor, Tuple[tf.Tensor, np.ndarray]]:
         input_dtype = img.dtype
 
-        img = tf.image.resize(img, self.wanted_size, self.method, self.preserve_aspect_ratio, antialias=True)
+        img = tf.image.resize(img, self.wanted_size, self.method, self.preserve_aspect_ratio, self.antialias)
         # It will produce an un-padded resized image, with a side shorter than wanted if we preserve aspect ratio
         raw_shape = img.shape[:2]
         if self.preserve_aspect_ratio:

--- a/tests/tensorflow/test_models_preprocessor_tf.py
+++ b/tests/tensorflow/test_models_preprocessor_tf.py
@@ -40,5 +40,5 @@ def test_preprocessor(batch_size, output_size, input_tensor, expected_batches, e
     assert all(isinstance(b, tf.Tensor) for b in out)
     assert all(b.dtype == tf.float32 for b in out)
     assert all(b.shape[1:3] == output_size for b in out)
-    assert all(tf.math.reduce_all(b == expected_value) for b in out)
+    assert all(tf.math.reduce_all(tf.math.abs(b - expected_value) < 1e-6) for b in out)
     assert len(repr(processor).split("\n")) == 4

--- a/tests/tensorflow/test_transforms_tf.py
+++ b/tests/tensorflow/test_transforms_tf.py
@@ -14,7 +14,7 @@ def test_resize():
     input_t = tf.cast(tf.fill([64, 64, 3], 1), dtype=tf.float32)
     out = transfo(input_t)
 
-    assert tf.reduce_all(out == 1)
+    assert tf.math.reduce_all(tf.math.abs(out - 1) < 1e-6)
     assert out.shape[:2] == output_size
     assert repr(transfo) == f"Resize(output_size={output_size}, method='bilinear')"
 
@@ -24,7 +24,7 @@ def test_resize():
 
     assert not tf.reduce_all(out == 1)
     # Asymetric padding
-    assert tf.reduce_all(out[-1] == 0) and tf.reduce_all(out[0] == 1)
+    assert tf.reduce_all(out[-1] == 0) and tf.math.reduce_all(tf.math.abs(out[0] - 1) < 1e-6)
     assert out.shape[:2] == output_size
 
     # Symetric padding


### PR DESCRIPTION
This PR: 

- changes `antialias` also for TF to True

NOTE tests:

- super minimal difference (< 1e-6) in the expected output  (e.g.: 5.00001 instead of 5.0  /  1.00002 instead of 1.0) - 
I don't think there's much we can do about that (the results are correct and close to PT see below)