### PR TITLE
[references] TF / PT crop & document orientation classifier train scripts

### DIFF
--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -109,10 +109,10 @@ jobs:
           unzip toy_detection_set-bbbb4243.zip -d det_set
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF)
-        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set mobilenet_v3_small -b 2 --epochs 1
+        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set mobilenet_v3_small -b 2 --epochs 1
       - if: matrix.framework == 'pytorch'
         name: Train for a short epoch (PT)
-        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set mobilenet_v3_small -b 2 --epochs 1
+        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set mobilenet_v3_small -b 2 --epochs 1
 
   train-text-recognition:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -59,6 +59,61 @@ jobs:
         name: Train for a short epoch (PT)
         run: python references/classification/train_pytorch.py vit_s -b 32 --val-samples 1 --train-samples 1 --epochs 1
 
+  train-orientation-classification:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python: ["3.8"]
+        framework: [tensorflow, pytorch]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: x64
+      - if: matrix.framework == 'tensorflow'
+        name: Cache python modules (TF)
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('references/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-
+      - if: matrix.framework == 'pytorch'
+        name: Cache python modules (PT)
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}-${{ hashFiles('references/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('requirements-pt.txt') }}-
+      - if: matrix.framework == 'tensorflow'
+        name: Install dependencies (TF)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[tf] --upgrade
+          pip install -r references/requirements.txt
+      - if: matrix.framework == 'pytorch'
+        name: Install dependencies (PT)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[torch] --upgrade
+          pip install -r references/requirements.txt
+      - name: Download and extract toy set
+        run: |
+          wget https://github.com/mindee/doctr/releases/download/v0.3.1/toy_detection_set-bbbb4243.zip
+          sudo apt-get update && sudo apt-get install unzip -y
+          unzip toy_detection_set-bbbb4243.zip -d det_set
+      - if: matrix.framework == 'tensorflow'
+        name: Train for a short epoch (TF)
+        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set mobilenet_v3_small -b 2 --epochs 1
+      - if: matrix.framework == 'pytorch'
+        name: Train for a short epoch (PT)
+        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set mobilenet_v3_small -b 2 --epochs 1
+
   train-text-recognition:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -120,10 +120,10 @@ jobs:
         run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set resnet18 document -b 2 --epochs 1
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF) (crop orientation)
-        run: python references/classification/train_tensorflow_orientation.py ./reco_set ./reco_set crnn_vgg16_bn crop -b 4 --epochs 1
+        run: python references/classification/train_tensorflow_orientation.py ./reco_set ./reco_set rresnet18 crop -b 4 --epochs 1
       - if: matrix.framework == 'pytorch'
         name: Train for a short epoch (PT) (crop orientation)
-        run: python references/classification/train_pytorch_orientation.py ./reco_set ./reco_set crnn_mobilenet_v3_small crop -b 4 --epochs 1
+        run: python references/classification/train_pytorch_orientation.py ./reco_set ./reco_set resnet18 crop -b 4 --epochs 1
 
   train-text-recognition:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -109,10 +109,10 @@ jobs:
           unzip toy_detection_set-bbbb4243.zip -d det_set
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF)
-        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set mobilenet_v3_small -b 2 --epochs 1
+        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set vit_s -b 2 --epochs 1
       - if: matrix.framework == 'pytorch'
         name: Train for a short epoch (PT)
-        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set mobilenet_v3_small -b 2 --epochs 1
+        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set vit_s -b 2 --epochs 1
 
   train-text-recognition:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -120,7 +120,7 @@ jobs:
         run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set resnet18 document -b 2 --epochs 1
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF) (crop orientation)
-        run: python references/classification/train_tensorflow_orientation.py ./reco_set ./reco_set rresnet18 crop -b 4 --epochs 1
+        run: python references/classification/train_tensorflow_orientation.py ./reco_set ./reco_set resnet18 crop -b 4 --epochs 1
       - if: matrix.framework == 'pytorch'
         name: Train for a short epoch (PT) (crop orientation)
         run: python references/classification/train_pytorch_orientation.py ./reco_set ./reco_set resnet18 crop -b 4 --epochs 1

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -102,17 +102,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[torch] --upgrade
           pip install -r references/requirements.txt
-      - name: Download and extract toy set
+      - name: Download and extract detection toy set
         run: |
           wget https://github.com/mindee/doctr/releases/download/v0.3.1/toy_detection_set-bbbb4243.zip
           sudo apt-get update && sudo apt-get install unzip -y
           unzip toy_detection_set-bbbb4243.zip -d det_set
+      - name: Download and extract recognition toy set
+        run: |
+          wget https://github.com/mindee/doctr/releases/download/v0.3.1/toy_recogition_set-036a4d80.zip
+          sudo apt-get update && sudo apt-get install unzip -y
+          unzip toy_recogition_set-036a4d80.zip -d reco_set
       - if: matrix.framework == 'tensorflow'
-        name: Train for a short epoch (TF)
-        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set vit_s -b 2 --epochs 1
+        name: Train for a short epoch (TF) (document orientation)
+        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set resnet18 document -b 2 --epochs 1
       - if: matrix.framework == 'pytorch'
-        name: Train for a short epoch (PT)
-        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set vit_s -b 2 --epochs 1
+        name: Train for a short epoch (PT) (document orientation)
+        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set resnet18 document -b 2 --epochs 1
+      - if: matrix.framework == 'tensorflow'
+        name: Train for a short epoch (TF) (crop orientation)
+        run: python references/classification/train_tensorflow_orientation.py ./reco_set ./reco_set crnn_vgg16_bn crop -b 4 --epochs 1
+      - if: matrix.framework == 'pytorch'
+        name: Train for a short epoch (PT) (crop orientation)
+        run: python references/classification/train_pytorch_orientation.py ./reco_set ./reco_set crnn_mobilenet_v3_small crop -b 4 --epochs 1
 
   train-text-recognition:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -114,10 +114,10 @@ jobs:
           unzip toy_recogition_set-036a4d80.zip -d reco_set
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF) (document orientation)
-        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set resnet18 document -b 2 --epochs 1
+        run: python references/classification/train_tensorflow_orientation.py ./det_set ./det_set resnet18 page -b 2 --epochs 1
       - if: matrix.framework == 'pytorch'
         name: Train for a short epoch (PT) (document orientation)
-        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set resnet18 document -b 2 --epochs 1
+        run: python references/classification/train_pytorch_orientation.py ./det_set ./det_set resnet18 page -b 2 --epochs 1
       - if: matrix.framework == 'tensorflow'
         name: Train for a short epoch (TF) (crop orientation)
         run: python references/classification/train_tensorflow_orientation.py ./reco_set ./reco_set resnet18 crop -b 4 --epochs 1

--- a/doctr/datasets/__init__.py
+++ b/doctr/datasets/__init__.py
@@ -13,6 +13,7 @@ from .imgur5k import *
 from .mjsynth import *
 from .ocr import *
 from .recognition import *
+from .rotation import *
 from .sroie import *
 from .svhn import *
 from .svt import *

--- a/doctr/datasets/__init__.py
+++ b/doctr/datasets/__init__.py
@@ -13,7 +13,7 @@ from .imgur5k import *
 from .mjsynth import *
 from .ocr import *
 from .recognition import *
-from .rotation import *
+from .orientation import *
 from .sroie import *
 from .svhn import *
 from .svt import *

--- a/doctr/datasets/orientation.py
+++ b/doctr/datasets/orientation.py
@@ -10,14 +10,14 @@ import numpy as np
 
 from .datasets import AbstractDataset
 
-__all__ = ["RotationDataset"]
+__all__ = ["OrientationDataset"]
 
 
-class RotationDataset(AbstractDataset):
+class OrientationDataset(AbstractDataset):
     """Implements a basic image dataset where targets are filled with zeros.
 
-    >>> from doctr.datasets import RotationDataset
-    >>> train_set = RotationDataset(img_folder="/path/to/images")
+    >>> from doctr.datasets import OrientationDataset
+    >>> train_set = OrientationDataset(img_folder="/path/to/images")
     >>> img, target = train_set[0]
 
     Args:

--- a/doctr/datasets/rotation.py
+++ b/doctr/datasets/rotation.py
@@ -7,7 +7,6 @@ import os
 from typing import Any, List, Tuple
 
 import numpy as np
-from PIL import Image
 
 from .datasets import AbstractDataset
 
@@ -37,10 +36,5 @@ class RotationDataset(AbstractDataset):
             **kwargs,
         )
 
-        self.data: List[Tuple[str, np.ndarray]] = []
-        for img_name in os.listdir(self.root):
-            # File type check
-            path = os.path.join(self.root, img_name)
-            if Image.open(path).format.lower() not in ["png", "jpeg", "jpg"]:
-                raise ValueError(f"File {path} is not a valid image")
-            self.data.append((img_name, np.array([0])))
+        # initialize dataset with 0 degree rotation targets
+        self.data: List[Tuple[str, np.ndarray]] = [(img_name, np.array([0])) for img_name in os.listdir(self.root)]

--- a/doctr/datasets/rotation.py
+++ b/doctr/datasets/rotation.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2021-2024, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+import os
+from typing import Any, List, Tuple
+
+import numpy as np
+
+from .datasets import AbstractDataset
+
+__all__ = ["RotationDataset"]
+
+
+class RotationDataset(AbstractDataset):
+    """Implements a basic image dataset where targets are filled with zeros.
+
+    >>> from doctr.datasets import RotationDataset
+    >>> train_set = RotationDataset(img_folder="/path/to/images")
+    >>> img, target = train_set[0]
+
+    Args:
+    ----
+        img_folder: folder with all the images of the dataset
+        **kwargs: keyword arguments from `AbstractDataset`.
+    """
+
+    def __init__(
+        self,
+        img_folder: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            img_folder,
+            **kwargs,
+        )
+
+        self.data: List[Tuple[str, np.ndarray]] = []
+        for img_name in os.listdir(self.root):
+            # File existence check
+            if not os.path.exists(os.path.join(self.root, img_name)):
+                raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_name)}")
+            self.data.append((img_name, np.array([0])))

--- a/doctr/datasets/rotation.py
+++ b/doctr/datasets/rotation.py
@@ -7,6 +7,7 @@ import os
 from typing import Any, List, Tuple
 
 import numpy as np
+from PIL import Image
 
 from .datasets import AbstractDataset
 
@@ -38,7 +39,8 @@ class RotationDataset(AbstractDataset):
 
         self.data: List[Tuple[str, np.ndarray]] = []
         for img_name in os.listdir(self.root):
-            # File existence check
-            if not os.path.exists(os.path.join(self.root, img_name)):
-                raise FileNotFoundError(f"unable to locate {os.path.join(self.root, img_name)}")
+            # File type check
+            path = os.path.join(self.root, img_name)
+            if Image.open(path).format.lower() not in ["png", "jpeg", "jpg"]:
+                raise ValueError(f"File {path} is not a valid image")
             self.data.append((img_name, np.array([0])))

--- a/doctr/models/detection/differentiable_binarization/pytorch.py
+++ b/doctr/models/detection/differentiable_binarization/pytorch.py
@@ -57,28 +57,24 @@ class FeaturePyramidNetwork(nn.Module):
 
         conv_layer = DeformConv2d if deform_conv else nn.Conv2d
 
-        self.in_branches = nn.ModuleList(
-            [
-                nn.Sequential(
-                    conv_layer(chans, out_channels, 1, bias=False),
-                    nn.BatchNorm2d(out_channels),
-                    nn.ReLU(inplace=True),
-                )
-                for idx, chans in enumerate(in_channels)
-            ]
-        )
+        self.in_branches = nn.ModuleList([
+            nn.Sequential(
+                conv_layer(chans, out_channels, 1, bias=False),
+                nn.BatchNorm2d(out_channels),
+                nn.ReLU(inplace=True),
+            )
+            for idx, chans in enumerate(in_channels)
+        ])
         self.upsample = nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True)
-        self.out_branches = nn.ModuleList(
-            [
-                nn.Sequential(
-                    conv_layer(out_channels, out_chans, 3, padding=1, bias=False),
-                    nn.BatchNorm2d(out_chans),
-                    nn.ReLU(inplace=True),
-                    nn.Upsample(scale_factor=2**idx, mode="bilinear", align_corners=True),
-                )
-                for idx, chans in enumerate(in_channels)
-            ]
-        )
+        self.out_branches = nn.ModuleList([
+            nn.Sequential(
+                conv_layer(out_channels, out_chans, 3, padding=1, bias=False),
+                nn.BatchNorm2d(out_chans),
+                nn.ReLU(inplace=True),
+                nn.Upsample(scale_factor=2**idx, mode="bilinear", align_corners=True),
+            )
+            for idx, chans in enumerate(in_channels)
+        ])
 
     def forward(self, x: List[torch.Tensor]) -> torch.Tensor:
         if len(x) != len(self.out_branches):

--- a/doctr/transforms/functional/tensorflow.py
+++ b/doctr/transforms/functional/tensorflow.py
@@ -15,7 +15,7 @@ from doctr.utils.geometry import compute_expanded_shape, rotate_abs_geoms
 
 from .base import create_shadow_mask, crop_boxes
 
-__all__ = ["invert_colors", "rotate_sample", "crop_detection", "random_shadow"]
+__all__ = ["invert_colors", "rotate_sample", "crop_detection", "random_shadow", "rotated_img_tensor"]
 
 
 def invert_colors(img: tf.Tensor, min_val: float = 0.6) -> tf.Tensor:

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -1,6 +1,6 @@
 # Character classification
 
-The sample training script was made to train a character classification model with docTR.
+The sample training scripts was made to train a character classification model or a orientation classifier with docTR.
 
 ## Setup
 
@@ -11,7 +11,7 @@ pip install -e . --upgrade
 pip install -r references/requirements.txt
 ```
 
-## Usage
+## Usage character classification
 
 You can start your training in TensorFlow:
 
@@ -25,10 +25,47 @@ or PyTorch:
 python references/classification/train_pytorch.py mobilenet_v3_large --epochs 5 --device 0
 ```
 
+## Usage orientation classification
+
+You can start your training in TensorFlow:
+
+```shell
+python references/classification/train_tensorflow_orientation.py path/to/your/train_set path/to/your/val_set resnet18 document --epochs 5
+```
+
+or PyTorch:
+
+```shell
+python references/classification/train_pytorch_orientation.py path/to/your/train_set path/to/your/val_set resnet18 document --epochs 5
+```
+
+The type can be either `document` for document images or `crop` for word crops.
+
+## Data format
+
+You need to provide both `train_path` and `val_path` arguments to start training.
+Each path must lead to a folder where the images are stored. For example:
+
+```shell
+ images
+    ├── sample_img_01.png
+    ├── sample_img_02.png
+    ├── sample_img_03.png
+    └── ...
+```
+
 ## Advanced options
 
 Feel free to inspect the multiple script option to customize your training to your own needs!
 
+Character classification:
+
 ```python
 python references/classification/train_tensorflow.py --help
+```
+
+Orientation classification:
+
+```python
+python references/classification/train_tensorflow_orientation.py --help
 ```

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -30,16 +30,16 @@ python references/classification/train_pytorch.py mobilenet_v3_large --epochs 5 
 You can start your training in TensorFlow:
 
 ```shell
-python references/classification/train_tensorflow_orientation.py path/to/your/train_set path/to/your/val_set resnet18 document --epochs 5
+python references/classification/train_tensorflow_orientation.py path/to/your/train_set path/to/your/val_set resnet18 page --epochs 5
 ```
 
 or PyTorch:
 
 ```shell
-python references/classification/train_pytorch_orientation.py path/to/your/train_set path/to/your/val_set resnet18 document --epochs 5
+python references/classification/train_pytorch_orientation.py path/to/your/train_set path/to/your/val_set resnet18 page --epochs 5
 ```
 
-The type can be either `document` for document images or `crop` for word crops.
+The type can be either `page` for document images or `crop` for word crops.
 
 ## Data format
 

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -218,7 +218,7 @@ def main(args):
     batch_transforms = Normalize(mean=(0.694, 0.695, 0.693), std=(0.299, 0.296, 0.301))
 
     # Load doctr model
-    model = classification.__dict__[args.arch](pretrained=args.pretrained, num_classes=4, classes=CLASSES)
+    model = classification.__dict__[args.arch](pretrained=args.pretrained, num_classes=len(CLASSES), classes=CLASSES)
 
     # Resume weights
     if isinstance(args.resume, str):

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -35,7 +35,7 @@ from doctr.models import classification, login_to_hub, push_to_hf_hub
 from doctr.models.utils import export_model_to_onnx
 from utils import EarlyStopper, plot_recorder, plot_samples
 
-CLASSES = [0, 90, 180, -90]
+CLASSES = [0, 90, 180, 270]
 
 
 def rnd_rotate(img: torch.Tensor, target):

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -218,9 +218,7 @@ def main(args):
     batch_transforms = Normalize(mean=(0.694, 0.695, 0.693), std=(0.299, 0.296, 0.301))
 
     # Load doctr model
-    model = classification.__dict__[args.arch](
-        pretrained=args.pretrained, num_classes=4, classes=["0", "90", "-90", "180"]
-    )
+    model = classification.__dict__[args.arch](pretrained=args.pretrained, num_classes=4, classes=CLASSES)
 
     # Resume weights
     if isinstance(args.resume, str):

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -191,7 +191,7 @@ def main(args):
 
     torch.backends.cudnn.benchmark = True
 
-    input_size = (1024, 1024) if args.type == "document" else (32, 128)
+    input_size = (256, 256) if args.type == "document" else (32, 32)
 
     # Load val data generator
     st = time.time()
@@ -257,11 +257,11 @@ def main(args):
             # Augmentations
             T.RandomApply(T.ColorInversion(), 0.1),
             T.RandomApply(T.GaussianNoise(mean=0.1, std=0.1), 0.1),
-            T.RandomApply(T.RandomShadow(), 0.4),
-            T.RandomApply(GaussianBlur(kernel_size=3), 0.3),
+            T.RandomApply(T.RandomShadow(), 0.2),
+            T.RandomApply(GaussianBlur(kernel_size=3), 0.1),
             RandomPhotometricDistort(p=0.1),
             RandomGrayscale(p=0.1),
-            RandomPerspective(distortion_scale=0.2, p=0.3),
+            RandomPerspective(distortion_scale=0.1, p=0.3),
         ]),
         sample_transforms=T.SampleCompose([
             lambda x, y: rnd_rotate(x, y),

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -191,7 +191,7 @@ def main(args):
 
     torch.backends.cudnn.benchmark = True
 
-    input_size = (256, 256) if args.type == "document" else (32, 32)
+    input_size = (256, 256) if args.type == "page" else (32, 32)
 
     # Load val data generator
     st = time.time()
@@ -375,7 +375,7 @@ def parse_args():
     parser.add_argument("train_path", type=str, help="path to training data folder")
     parser.add_argument("val_path", type=str, help="path to validation data folder")
     parser.add_argument("arch", type=str, help="classification model to train")
-    parser.add_argument("type", type=str, choices=["document", "crop"], help="type of data to train on")
+    parser.add_argument("type", type=str, choices=["page", "crop"], help="type of data to train on")
     parser.add_argument("--name", type=str, default=None, help="Name of your training experiment")
     parser.add_argument("--epochs", type=int, default=10, help="number of epochs to train the model on")
     parser.add_argument("-b", "--batch_size", type=int, default=2, help="batch size for training")

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -195,7 +195,7 @@ def main(args):
     st = time.time()
     val_set = RotationDataset(
         img_folder=os.path.join(args.val_path, "images"),
-        img_transforms=T.Compose([
+        img_transforms=Compose([
             T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
         ]),
         sample_transforms=T.SampleCompose([

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -1,0 +1,413 @@
+# Copyright (C) 2021-2024, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+import os
+
+os.environ["USE_TORCH"] = "1"
+
+import datetime
+import logging
+import multiprocessing as mp
+import time
+
+import numpy as np
+import torch
+import wandb
+from torch.nn.functional import cross_entropy
+from torch.optim.lr_scheduler import CosineAnnealingLR, MultiplicativeLR, OneCycleLR
+from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
+from torchvision.transforms import functional as F
+from torchvision.transforms.v2 import (
+    Compose,
+    GaussianBlur,
+    Normalize,
+    RandomGrayscale,
+    RandomPerspective,
+    RandomPhotometricDistort,
+)
+from tqdm.auto import tqdm
+
+from doctr import transforms as T
+from doctr.datasets import RotationDataset
+from doctr.models import classification, login_to_hub, push_to_hf_hub
+from doctr.models.utils import export_model_to_onnx
+from utils import EarlyStopper, plot_recorder, plot_samples
+
+CLASSES = [0, 90, 180, -90]
+
+
+def rnd_rotate(img: torch.Tensor, target):
+    angle = int(np.random.choice(CLASSES))
+    idx = CLASSES.index(angle)
+    rotated_img = F.rotate(img, angle=-angle, fill=0, expand=False)[:3]
+    return rotated_img, idx
+
+
+def record_lr(
+    model: torch.nn.Module,
+    train_loader: DataLoader,
+    batch_transforms,
+    optimizer,
+    start_lr: float = 1e-7,
+    end_lr: float = 1,
+    num_it: int = 100,
+    amp: bool = False,
+):
+    """Gridsearch the optimal learning rate for the training.
+    Adapted from https://github.com/frgfm/Holocron/blob/master/holocron/trainer/core.py
+    """
+    if num_it > len(train_loader):
+        raise ValueError("the value of `num_it` needs to be lower than the number of available batches")
+
+    model = model.train()
+    # Update param groups & LR
+    optimizer.defaults["lr"] = start_lr
+    for pgroup in optimizer.param_groups:
+        pgroup["lr"] = start_lr
+
+    gamma = (end_lr / start_lr) ** (1 / (num_it - 1))
+    scheduler = MultiplicativeLR(optimizer, lambda step: gamma)
+
+    lr_recorder = [start_lr * gamma**idx for idx in range(num_it)]
+    loss_recorder = []
+
+    if amp:
+        scaler = torch.cuda.amp.GradScaler()
+
+    for batch_idx, (images, targets) in enumerate(train_loader):
+        if torch.cuda.is_available():
+            images = images.cuda()
+            targets = targets.cuda()
+
+        images = batch_transforms(images)
+
+        # Forward, Backward & update
+        optimizer.zero_grad()
+        if amp:
+            with torch.cuda.amp.autocast():
+                out = model(images)
+                train_loss = cross_entropy(out, targets)
+            scaler.scale(train_loss).backward()
+            # Update the params
+            scaler.step(optimizer)
+            scaler.update()
+        else:
+            out = model(images)
+            train_loss = cross_entropy(out, targets)
+            train_loss.backward()
+            optimizer.step()
+        # Update LR
+        scheduler.step()
+
+        # Record
+        if not torch.isfinite(train_loss):
+            if batch_idx == 0:
+                raise ValueError("loss value is NaN or inf.")
+            else:
+                break
+        loss_recorder.append(train_loss.item())
+        # Stop after the number of iterations
+        if batch_idx + 1 == num_it:
+            break
+
+    return lr_recorder[: len(loss_recorder)], loss_recorder
+
+
+def fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler, amp=False):
+    if amp:
+        scaler = torch.cuda.amp.GradScaler()
+
+    model.train()
+    # Iterate over the batches of the dataset
+    pbar = tqdm(train_loader, position=1)
+    for images, targets in pbar:
+        if torch.cuda.is_available():
+            images = images.cuda()
+            targets = targets.cuda()
+
+        images = batch_transforms(images)
+
+        optimizer.zero_grad()
+        if amp:
+            with torch.cuda.amp.autocast():
+                out = model(images)
+                train_loss = cross_entropy(out, targets)
+            scaler.scale(train_loss).backward()
+            # Update the params
+            scaler.step(optimizer)
+            scaler.update()
+        else:
+            out = model(images)
+            train_loss = cross_entropy(out, targets)
+            train_loss.backward()
+            optimizer.step()
+        scheduler.step()
+
+        pbar.set_description(f"Training loss: {train_loss.item():.6}")
+
+
+@torch.no_grad()
+def evaluate(model, val_loader, batch_transforms, amp=False):
+    # Model in eval mode
+    model.eval()
+    # Validation loop
+    val_loss, correct, samples, batch_cnt = 0, 0, 0, 0
+    for images, targets in tqdm(val_loader):
+        images = batch_transforms(images)
+
+        if torch.cuda.is_available():
+            images = images.cuda()
+            targets = targets.cuda()
+
+        if amp:
+            with torch.cuda.amp.autocast():
+                out = model(images)
+                loss = cross_entropy(out, targets)
+        else:
+            out = model(images)
+            loss = cross_entropy(out, targets)
+        # Compute metric
+        correct += (out.argmax(dim=1) == targets).sum().item()
+
+        val_loss += loss.item()
+        batch_cnt += 1
+        samples += images.shape[0]
+
+    val_loss /= batch_cnt
+    acc = correct / samples
+    return val_loss, acc
+
+
+def main(args):
+    print(args)
+
+    if args.push_to_hub:
+        login_to_hub()
+
+    if not isinstance(args.workers, int):
+        args.workers = min(16, mp.cpu_count())
+
+    torch.backends.cudnn.benchmark = True
+
+    # Load val data generator
+    st = time.time()
+    val_set = RotationDataset(
+        img_folder=os.path.join(args.val_path, "images"),
+        img_transforms=T.Compose([
+            T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+        ]),
+        sample_transforms=T.SampleCompose([
+            lambda x, y: rnd_rotate(x, y),
+            T.Resize((args.input_size, args.input_size)),
+        ]),
+    )
+    val_loader = DataLoader(
+        val_set,
+        batch_size=args.batch_size,
+        drop_last=False,
+        num_workers=args.workers,
+        sampler=SequentialSampler(val_set),
+        pin_memory=torch.cuda.is_available(),
+    )
+    print(f"Validation set loaded in {time.time() - st:.4}s ({len(val_set)} samples in " f"{len(val_loader)} batches)")
+
+    batch_transforms = Normalize(mean=(0.694, 0.695, 0.693), std=(0.299, 0.296, 0.301))
+
+    # Load doctr model
+    model = classification.__dict__[args.arch](
+        pretrained=args.pretrained, num_classes=4, classes=["0", "90", "-90", "180"]
+    )
+
+    # Resume weights
+    if isinstance(args.resume, str):
+        print(f"Resuming {args.resume}")
+        checkpoint = torch.load(args.resume, map_location="cpu")
+        model.load_state_dict(checkpoint)
+
+    # GPU
+    if isinstance(args.device, int):
+        if not torch.cuda.is_available():
+            raise AssertionError("PyTorch cannot access your GPU. Please investigate!")
+        if args.device >= torch.cuda.device_count():
+            raise ValueError("Invalid device index")
+    # Silent default switch to GPU if available
+    elif torch.cuda.is_available():
+        args.device = 0
+    else:
+        logging.warning("No accessible GPU, targe device set to CPU.")
+    if torch.cuda.is_available():
+        torch.cuda.set_device(args.device)
+        model = model.cuda()
+
+    if args.test_only:
+        print("Running evaluation")
+        val_loss, acc = evaluate(model, val_loader, batch_transforms)
+        print(f"Validation loss: {val_loss:.6} (Acc: {acc:.2%})")
+        return
+
+    st = time.time()
+    train_set = RotationDataset(
+        img_folder=os.path.join(args.train_path, "images"),
+        img_transforms=Compose([
+            T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+            # Augmentations
+            T.RandomApply(T.ColorInversion(), 0.1),
+            T.RandomApply(T.GaussianNoise(mean=0.1, std=0.1), 0.1),
+            T.RandomApply(T.RandomShadow(), 0.4),
+            T.RandomApply(GaussianBlur(kernel_size=3), 0.3),
+            RandomPhotometricDistort(p=0.1),
+            RandomGrayscale(p=0.1),
+            RandomPerspective(distortion_scale=0.2, p=0.3),
+        ]),
+        sample_transforms=T.SampleCompose([
+            lambda x, y: rnd_rotate(x, y),
+            T.Resize((args.input_size, args.input_size)),
+        ]),
+    )
+
+    train_loader = DataLoader(
+        train_set,
+        batch_size=args.batch_size,
+        drop_last=True,
+        num_workers=args.workers,
+        sampler=RandomSampler(train_set),
+        pin_memory=torch.cuda.is_available(),
+    )
+    print(f"Train set loaded in {time.time() - st:.4}s ({len(train_set)} samples in " f"{len(train_loader)} batches)")
+
+    if args.show_samples:
+        x, target = next(iter(train_loader))
+        plot_samples(x, [CLASSES[t] for t in target])
+        return
+
+    # Optimizer
+    optimizer = torch.optim.Adam(
+        [p for p in model.parameters() if p.requires_grad],
+        args.lr,
+        betas=(0.95, 0.99),
+        eps=1e-6,
+        weight_decay=args.weight_decay,
+    )
+
+    # LR Finder
+    if args.find_lr:
+        lrs, losses = record_lr(model, train_loader, batch_transforms, optimizer, amp=args.amp)
+        plot_recorder(lrs, losses)
+        return
+    # Scheduler
+    if args.sched == "cosine":
+        scheduler = CosineAnnealingLR(optimizer, args.epochs * len(train_loader), eta_min=args.lr / 25e4)
+    elif args.sched == "onecycle":
+        scheduler = OneCycleLR(optimizer, args.lr, args.epochs * len(train_loader))
+
+    # Training monitoring
+    current_time = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    exp_name = f"{args.arch}_{current_time}" if args.name is None else args.name
+
+    # W&B
+    if args.wb:
+        run = wandb.init(
+            name=exp_name,
+            project="orientation-classification",
+            config={
+                "learning_rate": args.lr,
+                "epochs": args.epochs,
+                "weight_decay": args.weight_decay,
+                "batch_size": args.batch_size,
+                "architecture": args.arch,
+                "input_size": args.input_size,
+                "optimizer": "adam",
+                "framework": "pytorch",
+                "classes": CLASSES,
+                "scheduler": args.sched,
+                "pretrained": args.pretrained,
+            },
+        )
+
+    # Create loss queue
+    min_loss = np.inf
+    # Training loop
+    if args.early_stop:
+        early_stopper = EarlyStopper(patience=args.early_stop_epochs, min_delta=args.early_stop_delta)
+    for epoch in range(args.epochs):
+        fit_one_epoch(model, train_loader, batch_transforms, optimizer, scheduler)
+
+        # Validation loop at the end of each epoch
+        val_loss, acc = evaluate(model, val_loader, batch_transforms)
+        if val_loss < min_loss:
+            print(f"Validation loss decreased {min_loss:.6} --> {val_loss:.6}: saving state...")
+            torch.save(model.state_dict(), f"./{exp_name}.pt")
+            min_loss = val_loss
+        print(f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} (Acc: {acc:.2%})")
+        # W&B
+        if args.wb:
+            wandb.log({
+                "val_loss": val_loss,
+                "acc": acc,
+            })
+        if args.early_stop and early_stopper.early_stop(val_loss):
+            print("Training halted early due to reaching patience limit.")
+            break
+    if args.wb:
+        run.finish()
+
+    if args.push_to_hub:
+        push_to_hf_hub(model, exp_name, task="classification", run_config=args)
+
+    if args.export_onnx:
+        print("Exporting model to ONNX...")
+        dummy_batch = next(iter(val_loader))
+        dummy_input = dummy_batch[0].cuda() if torch.cuda.is_available() else dummy_batch[0]
+        model_path = export_model_to_onnx(model, exp_name, dummy_input)
+        print(f"Exported model saved in {model_path}")
+
+
+def parse_args():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="DocTR training script for orientation classification (PyTorch)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument("train_path", type=str, help="path to training data folder")
+    parser.add_argument("val_path", type=str, help="path to validation data folder")
+    parser.add_argument("arch", type=str, help="classification model to train")
+    parser.add_argument("--name", type=str, default=None, help="Name of your training experiment")
+    parser.add_argument("--epochs", type=int, default=10, help="number of epochs to train the model on")
+    parser.add_argument("-b", "--batch_size", type=int, default=2, help="batch size for training")
+    parser.add_argument("--device", default=None, type=int, help="device")
+    parser.add_argument("--input_size", type=int, default=1024, help="model input size, H = W")
+    parser.add_argument("--lr", type=float, default=0.001, help="learning rate for the optimizer (Adam)")
+    parser.add_argument("--wd", "--weight-decay", default=0, type=float, help="weight decay", dest="weight_decay")
+    parser.add_argument("-j", "--workers", type=int, default=None, help="number of workers used for dataloading")
+    parser.add_argument("--resume", type=str, default=None, help="Path to your checkpoint")
+    parser.add_argument("--test-only", dest="test_only", action="store_true", help="Run the validation loop")
+    parser.add_argument(
+        "--show-samples", dest="show_samples", action="store_true", help="Display unormalized training samples"
+    )
+    parser.add_argument("--wb", dest="wb", action="store_true", help="Log to Weights & Biases")
+    parser.add_argument("--push-to-hub", dest="push_to_hub", action="store_true", help="Push to Huggingface Hub")
+    parser.add_argument(
+        "--pretrained",
+        dest="pretrained",
+        action="store_true",
+        help="Load pretrained parameters before starting the training",
+    )
+    parser.add_argument("--export-onnx", dest="export_onnx", action="store_true", help="Export the model to ONNX")
+    parser.add_argument("--sched", type=str, default="cosine", help="scheduler to use")
+    parser.add_argument("--amp", dest="amp", help="Use Automatic Mixed Precision", action="store_true")
+    parser.add_argument("--find-lr", action="store_true", help="Gridsearch the optimal LR")
+    parser.add_argument("--early-stop", action="store_true", help="Enable early stopping")
+    parser.add_argument("--early-stop-epochs", type=int, default=5, help="Patience for early stopping")
+    parser.add_argument("--early-stop-delta", type=float, default=0.01, help="Minimum Delta for early stopping")
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -30,7 +30,7 @@ from torchvision.transforms.v2 import (
 from tqdm.auto import tqdm
 
 from doctr import transforms as T
-from doctr.datasets import RotationDataset
+from doctr.datasets import OrientationDataset
 from doctr.models import classification, login_to_hub, push_to_hf_hub
 from doctr.models.utils import export_model_to_onnx
 from utils import EarlyStopper, plot_recorder, plot_samples
@@ -195,7 +195,7 @@ def main(args):
 
     # Load val data generator
     st = time.time()
-    val_set = RotationDataset(
+    val_set = OrientationDataset(
         img_folder=os.path.join(args.val_path, "images"),
         img_transforms=Compose([
             T.Resize(input_size, preserve_aspect_ratio=True, symmetric_pad=True),
@@ -248,7 +248,7 @@ def main(args):
         return
 
     st = time.time()
-    train_set = RotationDataset(
+    train_set = OrientationDataset(
         img_folder=os.path.join(args.train_path, "images"),
         img_transforms=Compose([
             T.Resize(input_size, preserve_aspect_ratio=True, symmetric_pad=True),

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -1,0 +1,390 @@
+# Copyright (C) 2021-2024, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+import os
+
+os.environ["USE_TF"] = "1"
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+
+import datetime
+import multiprocessing as mp
+import time
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras import mixed_precision
+from tqdm.auto import tqdm
+
+from doctr.models import login_to_hub, push_to_hf_hub
+
+gpu_devices = tf.config.experimental.list_physical_devices("GPU")
+if any(gpu_devices):
+    tf.config.experimental.set_memory_growth(gpu_devices[0], True)
+
+from doctr import transforms as T
+from doctr.datasets import DataLoader, RotationDataset
+from doctr.models import classification
+from doctr.models.utils import export_model_to_onnx
+from utils import EarlyStopper, plot_recorder, plot_samples
+
+CLASSES = [0, 90, 180, -90]
+
+
+def rnd_rotate(img: tf.Tensor, target):
+    angle = int(np.random.choice(CLASSES))
+    idx = CLASSES.index(angle)
+    # counter-clockwise rotation (change index sign)
+    rotated_img = tf.image.rot90(img, k=idx)
+    idx = 1 if idx == 3 else 3 if idx == 1 else idx
+    return rotated_img, idx
+
+
+def record_lr(
+    model: tf.keras.Model,
+    train_loader: DataLoader,
+    batch_transforms,
+    optimizer,
+    start_lr: float = 1e-7,
+    end_lr: float = 1,
+    num_it: int = 100,
+    amp: bool = False,
+):
+    """Gridsearch the optimal learning rate for the training.
+    Adapted from https://github.com/frgfm/Holocron/blob/master/holocron/trainer/core.py
+    """
+    if num_it > len(train_loader):
+        raise ValueError("the value of `num_it` needs to be lower than the number of available batches")
+
+    # Update param groups & LR
+    gamma = (end_lr / start_lr) ** (1 / (num_it - 1))
+    optimizer.learning_rate = start_lr
+
+    lr_recorder = [start_lr * gamma**idx for idx in range(num_it)]
+    loss_recorder = []
+
+    for batch_idx, (images, targets) in enumerate(train_loader):
+        images = batch_transforms(images)
+
+        # Forward, Backward & update
+        with tf.GradientTape() as tape:
+            out = model(images, training=True)
+            train_loss = tf.nn.sparse_softmax_cross_entropy_with_logits(targets, out)
+        grads = tape.gradient(train_loss, model.trainable_weights)
+
+        if amp:
+            grads = optimizer.get_unscaled_gradients(grads)
+        optimizer.apply_gradients(zip(grads, model.trainable_weights))
+
+        optimizer.learning_rate = optimizer.learning_rate * gamma
+
+        # Record
+        train_loss = train_loss.numpy()
+        if np.any(np.isnan(train_loss)):
+            if batch_idx == 0:
+                raise ValueError("loss value is NaN or inf.")
+            else:
+                break
+        loss_recorder.append(train_loss.mean())
+        # Stop after the number of iterations
+        if batch_idx + 1 == num_it:
+            break
+
+    return lr_recorder[: len(loss_recorder)], loss_recorder
+
+
+def fit_one_epoch(model, train_loader, batch_transforms, optimizer, amp=False):
+    # Iterate over the batches of the dataset
+    pbar = tqdm(train_loader, position=1)
+    for images, targets in pbar:
+        images = batch_transforms(images)
+
+        with tf.GradientTape() as tape:
+            out = model(images, training=True)
+            train_loss = tf.nn.sparse_softmax_cross_entropy_with_logits(targets, out)
+        grads = tape.gradient(train_loss, model.trainable_weights)
+        if amp:
+            grads = optimizer.get_unscaled_gradients(grads)
+        optimizer.apply_gradients(zip(grads, model.trainable_weights))
+
+        pbar.set_description(f"Training loss: {train_loss.numpy().mean():.6}")
+
+
+def evaluate(model, val_loader, batch_transforms):
+    # Validation loop
+    val_loss, correct, samples, batch_cnt = 0, 0, 0, 0
+    val_iter = iter(val_loader)
+    for images, targets in tqdm(val_iter):
+        images = batch_transforms(images)
+        out = model(images, training=False)
+        loss = tf.nn.sparse_softmax_cross_entropy_with_logits(targets, out)
+        # Compute metric
+        correct += int((out.numpy().argmax(1) == targets.numpy()).sum())
+
+        val_loss += loss.numpy().mean()
+        batch_cnt += 1
+        samples += images.shape[0]
+
+    val_loss /= batch_cnt
+    acc = correct / samples
+    return val_loss, acc
+
+
+def collate_fn(samples):
+    images, targets = zip(*samples)
+    images = tf.stack(images, axis=0)
+
+    return images, tf.convert_to_tensor(targets)
+
+
+def main(args):
+    print(args)
+
+    if args.push_to_hub:
+        login_to_hub()
+
+    if not isinstance(args.workers, int):
+        args.workers = min(16, mp.cpu_count())
+
+    # AMP
+    if args.amp:
+        mixed_precision.set_global_policy("mixed_float16")
+
+    st = time.time()
+    val_set = RotationDataset(
+        img_folder=os.path.join(args.val_path, "images"),
+        img_transforms=T.Compose([
+            T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+        ]),
+        sample_transforms=T.SampleCompose([
+            lambda x, y: rnd_rotate(x, y),
+            T.Resize((args.input_size, args.input_size)),
+        ]),
+    )
+
+    val_loader = DataLoader(
+        val_set,
+        batch_size=args.batch_size,
+        shuffle=False,
+        drop_last=False,
+        num_workers=args.workers,
+        collate_fn=collate_fn,
+    )
+    print(
+        f"Validation set loaded in {time.time() - st:.4}s ({len(val_set)} samples in "
+        f"{val_loader.num_batches} batches)"
+    )
+
+    # Load doctr model
+    model = classification.__dict__[args.arch](
+        pretrained=args.pretrained,
+        input_shape=(args.input_size, args.input_size, 3),
+        num_classes=4,
+        classes=CLASSES,
+        include_top=True,
+    )
+
+    # Resume weights
+    if isinstance(args.resume, str):
+        model.load_weights(args.resume)
+
+    batch_transforms = T.Compose([
+        T.Normalize(mean=(0.694, 0.695, 0.693), std=(0.299, 0.296, 0.301)),
+    ])
+
+    if args.test_only:
+        print("Running evaluation")
+        val_loss, acc = evaluate(model, val_loader, batch_transforms)
+        print(f"Validation loss: {val_loss:.6} (Acc: {acc:.2%})")
+        return
+
+    st = time.time()
+    train_set = RotationDataset(
+        img_folder=os.path.join(args.train_path, "images"),
+        img_transforms=T.Compose([
+            T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+            # Augmentations
+            T.RandomApply(T.ColorInversion(), 0.1),
+            T.RandomApply(T.ToGray(3), 0.1),
+            T.RandomJpegQuality(60),
+            T.RandomSaturation(0.3),
+            T.RandomContrast(0.3),
+            T.RandomBrightness(0.3),
+            # Blur
+            T.RandomApply(T.GaussianBlur(kernel_shape=(3, 3), std=(0.1, 3)), 0.3),
+        ]),
+        sample_transforms=T.SampleCompose([
+            lambda x, y: rnd_rotate(x, y),
+            T.Resize((args.input_size, args.input_size)),
+        ]),
+    )
+    train_loader = DataLoader(
+        train_set,
+        batch_size=args.batch_size,
+        shuffle=True,
+        drop_last=True,
+        num_workers=args.workers,
+        collate_fn=collate_fn,
+    )
+    print(
+        f"Train set loaded in {time.time() - st:.4}s ({len(train_set)} samples in "
+        f"{train_loader.num_batches} batches)"
+    )
+
+    if args.show_samples:
+        x, target = next(iter(train_loader))
+        plot_samples(x, [CLASSES[t] for t in target])
+        return
+
+    # Optimizer
+    scheduler = tf.keras.optimizers.schedules.ExponentialDecay(
+        args.lr,
+        decay_steps=args.epochs * len(train_loader),
+        decay_rate=1 / (1e3),  # final lr as a fraction of initial lr
+        staircase=False,
+        name="ExponentialDecay",
+    )
+    optimizer = tf.keras.optimizers.Adam(
+        learning_rate=scheduler,
+        beta_1=0.95,
+        beta_2=0.99,
+        epsilon=1e-6,
+    )
+    if args.amp:
+        optimizer = mixed_precision.LossScaleOptimizer(optimizer)
+
+    # LR Finder
+    if args.find_lr:
+        lrs, losses = record_lr(model, train_loader, batch_transforms, optimizer, amp=args.amp)
+        plot_recorder(lrs, losses)
+        return
+
+    # Tensorboard to monitor training
+    current_time = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    exp_name = f"{args.arch}_{current_time}" if args.name is None else args.name
+
+    config = {
+        "learning_rate": args.lr,
+        "epochs": args.epochs,
+        "batch_size": args.batch_size,
+        "architecture": args.arch,
+        "input_size": args.input_size,
+        "optimizer": "adam",
+        "framework": "pytorch",
+        "classes": CLASSES,
+        "scheduler": args.sched,
+        "pretrained": args.pretrained,
+    }
+
+    # W&B
+    if args.wb:
+        import wandb
+
+        run = wandb.init(name=exp_name, project="character-classification", config=config)
+    # ClearML
+    if args.clearml:
+        from clearml import Task
+
+        task = Task.init(project_name="docTR/character-classification", task_name=exp_name, reuse_last_task_id=False)
+        task.upload_artifact("config", config)
+
+    # Create loss queue
+    min_loss = np.inf
+
+    # Training loop
+    if args.early_stop:
+        early_stopper = EarlyStopper(patience=args.early_stop_epochs, min_delta=args.early_stop_delta)
+    for epoch in range(args.epochs):
+        fit_one_epoch(model, train_loader, batch_transforms, optimizer, args.amp)
+
+        # Validation loop at the end of each epoch
+        val_loss, acc = evaluate(model, val_loader, batch_transforms)
+        if val_loss < min_loss:
+            print(f"Validation loss decreased {min_loss:.6} --> {val_loss:.6}: saving state...")
+            model.save_weights(f"./{exp_name}/weights")
+            min_loss = val_loss
+        print(f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} (Acc: {acc:.2%})")
+        # W&B
+        if args.wb:
+            wandb.log({
+                "val_loss": val_loss,
+                "acc": acc,
+            })
+
+        # ClearML
+        if args.clearml:
+            from clearml import Logger
+
+            logger = Logger.current_logger()
+            logger.report_scalar(title="Validation Loss", series="val_loss", value=val_loss, iteration=epoch)
+            logger.report_scalar(title="Accuracy", series="acc", value=acc, iteration=epoch)
+        if args.early_stop and early_stopper.early_stop(val_loss):
+            print("Training halted early due to reaching patience limit.")
+            break
+    if args.wb:
+        run.finish()
+
+    if args.push_to_hub:
+        push_to_hf_hub(model, exp_name, task="classification", run_config=args)
+
+    if args.export_onnx:
+        print("Exporting model to ONNX...")
+        if args.arch == "vit_b":
+            # fixed batch size for vit
+            dummy_input = [tf.TensorSpec([1, args.input_size, args.input_size, 3], tf.float32, name="input")]
+        else:
+            # dynamic batch size
+            dummy_input = [tf.TensorSpec([None, args.input_size, args.input_size, 3], tf.float32, name="input")]
+        model_path, _ = export_model_to_onnx(model, exp_name, dummy_input)
+        print(f"Exported model saved in {model_path}")
+
+
+def parse_args():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="DocTR training script for orientation classification (TensorFlow)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument("train_path", type=str, help="path to training data folder")
+    parser.add_argument("val_path", type=str, help="path to validation data folder")
+    parser.add_argument("arch", type=str, help="classification model to train")
+    parser.add_argument("--name", type=str, default=None, help="Name of your training experiment")
+    parser.add_argument("--epochs", type=int, default=10, help="number of epochs to train the model on")
+    parser.add_argument("-b", "--batch_size", type=int, default=2, help="batch size for training")
+    parser.add_argument("--device", default=None, type=int, help="device")
+    parser.add_argument("--input_size", type=int, default=1024, help="model input size, H = W")
+    parser.add_argument("--lr", type=float, default=0.001, help="learning rate for the optimizer (Adam)")
+    parser.add_argument("--wd", "--weight-decay", default=0, type=float, help="weight decay", dest="weight_decay")
+    parser.add_argument("-j", "--workers", type=int, default=None, help="number of workers used for dataloading")
+    parser.add_argument("--resume", type=str, default=None, help="Path to your checkpoint")
+    parser.add_argument("--test-only", dest="test_only", action="store_true", help="Run the validation loop")
+    parser.add_argument(
+        "--show-samples", dest="show_samples", action="store_true", help="Display unormalized training samples"
+    )
+    parser.add_argument("--wb", dest="wb", action="store_true", help="Log to Weights & Biases")
+    parser.add_argument("--clearml", dest="clearml", action="store_true", help="Log to ClearML")
+    parser.add_argument("--push-to-hub", dest="push_to_hub", action="store_true", help="Push to Huggingface Hub")
+    parser.add_argument(
+        "--pretrained",
+        dest="pretrained",
+        action="store_true",
+        help="Load pretrained parameters before starting the training",
+    )
+    parser.add_argument("--export-onnx", dest="export_onnx", action="store_true", help="Export the model to ONNX")
+    parser.add_argument("--sched", type=str, default="cosine", help="scheduler to use")
+    parser.add_argument("--amp", dest="amp", help="Use Automatic Mixed Precision", action="store_true")
+    parser.add_argument("--find-lr", action="store_true", help="Gridsearch the optimal LR")
+    parser.add_argument("--early-stop", action="store_true", help="Enable early stopping")
+    parser.add_argument("--early-stop-epochs", type=int, default=5, help="Patience for early stopping")
+    parser.add_argument("--early-stop-delta", type=float, default=0.01, help="Minimum Delta for early stopping")
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -24,7 +24,7 @@ if any(gpu_devices):
     tf.config.experimental.set_memory_growth(gpu_devices[0], True)
 
 from doctr import transforms as T
-from doctr.datasets import DataLoader, RotationDataset
+from doctr.datasets import DataLoader, OrientationDataset
 from doctr.models import classification
 from doctr.models.utils import export_model_to_onnx
 from doctr.transforms.functional import rotated_img_tensor
@@ -154,7 +154,7 @@ def main(args):
         mixed_precision.set_global_policy("mixed_float16")
 
     st = time.time()
-    val_set = RotationDataset(
+    val_set = OrientationDataset(
         img_folder=os.path.join(args.val_path, "images"),
         img_transforms=T.Compose([
             T.Resize(input_size, preserve_aspect_ratio=True, symmetric_pad=True),
@@ -202,7 +202,7 @@ def main(args):
         return
 
     st = time.time()
-    train_set = RotationDataset(
+    train_set = OrientationDataset(
         img_folder=os.path.join(args.train_path, "images"),
         img_transforms=T.Compose([
             T.Resize(input_size, preserve_aspect_ratio=True, symmetric_pad=True),

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -147,7 +147,7 @@ def main(args):
     if not isinstance(args.workers, int):
         args.workers = min(16, mp.cpu_count())
 
-    input_size = (1024, 1024) if args.type == "document" else (32, 128)
+    input_size = (256, 256) if args.type == "document" else (32, 32)
 
     # AMP
     if args.amp:
@@ -214,7 +214,7 @@ def main(args):
             T.RandomContrast(0.3),
             T.RandomBrightness(0.3),
             # Blur
-            T.RandomApply(T.GaussianBlur(kernel_shape=(3, 3), std=(0.1, 3)), 0.3),
+            T.RandomApply(T.GaussianBlur(kernel_shape=(3, 3), std=(0.1, 3)), 0.1),
         ]),
         sample_transforms=T.SampleCompose([
             lambda x, y: rnd_rotate(x, y),

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -283,12 +283,12 @@ def main(args):
     if args.wb:
         import wandb
 
-        run = wandb.init(name=exp_name, project="character-classification", config=config)
+        run = wandb.init(name=exp_name, project="orientation-classification", config=config)
     # ClearML
     if args.clearml:
         from clearml import Task
 
-        task = Task.init(project_name="docTR/character-classification", task_name=exp_name, reuse_last_task_id=False)
+        task = Task.init(project_name="docTR/orientation-classification", task_name=exp_name, reuse_last_task_id=False)
         task.upload_artifact("config", config)
 
     # Create loss queue

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -182,7 +182,7 @@ def main(args):
     model = classification.__dict__[args.arch](
         pretrained=args.pretrained,
         input_shape=(*(input_size), 3),
-        num_classes=4,
+        num_classes=len(CLASSES),
         classes=CLASSES,
         include_top=True,
     )

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -271,7 +271,7 @@ def main(args):
         "epochs": args.epochs,
         "batch_size": args.batch_size,
         "architecture": args.arch,
-        "input_size": args.input_size,
+        "input_size": input_size,
         "optimizer": "adam",
         "framework": "pytorch",
         "classes": CLASSES,

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -30,7 +30,7 @@ from doctr.models.utils import export_model_to_onnx
 from doctr.transforms.functional import rotated_img_tensor
 from utils import EarlyStopper, plot_recorder, plot_samples
 
-CLASSES = [0, 90, 180, -90]
+CLASSES = [0, 90, 180, 270]
 
 
 def rnd_rotate(img: tf.Tensor, target):

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -147,7 +147,7 @@ def main(args):
     if not isinstance(args.workers, int):
         args.workers = min(16, mp.cpu_count())
 
-    input_size = (256, 256) if args.type == "document" else (32, 32)
+    input_size = (256, 256) if args.type == "page" else (32, 32)
 
     # AMP
     if args.amp:
@@ -353,7 +353,7 @@ def parse_args():
     parser.add_argument("train_path", type=str, help="path to training data folder")
     parser.add_argument("val_path", type=str, help="path to validation data folder")
     parser.add_argument("arch", type=str, help="classification model to train")
-    parser.add_argument("type", type=str, choices=["document", "crop"], help="type of data to train on")
+    parser.add_argument("type", type=str, choices=["page", "crop"], help="type of data to train on")
     parser.add_argument("--name", type=str, default=None, help="Name of your training experiment")
     parser.add_argument("--epochs", type=int, default=10, help="number of epochs to train the model on")
     parser.add_argument("-b", "--batch_size", type=int, default=2, help="batch size for training")

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -85,7 +85,7 @@ def test_visiondataset():
 def test_rotation_dataset(mock_image_folder):
     input_size = (1024, 1024)
 
-    ds = datasets.RotationDataset(img_folder=mock_image_folder, img_transforms=Resize(input_size))
+    ds = datasets.OrientationDataset(img_folder=mock_image_folder, img_transforms=Resize(input_size))
     assert len(ds) == 5
     img, target = ds[0]
     assert isinstance(img, torch.Tensor)

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -101,10 +101,6 @@ def test_rotation_dataset(mock_image_folder):
     assert isinstance(images, torch.Tensor) and images.shape == (2, 3, *input_size)
     assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
 
-    # File existence check
-    with pytest.raises(ValueError):
-        datasets.RotationDataset("/random/path/")
-
 
 def test_detection_dataset(mock_image_folder, mock_detection_label):
     input_size = (1024, 1024)

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -101,6 +101,10 @@ def test_rotation_dataset(mock_image_folder):
     assert isinstance(images, torch.Tensor) and images.shape == (2, 3, *input_size)
     assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
 
+    # File existence check
+    with pytest.raises(ValueError):
+        datasets.RotationDataset("/random/path/")
+
 
 def test_detection_dataset(mock_image_folder, mock_detection_label):
     input_size = (1024, 1024)

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -82,6 +82,26 @@ def test_visiondataset():
     assert repr(dataset) == "VisionDataset()"
 
 
+def test_rotation_dataset(mock_image_folder):
+    input_size = (1024, 1024)
+
+    ds = datasets.RotationDataset(img_folder=mock_image_folder, img_transforms=Resize(input_size))
+    assert len(ds) == 5
+    img, target = ds[0]
+    assert isinstance(img, torch.Tensor)
+    assert img.dtype == torch.float32
+    assert img.shape[-2:] == input_size
+    # Prefilled rotation targets
+    assert isinstance(target, np.ndarray) and target.dtype == np.int64
+    # check that all prefilled targets are 0 (degrees)
+    assert np.all(target == 0)
+
+    loader = DataLoader(ds, batch_size=2, collate_fn=ds.collate_fn)
+    images, targets = next(iter(loader))
+    assert isinstance(images, torch.Tensor) and images.shape == (2, 3, *input_size)
+    assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
+
+
 def test_detection_dataset(mock_image_folder, mock_detection_label):
     input_size = (1024, 1024)
 

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -64,6 +64,26 @@ def test_visiondataset():
     assert repr(dataset) == "VisionDataset()"
 
 
+def test_rotation_dataset(mock_image_folder):
+    input_size = (1024, 1024)
+
+    ds = datasets.RotationDataset(img_folder=mock_image_folder, img_transforms=Resize(input_size))
+    assert len(ds) == 5
+    img, target = ds[0]
+    assert isinstance(img, tf.Tensor)
+    assert img.dtype == tf.float32
+    assert img.shape[:2] == input_size
+    # Prefilled rotation targets
+    assert isinstance(target, np.ndarray) and target.dtype == np.int64
+    # check that all prefilled targets are 0 (degrees)
+    assert np.all(target == 0)
+
+    loader = DataLoader(ds, batch_size=2)
+    images, targets = next(iter(loader))
+    assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
+    assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
+
+
 def test_detection_dataset(mock_image_folder, mock_detection_label):
     input_size = (1024, 1024)
 

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -83,6 +83,10 @@ def test_rotation_dataset(mock_image_folder):
     assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
     assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
 
+    # File existence check
+    with pytest.raises(ValueError):
+        datasets.RotationDataset("/random/path/")
+
 
 def test_detection_dataset(mock_image_folder, mock_detection_label):
     input_size = (1024, 1024)

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -67,7 +67,7 @@ def test_visiondataset():
 def test_rotation_dataset(mock_image_folder):
     input_size = (1024, 1024)
 
-    ds = datasets.RotationDataset(img_folder=mock_image_folder, img_transforms=Resize(input_size))
+    ds = datasets.OrientationDataset(img_folder=mock_image_folder, img_transforms=Resize(input_size))
     assert len(ds) == 5
     img, target = ds[0]
     assert isinstance(img, tf.Tensor)

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -83,10 +83,6 @@ def test_rotation_dataset(mock_image_folder):
     assert isinstance(images, tf.Tensor) and images.shape == (2, *input_size, 3)
     assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
 
-    # File existence check
-    with pytest.raises(ValueError):
-        datasets.RotationDataset("/random/path/")
-
 
 def test_detection_dataset(mock_image_folder, mock_detection_label):
     input_size = (1024, 1024)


### PR DESCRIPTION
This PR:

- Add training scripts (TF & PT) for the crop orientation classifier and additional for general document orientation classification (needed for 0.9.0 (similar to the crop_orientation_predictor) to generally recognize the documents rotation angle correctly before we compute the angle from the bin_map - which works only for rotated documents in the range ~ -60-60 well)
- Add a simple dataset (prefilled with 0 degree targets - to match the AbstractDataset checks)

Any feedback is welcome :)


- [x] Tests
- [x] Optimization  (input_size tests left)  - for crop orientation (32x32 is enough and works well) / for document orientation (256x256 seems to be enough)
- [x] Clean up
- [x] Readme

Dummy runs (mobilenet_v3_small)

```
crop orientation (800k train / 200k val)
Validation loss decreased 0.372947 --> 0.355291: saving state...
Epoch 5/30 - Validation loss: 0.355291 (Acc: 81.51%)

doc orientation (only 4k train / 1k val)
Validation loss decreased 0.559973 --> 0.481535: saving state...
Epoch 14/30 - Validation loss: 0.481535 (Acc: 79.22%)
```