### PR TITLE
[misc] increase to 0.8.0 and temp pin onnx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
 tf = [
     "tensorflow>=2.11.0,<3.0.0",  # cf. https://github.com/mindee/doctr/pull/1182
     "tf2onnx>=1.15.1,<2.0.0",  # cf.https://github.com/onnx/tensorflow-onnx/releases/tag/v1.15.1
+    "onnx>=1.12.0,!=1.15.0,<3.0.0",  # TODO: remove this line once tf2onnx supports onnx>=1.15.0
 ]
 torch = [
     "torch>=1.12.0,<3.0.0",
@@ -97,7 +98,9 @@ dev = [
     # PyTorch
     "torch>=1.12.0,<3.0.0",
     "torchvision>=0.13.0",
-    "onnx>=1.12.0,<3.0.0",
+    # TODO: remove the constraint once tf2onnx supports onnx>=1.15.0
+    # TODO: cf. https://github.com/onnx/tensorflow-onnx/pull/2252
+    "onnx>=1.12.0,!=1.15.0,<3.0.0",
     # Testing
     "pytest>=5.3.2",
     "coverage[toml]>=4.5.4",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from setuptools import setup
 
 PKG_NAME = "python-doctr"
-VERSION = os.getenv("BUILD_VERSION", "0.7.1a0")
+VERSION = os.getenv("BUILD_VERSION", "0.8.0a0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:

- increase version to 0.8.0 (docker feature / orientation improvement / etc. -> minor instead of patch)
- temp pin onnx until https://github.com/onnx/tensorflow-onnx/pull/2252 is fixed