### PR TITLE
feat: :sparkles: use `tqdm` instead of `fastprogress` in reference scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,7 @@ preview=true
 
 [tool.ruff.isort]
 known-first-party = ["doctr", "app", "utils"]
-known-third-party = ["tensorflow", "torch", "torchvision", "wandb", "fastprogress", "fastapi"]
+known-third-party = ["tensorflow", "torch", "torchvision", "wandb", "tqdm", "fastapi"]
 
 [tool.ruff.per-file-ignores]
 "doctr/models/**.py" = ["N806", "F841"]

--- a/references/classification/train_pytorch.py
+++ b/references/classification/train_pytorch.py
@@ -15,7 +15,6 @@ import time
 import numpy as np
 import torch
 import wandb
-from fastprogress.fastprogress import master_bar, progress_bar
 from torch.nn.functional import cross_entropy
 from torch.optim.lr_scheduler import CosineAnnealingLR, MultiplicativeLR, OneCycleLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
@@ -29,6 +28,7 @@ from torchvision.transforms.v2 import (
     RandomPhotometricDistort,
     RandomRotation,
 )
+from tqdm.auto import tqdm, trange
 
 from doctr import transforms as T
 from doctr.datasets import VOCABS, CharacterGenerator
@@ -107,13 +107,14 @@ def record_lr(
     return lr_recorder[: len(loss_recorder)], loss_recorder
 
 
-def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, mb, amp=False):
+def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, amp=False):
     if amp:
         scaler = torch.cuda.amp.GradScaler()
 
     model.train()
     # Iterate over the batches of the dataset
-    for images, targets in progress_bar(train_loader, parent=mb):
+    pbar = tqdm(train_loader, position=1)
+    for images, targets in pbar:
         if torch.cuda.is_available():
             images = images.cuda()
             targets = targets.cuda()
@@ -136,7 +137,7 @@ def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, m
             optimizer.step()
         scheduler.step()
 
-        mb.child.comment = f"Training loss: {train_loss.item():.6}"
+        pbar.set_description(f"Training loss: {train_loss.item():.6}")
 
 
 @torch.no_grad()
@@ -329,9 +330,9 @@ def main(args):
     # Create loss queue
     min_loss = np.inf
     # Training loop
-    mb = master_bar(range(args.epochs))
+    mb = trange(args.epochs)
     for epoch in mb:
-        fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, mb)
+        fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler)
 
         # Validation loop at the end of each epoch
         val_loss, acc = evaluate(model, val_loader, batch_transforms)

--- a/references/classification/train_pytorch.py
+++ b/references/classification/train_pytorch.py
@@ -146,7 +146,7 @@ def evaluate(model, val_loader, batch_transforms, amp=False):
     model.eval()
     # Validation loop
     val_loss, correct, samples, batch_cnt = 0, 0, 0, 0
-    for images, targets in val_loader:
+    for images, targets in tqdm(val_loader):
         images = batch_transforms(images)
 
         if torch.cuda.is_available():

--- a/references/classification/train_pytorch.py
+++ b/references/classification/train_pytorch.py
@@ -28,7 +28,7 @@ from torchvision.transforms.v2 import (
     RandomPhotometricDistort,
     RandomRotation,
 )
-from tqdm.auto import tqdm, trange
+from tqdm.auto import tqdm
 
 from doctr import transforms as T
 from doctr.datasets import VOCABS, CharacterGenerator
@@ -330,8 +330,7 @@ def main(args):
     # Create loss queue
     min_loss = np.inf
     # Training loop
-    mb = trange(args.epochs)
-    for epoch in mb:
+    for epoch in range(args.epochs):
         fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler)
 
         # Validation loop at the end of each epoch
@@ -340,7 +339,7 @@ def main(args):
             print(f"Validation loss decreased {min_loss:.6} --> {val_loss:.6}: saving state...")
             torch.save(model.state_dict(), f"./{exp_name}.pt")
             min_loss = val_loss
-        mb.write(f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} (Acc: {acc:.2%})")
+        print(f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} (Acc: {acc:.2%})")
         # W&B
         if args.wb:
             wandb.log(

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -15,7 +15,7 @@ import time
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras import mixed_precision
-from tqdm.auto import tqdm, trange
+from tqdm.auto import tqdm
 
 from doctr.models import login_to_hub, push_to_hf_hub
 
@@ -294,8 +294,7 @@ def main(args):
     min_loss = np.inf
 
     # Training loop
-    mb = trange(args.epochs)
-    for epoch in mb:
+    for epoch in range(args.epochs):
         fit_one_epoch(model, train_loader, batch_transforms, optimizer, args.amp)
 
         # Validation loop at the end of each epoch
@@ -304,7 +303,7 @@ def main(args):
             print(f"Validation loss decreased {min_loss:.6} --> {val_loss:.6}: saving state...")
             model.save_weights(f"./{exp_name}/weights")
             min_loss = val_loss
-        mb.write(f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} (Acc: {acc:.2%})")
+        print(f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} (Acc: {acc:.2%})")
         # W&B
         if args.wb:
             wandb.log(

--- a/references/classification/train_tensorflow.py
+++ b/references/classification/train_tensorflow.py
@@ -104,7 +104,7 @@ def evaluate(model, val_loader, batch_transforms):
     # Validation loop
     val_loss, correct, samples, batch_cnt = 0, 0, 0, 0
     val_iter = iter(val_loader)
-    for images, targets in val_iter:
+    for images, targets in tqdm(val_iter):
         images = batch_transforms(images)
         out = model(images, training=False)
         loss = tf.nn.sparse_softmax_cross_entropy_with_logits(targets, out)

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -20,7 +20,7 @@ import wandb
 from torch.optim.lr_scheduler import CosineAnnealingLR, MultiplicativeLR, OneCycleLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torchvision.transforms.v2 import Compose, GaussianBlur, Normalize, RandomGrayscale, RandomPhotometricDistort
-from tqdm.auto import tqdm, trange
+from tqdm.auto import tqdm
 
 from doctr import transforms as T
 from doctr.datasets import DetectionDataset
@@ -369,8 +369,7 @@ def main(args):
     min_loss = np.inf
 
     # Training loop
-    mb = trange(args.epochs)
-    for epoch in mb:
+    for epoch in range(args.epochs):
         fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, amp=args.amp)
         # Validation loop at the end of each epoch
         val_loss, recall, precision, mean_iou = evaluate(model, val_loader, batch_transforms, val_metric, amp=args.amp)
@@ -383,7 +382,7 @@ def main(args):
             log_msg += "(Undefined metric value, caused by empty GTs or predictions)"
         else:
             log_msg += f"(Recall: {recall:.2%} | Precision: {precision:.2%} | Mean IoU: {mean_iou:.2%})"
-        mb.write(log_msg)
+        print(log_msg)
         # W&B
         if args.wb:
             wandb.log(

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -142,7 +142,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
     val_metric.reset()
     # Validation loop
     val_loss, batch_cnt = 0, 0
-    for images, targets in val_loader:
+    for images, targets in tqdm(val_loader):
         if torch.cuda.is_available():
             images = images.cuda()
         images = batch_transforms(images)

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -107,7 +107,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
     # Validation loop
     val_loss, batch_cnt = 0, 0
     val_iter = iter(val_loader)
-    for images, targets in val_iter:
+    for images, targets in tqdm(val_iter):
         images = batch_transforms(images)
         out = model(images, targets, training=False, return_preds=True)
         # Compute metric

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -17,7 +17,7 @@ import numpy as np
 import psutil
 import tensorflow as tf
 from tensorflow.keras import mixed_precision
-from tqdm.auto import tqdm, trange
+from tqdm.auto import tqdm
 
 from doctr.models import login_to_hub, push_to_hf_hub
 
@@ -328,8 +328,7 @@ def main(args):
     min_loss = np.inf
 
     # Training loop
-    mb = trange(args.epochs)
-    for epoch in mb:
+    for epoch in range(args.epochs):
         fit_one_epoch(model, train_loader, batch_transforms, optimizer, args.amp)
         # Validation loop at the end of each epoch
         val_loss, recall, precision, mean_iou = evaluate(model, val_loader, batch_transforms, val_metric)
@@ -342,7 +341,7 @@ def main(args):
             log_msg += "(Undefined metric value, caused by empty GTs or predictions)"
         else:
             log_msg += f"(Recall: {recall:.2%} | Precision: {precision:.2%} | Mean IoU: {mean_iou:.2%})"
-        mb.write(log_msg)
+        print(log_msg)
         # W&B
         if args.wb:
             wandb.log(

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -16,8 +16,8 @@ import time
 import numpy as np
 import psutil
 import tensorflow as tf
-from fastprogress.fastprogress import master_bar, progress_bar
 from tensorflow.keras import mixed_precision
+from tqdm.auto import tqdm, trange
 
 from doctr.models import login_to_hub, push_to_hf_hub
 
@@ -84,10 +84,11 @@ def record_lr(
     return lr_recorder[: len(loss_recorder)], loss_recorder
 
 
-def fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb, amp=False):
+def fit_one_epoch(model, train_loader, batch_transforms, optimizer, amp=False):
     train_iter = iter(train_loader)
     # Iterate over the batches of the dataset
-    for images, targets in progress_bar(train_iter, parent=mb):
+    pbar = tqdm(train_iter, position=1)
+    for images, targets in pbar:
         images = batch_transforms(images)
 
         with tf.GradientTape() as tape:
@@ -97,7 +98,7 @@ def fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb, amp=Fals
             grads = optimizer.get_unscaled_gradients(grads)
         optimizer.apply_gradients(zip(grads, model.trainable_weights))
 
-        mb.child.comment = f"Training loss: {train_loss.numpy():.6}"
+        pbar.set_description(f"Training loss: {train_loss.numpy():.6}")
 
 
 def evaluate(model, val_loader, batch_transforms, val_metric):
@@ -327,9 +328,9 @@ def main(args):
     min_loss = np.inf
 
     # Training loop
-    mb = master_bar(range(args.epochs))
+    mb = trange(args.epochs)
     for epoch in mb:
-        fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb, args.amp)
+        fit_one_epoch(model, train_loader, batch_transforms, optimizer, args.amp)
         # Validation loop at the end of each epoch
         val_loss, recall, precision, mean_iou = evaluate(model, val_loader, batch_transforms, val_metric)
         if val_loss < min_loss:

--- a/references/obj_detection/train_pytorch.py
+++ b/references/obj_detection/train_pytorch.py
@@ -19,7 +19,7 @@ import wandb
 from torch.optim.lr_scheduler import MultiplicativeLR, StepLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torchvision.transforms import ColorJitter, Compose, GaussianBlur
-from tqdm.auto import tqdm, trange
+from tqdm.auto import tqdm
 
 from doctr import transforms as T
 from doctr.datasets import DocArtefacts
@@ -304,10 +304,9 @@ def main(args):
             },
         )
 
-    mb = trange(args.epochs)
     max_score = 0.0
 
-    for epoch in mb:
+    for epoch in range(args.epochs):
         fit_one_epoch(model, train_loader, optimizer, scheduler, amp=args.amp)
         # Validation loop at the end of each epoch
         recall, precision, mean_iou = evaluate(model, val_loader, metric, amp=args.amp)
@@ -322,7 +321,7 @@ def main(args):
             log_msg += "Undefined metric value, caused by empty GTs or predictions"
         else:
             log_msg += f"Recall: {recall:.2%} | Precision: {precision:.2%} | Mean IoU: {mean_iou:.2%}"
-        mb.write(log_msg)
+        print(log_msg)
         # W&B
         if args.wb:
             wandb.log(

--- a/references/obj_detection/train_pytorch.py
+++ b/references/obj_detection/train_pytorch.py
@@ -149,7 +149,7 @@ def fit_one_epoch(model, train_loader, optimizer, scheduler, amp=False):
 def evaluate(model, val_loader, metric, amp=False):
     model.eval()
     metric.reset()
-    for images, targets in val_loader:
+    for images, targets in tqdm(val_loader):
         targets = convert_to_abs_coords(targets, images.shape)
         if torch.cuda.is_available():
             images = images.cuda()

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -27,7 +27,7 @@ from torchvision.transforms.v2 import (
     RandomPerspective,
     RandomPhotometricDistort,
 )
-from tqdm.auto import tqdm, trange
+from tqdm.auto import tqdm
 
 from doctr import transforms as T
 from doctr.datasets import VOCABS, RecognitionDataset, WordGenerator
@@ -392,8 +392,7 @@ def main(args):
     # Create loss queue
     min_loss = np.inf
     # Training loop
-    mb = trange(args.epochs)
-    for epoch in mb:
+    for epoch in range(args.epochs):
         fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, amp=args.amp)
 
         # Validation loop at the end of each epoch
@@ -402,7 +401,7 @@ def main(args):
             print(f"Validation loss decreased {min_loss:.6} --> {val_loss:.6}: saving state...")
             torch.save(model.state_dict(), f"./{exp_name}.pt")
             min_loss = val_loss
-        mb.write(
+        print(
             f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} "
             f"(Exact: {exact_match:.2%} | Partial: {partial_match:.2%})"
         )

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -151,7 +151,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
     val_metric.reset()
     # Validation loop
     val_loss, batch_cnt = 0, 0
-    for images, targets in val_loader:
+    for images, targets in tqdm(val_loader):
         if torch.cuda.is_available():
             images = images.cuda()
         images = batch_transforms(images)

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import numpy as np
 import torch
 import wandb
-from fastprogress.fastprogress import master_bar, progress_bar
 from torch.optim.lr_scheduler import CosineAnnealingLR, MultiplicativeLR, OneCycleLR
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torchvision.transforms.v2 import (
@@ -28,6 +27,7 @@ from torchvision.transforms.v2 import (
     RandomPerspective,
     RandomPhotometricDistort,
 )
+from tqdm.auto import tqdm, trange
 
 from doctr import transforms as T
 from doctr.datasets import VOCABS, RecognitionDataset, WordGenerator
@@ -107,13 +107,14 @@ def record_lr(
     return lr_recorder[: len(loss_recorder)], loss_recorder
 
 
-def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, mb, amp=False):
+def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, amp=False):
     if amp:
         scaler = torch.cuda.amp.GradScaler()
 
     model.train()
     # Iterate over the batches of the dataset
-    for images, targets in progress_bar(train_loader, parent=mb):
+    pbar = tqdm(train_loader, position=1)
+    for images, targets in pbar:
         if torch.cuda.is_available():
             images = images.cuda()
         images = batch_transforms(images)
@@ -139,7 +140,7 @@ def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, m
 
         scheduler.step()
 
-        mb.child.comment = f"Training loss: {train_loss.item():.6}"
+        pbar.set_description(f"Training loss: {train_loss.item():.6}")
 
 
 @torch.no_grad()
@@ -391,9 +392,9 @@ def main(args):
     # Create loss queue
     min_loss = np.inf
     # Training loop
-    mb = master_bar(range(args.epochs))
+    mb = trange(args.epochs)
     for epoch in mb:
-        fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, mb, amp=args.amp)
+        fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, amp=args.amp)
 
         # Validation loop at the end of each epoch
         val_loss, exact_match, partial_match = evaluate(model, val_loader, batch_transforms, val_metric, amp=args.amp)

--- a/references/recognition/train_pytorch_ddp.py
+++ b/references/recognition/train_pytorch_ddp.py
@@ -82,7 +82,7 @@ def evaluate(model, device, val_loader, batch_transforms, val_metric, amp=False)
     val_metric.reset()
     # Validation loop
     val_loss, batch_cnt = 0, 0
-    for images, targets in val_loader:
+    for images, targets in tqdm(val_loader):
         images = images.to(device)
         images = batch_transforms(images)
         if amp:

--- a/references/recognition/train_pytorch_ddp.py
+++ b/references/recognition/train_pytorch_ddp.py
@@ -30,7 +30,7 @@ from torchvision.transforms.v2 import (
     RandomPerspective,
     RandomPhotometricDistort,
 )
-from tqdm.auto import tqdm, trange
+from tqdm.auto import tqdm
 
 from doctr import transforms as T
 from doctr.datasets import VOCABS, RecognitionDataset, WordGenerator
@@ -322,8 +322,7 @@ def main(rank: int, world_size: int, args):
     # Create loss queue
     min_loss = np.inf
     # Training loop
-    mb = trange(args.epochs)
-    for epoch in mb:
+    for epoch in range(args.epochs):
         fit_one_epoch(model, device, train_loader, batch_transforms, optimizer, scheduler, amp=args.amp)
 
         if rank == 0:
@@ -338,7 +337,7 @@ def main(rank: int, world_size: int, args):
                 print(f"Validation loss decreased {min_loss:.6} --> {val_loss:.6}: saving state...")
                 torch.save(model.module.state_dict(), f"./{exp_name}.pt")
             min_loss = val_loss
-            mb.write(
+            print(
                 f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} "
                 f"(Exact: {exact_match:.2%} | Partial: {partial_match:.2%})"
             )

--- a/references/recognition/train_pytorch_ddp.py
+++ b/references/recognition/train_pytorch_ddp.py
@@ -18,7 +18,6 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import wandb
-from fastprogress.fastprogress import master_bar, progress_bar
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim.lr_scheduler import CosineAnnealingLR, OneCycleLR
 from torch.utils.data import DataLoader, SequentialSampler
@@ -31,6 +30,7 @@ from torchvision.transforms.v2 import (
     RandomPerspective,
     RandomPhotometricDistort,
 )
+from tqdm.auto import tqdm, trange
 
 from doctr import transforms as T
 from doctr.datasets import VOCABS, RecognitionDataset, WordGenerator
@@ -39,13 +39,14 @@ from doctr.utils.metrics import TextMatch
 from utils import plot_samples
 
 
-def fit_one_epoch(model, device, train_loader, batch_transforms, optimizer, scheduler, mb, amp=False):
+def fit_one_epoch(model, device, train_loader, batch_transforms, optimizer, scheduler, amp=False):
     if amp:
         scaler = torch.cuda.amp.GradScaler()
 
     model.train()
     # Iterate over the batches of the dataset
-    for images, targets in progress_bar(train_loader, parent=mb):
+    pbar = tqdm(train_loader, position=1)
+    for images, targets in pbar:
         images = images.to(device)
         images = batch_transforms(images)
 
@@ -70,7 +71,7 @@ def fit_one_epoch(model, device, train_loader, batch_transforms, optimizer, sche
 
         scheduler.step()
 
-        mb.child.comment = f"Training loss: {train_loss.item():.6}"
+        pbar.set_description(f"Training loss: {train_loss.item():.6}")
 
 
 @torch.no_grad()
@@ -321,9 +322,9 @@ def main(rank: int, world_size: int, args):
     # Create loss queue
     min_loss = np.inf
     # Training loop
-    mb = master_bar(range(args.epochs))
+    mb = trange(args.epochs)
     for epoch in mb:
-        fit_one_epoch(model, device, train_loader, batch_transforms, optimizer, scheduler, mb, amp=args.amp)
+        fit_one_epoch(model, device, train_loader, batch_transforms, optimizer, scheduler, amp=args.amp)
 
         if rank == 0:
             # Validation loop at the end of each epoch

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras import mixed_precision
-from tqdm.auto import tqdm, trange
+from tqdm.auto import tqdm
 
 from doctr.models import login_to_hub, push_to_hf_hub
 
@@ -349,8 +349,7 @@ def main(args):
     min_loss = np.inf
 
     # Training loop
-    mb = trange(args.epochs)
-    for epoch in mb:
+    for epoch in range(args.epochs):
         fit_one_epoch(model, train_loader, batch_transforms, optimizer, args.amp)
 
         # Validation loop at the end of each epoch
@@ -359,7 +358,7 @@ def main(args):
             print(f"Validation loss decreased {min_loss:.6} --> {val_loss:.6}: saving state...")
             model.save_weights(f"./{exp_name}/weights")
             min_loss = val_loss
-        mb.write(
+        print(
             f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} "
             f"(Exact: {exact_match:.2%} | Partial: {partial_match:.2%})"
         )

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -16,8 +16,8 @@ from pathlib import Path
 
 import numpy as np
 import tensorflow as tf
-from fastprogress.fastprogress import master_bar, progress_bar
 from tensorflow.keras import mixed_precision
+from tqdm.auto import tqdm, trange
 
 from doctr.models import login_to_hub, push_to_hf_hub
 
@@ -84,10 +84,11 @@ def record_lr(
     return lr_recorder[: len(loss_recorder)], loss_recorder
 
 
-def fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb, amp=False):
+def fit_one_epoch(model, train_loader, batch_transforms, optimizer, amp=False):
     train_iter = iter(train_loader)
     # Iterate over the batches of the dataset
-    for images, targets in progress_bar(train_iter, parent=mb):
+    pbar = tqdm(train_iter, position=1)
+    for images, targets in pbar:
         images = batch_transforms(images)
 
         with tf.GradientTape() as tape:
@@ -97,7 +98,7 @@ def fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb, amp=Fals
             grads = optimizer.get_unscaled_gradients(grads)
         optimizer.apply_gradients(zip(grads, model.trainable_weights))
 
-        mb.child.comment = f"Training loss: {train_loss.numpy().mean():.6}"
+        pbar.set_description(f"Training loss: {train_loss.numpy().mean():.6}")
 
 
 def evaluate(model, val_loader, batch_transforms, val_metric):
@@ -348,9 +349,9 @@ def main(args):
     min_loss = np.inf
 
     # Training loop
-    mb = master_bar(range(args.epochs))
+    mb = trange(args.epochs)
     for epoch in mb:
-        fit_one_epoch(model, train_loader, batch_transforms, optimizer, mb, args.amp)
+        fit_one_epoch(model, train_loader, batch_transforms, optimizer, args.amp)
 
         # Validation loop at the end of each epoch
         val_loss, exact_match, partial_match = evaluate(model, val_loader, batch_transforms, val_metric)

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -107,7 +107,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
     # Validation loop
     val_loss, batch_cnt = 0, 0
     val_iter = iter(val_loader)
-    for images, targets in val_iter:
+    for images, targets in tqdm(val_iter):
         images = batch_transforms(images)
         out = model(images, targets, return_preds=True, training=False)
         # Compute metric

--- a/references/requirements.txt
+++ b/references/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-fastprogress>=0.1.21
+tqdm
 wandb>=0.10.31
 psutil>=5.9.0
 clearml>=1.11.1


### PR DESCRIPTION
I have not been able to run `train_pytorch.py` script on Colab. An idea is to use `tqdm` instead of `fastprogress`.

Related to https://github.com/mindee/doctr/discussions/1388 and https://github.com/mindee/doctr/discussions/1106