### PR TITLE
Fix broken weasyprint link

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The KIE predictor results per page are in a dictionary format with each key repr
 
 Python 3.8 (or higher) and [pip](https://pip.pypa.io/en/stable/) are required to install docTR.
 
-Since we use [weasyprint](https://weasyprint.readthedocs.io/), you will need extra dependencies if you are not running Linux.
+Since we use [weasyprint](https://weasyprint.org/), you will need extra dependencies if you are not running Linux.
 
 For MacOS users, you can install them as follows:
 


### PR DESCRIPTION
Currently links to https://weasyprint.readthedocs.io/ which says:

<img width="658" alt="Read the Docs has marked this content as spam and is not serving it anymore." src="https://github.com/mindee/doctr/assets/9599/70cc6858-e562-4adb-a752-1f255522467b">

https://weasyprint.org looks to be a better URL.


