### PR TITLE
Fixed DivisionByZeroError issue with contours having 0 height or width by excluding them

### DIFF
--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -53,7 +53,7 @@ def estimate_orientation(img: np.ndarray, n_ct: int = 50, ratio_threshold_for_li
     contours, _ = cv2.findContours(thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
 
     # Sort contours
-    contours = sorted(contours, key=get_max_width_length_ratio, reverse=True)
+    contours = sorted([contour for contour in contours if 0 not in cv2.minAreaRect(contour)[1]], key=get_max_width_length_ratio, reverse=True)
 
     angles = []
     for contour in contours[:n_ct]:


### PR DESCRIPTION
I encountered a DivisionByZeroError when running the function to determine orientation (which calls the function get_max_width_length_ratio() while sorting, which divides the width and height), with one of the contours having 0 width or height, which caused the code to abruptly stop. So I added a quick fix to exclude any such contours, as the width and height of the contours are used later on as well.