### PR TITLE
[orientation] page orientation improvements

### DIFF
--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -75,7 +75,7 @@ def estimate_orientation(
         k_x = max(1, (floor(w / 100)))
         k_y = max(1, (floor(h / 100)))
         kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (k_x, k_y))
-        thresh = cv2.dilate(thresh, kernel, iterations=1)  # type: ignore[assignment]
+        thresh = cv2.dilate(thresh, kernel, iterations=1)
 
     # extract contours
     contours, _ = cv2.findContours(thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -98,7 +98,7 @@ def estimate_orientation(
     if general_page_orientation and general_page_orientation[1] >= min_confidence:
         estimated_angle = estimated_angle + general_page_orientation[0]
 
-    return estimated_angle
+    return -estimated_angle  # return the clockwise angle
 
 
 def rectify_crops(
@@ -107,12 +107,10 @@ def rectify_crops(
 ) -> List[np.ndarray]:
     """Rotate each crop of the list according to the predicted orientation:
     0: already straight, no rotation
-    1: 90 ccw, rotate 3 times ccw
-    2: 180, rotate 2 times ccw
-    3: 270 ccw, rotate 1 time ccw
+    1: 90 cw, rotate 3 times ccw
+    2: 180 cw, rotate 2 times ccw
+    3: 270 cw, rotate 1 times ccw
     """
-    # Inverse predictions (if angle of +90 is detected, rotate by -90)
-    orientations = [4 - pred if pred != 0 else 0 for pred in orientations]
     return (
         [crop if orientation == 0 else np.rot90(crop, orientation) for orientation, crop in zip(orientations, crops)]
         if len(orientations) > 0

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -62,13 +62,13 @@ def estimate_orientation(
         gray_img = cv2.medianBlur(gray_img, 5)
         thresh = cv2.threshold(gray_img, thresh=0, maxval=255, type=cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)[1]
     else:
-        thresh = img.astype(np.uint8)
+        thresh = img.astype(np.uint8)  # type: ignore[assignment]
 
     page_orientation, orientation_confidence = general_page_orientation or (None, 0.0)
     if page_orientation and orientation_confidence >= min_confidence:
         # We rotate the image to the general orientation which improves the detection
         # No expand needed bitmap is already padded
-        thresh = rotate_image(thresh, -page_orientation)
+        thresh = rotate_image(thresh, -page_orientation)  # type: ignore
     else:  # That's only required if we do not work on the detection models bin map
         # try to merge words in lines
         (h, w) = img.shape[:2]

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -128,7 +128,8 @@ def rectify_loc_preds(
     return (
         np.stack(
             [
-                np.roll(page_loc_pred, orientation, axis=0)
+                # shift clockwise
+                np.roll(page_loc_pred, -orientation, axis=0)
                 for orientation, page_loc_pred in zip(orientations, page_loc_preds)
             ],
             axis=0,

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -106,10 +106,14 @@ def estimate_orientation(
     # combine with the general orientation and the estimated angle
     if page_orientation and orientation_confidence >= min_confidence:
         # special case where the estimated angle is mostly wrong:
-        # when estimated angle is + or - 90 degree, we should consider the general orientation
-        if abs(estimated_angle) == 90 and abs(page_orientation) in [0, 90]:
+        # case 1: - and + swapped
+        # case 2: estimated angle is completely wrong
+        # so in this case we prefer the general page orientation
+        if abs(estimated_angle) == abs(page_orientation):
             return page_orientation
         estimated_angle = estimated_angle if page_orientation == 0 else page_orientation + estimated_angle
+        if estimated_angle > 180:
+            estimated_angle -= 360
 
     return estimated_angle  # return the clockwise angle (negative - left side rotation, positive - right side rotation)
 

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -98,7 +98,7 @@ def estimate_orientation(
     if general_page_orientation and general_page_orientation[1] >= min_confidence:
         estimated_angle = estimated_angle + general_page_orientation[0]
 
-    return -estimated_angle  # return the clockwise angle
+    return estimated_angle  # return the clockwise angle
 
 
 def rectify_crops(
@@ -107,10 +107,12 @@ def rectify_crops(
 ) -> List[np.ndarray]:
     """Rotate each crop of the list according to the predicted orientation:
     0: already straight, no rotation
-    1: 90 cw, rotate 3 times ccw
-    2: 180 cw, rotate 2 times ccw
-    3: 270 cw, rotate 1 times ccw
+    1: 90 ccw, rotate 3 times ccw
+    2: 180, rotate 2 times ccw
+    3: 270 ccw, rotate 1 time ccw
     """
+    # Inverse predictions (if angle of +90 is detected, rotate by -90)
+    orientations = [4 - pred if pred != 0 else 0 for pred in orientations]
     return (
         [crop if orientation == 0 else np.rot90(crop, orientation) for orientation, crop in zip(orientations, crops)]
         if len(orientations) > 0
@@ -128,8 +130,7 @@ def rectify_loc_preds(
     return (
         np.stack(
             [
-                # shift clockwise
-                np.roll(page_loc_pred, -orientation, axis=0)
+                np.roll(page_loc_pred, orientation, axis=0)
                 for orientation, page_loc_pred in zip(orientations, page_loc_preds)
             ],
             axis=0,

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -35,7 +35,7 @@ def estimate_orientation(
     img: np.ndarray,
     general_page_orientation: Optional[Tuple[int, float]] = None,
     n_ct: int = 50,
-    ratio_threshold_for_lines: float = 5,
+    ratio_threshold_for_lines: float = 3,
     min_confidence: float = 0.5,
 ) -> int:
     """Estimate the angle of the general document orientation based on the

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -37,6 +37,7 @@ def estimate_orientation(
     n_ct: int = 70,
     ratio_threshold_for_lines: float = 3,
     min_confidence: float = 0.5,
+    lower_area: int = 100,
 ) -> int:
     """Estimate the angle of the general document orientation based on the
      lines of the document and the assumption that they should be horizontal.
@@ -49,6 +50,7 @@ def estimate_orientation(
         n_ct: the number of contours used for the orientation estimation
         ratio_threshold_for_lines: this is the ratio w/h used to discriminates lines
         min_confidence: the minimum confidence to consider the general_page_orientation
+        lower_area: the minimum area of a contour to be considered
 
     Returns:
     -------
@@ -80,11 +82,12 @@ def estimate_orientation(
     # extract contours
     contours, _ = cv2.findContours(thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
 
-    # Filter contours
-    contours = [contour for contour in contours if cv2.contourArea(contour) > 100]
-
-    # Sort contours
-    contours = sorted(contours, key=get_max_width_length_ratio, reverse=True)
+    # Filter & Sort contours
+    contours = sorted(
+        [contour for contour in contours if cv2.contourArea(contour) > lower_area],
+        key=get_max_width_length_ratio,
+        reverse=True,
+    )
 
     angles = []
     for contour in contours[:n_ct]:

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -80,6 +80,9 @@ def estimate_orientation(
     # extract contours
     contours, _ = cv2.findContours(thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
 
+    # Filter contours
+    contours = [contour for contour in contours if cv2.contourArea(contour) > 100]
+
     # Sort contours
     contours = sorted(contours, key=get_max_width_length_ratio, reverse=True)
 

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -36,7 +36,7 @@ def estimate_orientation(
     general_page_orientation: Optional[Tuple[int, float]] = None,
     n_ct: int = 70,
     ratio_threshold_for_lines: float = 3,
-    min_confidence: float = 0.5,
+    min_confidence: float = 0.2,
     lower_area: int = 100,
 ) -> int:
     """Estimate the angle of the general document orientation based on the

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -63,7 +63,7 @@ def estimate_orientation(
         thresh = cv2.threshold(gray_img, thresh=0, maxval=255, type=cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)[1]
 
     if general_page_orientation:
-        thresh = rotate_image(img, -general_page_orientation[0], expand=img.shape[1] > img.shape[0])
+        thresh = rotate_image(img, -general_page_orientation[0], expand=abs(general_page_orientation[0]) == 90)
 
     # try to merge words in lines
     (h, w) = img.shape[:2]

--- a/doctr/models/_utils.py
+++ b/doctr/models/_utils.py
@@ -60,7 +60,7 @@ def estimate_orientation(
     if img.shape[-1] == 3:
         gray_img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         gray_img = cv2.medianBlur(gray_img, 5)
-        thresh = cv2.threshold(gray_img, thresh=0, maxval=255, type=cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)[1]  # type: ignore[assignment]
+        thresh = cv2.threshold(gray_img, thresh=0, maxval=255, type=cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)[1]
     else:
         thresh = img.astype(np.uint8)
 

--- a/doctr/models/classification/mobilenet/pytorch.py
+++ b/doctr/models/classification/mobilenet/pytorch.py
@@ -255,7 +255,7 @@ def mobilenet_v3_small_page_orientation(pretrained: bool = False, **kwargs: Any)
 
     >>> import torch
     >>> from doctr.models import mobilenet_v3_small_page_orientation
-    >>> model = mobilenet_v3_small_orientation(pretrained=False)
+    >>> model = mobilenet_v3_small_page_orientation(pretrained=False)
     >>> input_tensor = torch.rand((1, 3, 512, 512), dtype=torch.float32)
     >>> out = model(input_tensor)
 

--- a/doctr/models/classification/mobilenet/pytorch.py
+++ b/doctr/models/classification/mobilenet/pytorch.py
@@ -252,15 +252,18 @@ def mobilenet_v3_small_page_orientation(pretrained: bool = False, **kwargs: Any)
     """MobileNetV3-Small architecture as described in
     `"Searching for MobileNetV3",
     <https://arxiv.org/pdf/1905.02244.pdf>`_.
+
     >>> import torch
     >>> from doctr.models import mobilenet_v3_small_page_orientation
-    >>> model = mobilenet_v3_small_page_orientation(pretrained=False)
+    >>> model = mobilenet_v3_small_orientation(pretrained=False)
     >>> input_tensor = torch.rand((1, 3, 512, 512), dtype=torch.float32)
     >>> out = model(input_tensor)
+
     Args:
     ----
         pretrained: boolean, True if model is pretrained
         **kwargs: keyword arguments of the MobileNetV3 architecture
+
     Returns:
     -------
         a torch.nn.Module

--- a/doctr/models/classification/mobilenet/tensorflow.py
+++ b/doctr/models/classification/mobilenet/tensorflow.py
@@ -421,15 +421,18 @@ def mobilenet_v3_small_page_orientation(pretrained: bool = False, **kwargs: Any)
     """MobileNetV3-Small architecture as described in
     `"Searching for MobileNetV3",
     <https://arxiv.org/pdf/1905.02244.pdf>`_.
+
     >>> import tensorflow as tf
     >>> from doctr.models import mobilenet_v3_small_page_orientation
-    >>> model = mobilenet_v3_small_page_orientation(pretrained=False)
+    >>> model = mobilenet_v3_small_orientation(pretrained=False)
     >>> input_tensor = tf.random.uniform(shape=[1, 512, 512, 3], maxval=1, dtype=tf.float32)
     >>> out = model(input_tensor)
+
     Args:
     ----
         pretrained: boolean, True if model is pretrained
         **kwargs: keyword arguments of the MobileNetV3 architecture
+
     Returns:
     -------
         a keras.Model

--- a/doctr/models/classification/mobilenet/tensorflow.py
+++ b/doctr/models/classification/mobilenet/tensorflow.py
@@ -424,7 +424,7 @@ def mobilenet_v3_small_page_orientation(pretrained: bool = False, **kwargs: Any)
 
     >>> import tensorflow as tf
     >>> from doctr.models import mobilenet_v3_small_page_orientation
-    >>> model = mobilenet_v3_small_orientation(pretrained=False)
+    >>> model = mobilenet_v3_small_page_orientation(pretrained=False)
     >>> input_tensor = tf.random.uniform(shape=[1, 512, 512, 3], maxval=1, dtype=tf.float32)
     >>> out = model(input_tensor)
 

--- a/doctr/models/kie_predictor/base.py
+++ b/doctr/models/kie_predictor/base.py
@@ -25,10 +25,13 @@ class _KIEPredictor(_OCRPredictor):
             accordingly. Doing so will improve performances for documents with page-uniform rotations.
         preserve_aspect_ratio: if True, resize preserving the aspect ratio (with padding)
         symmetric_pad: if True and preserve_aspect_ratio is True, pas the image symmetrically.
+        detect_orientation: if True, the estimated general page orientation will be added to the predictions for each
+            page. Doing so will slightly deteriorate the overall latency.
         kwargs: keyword args of `DocumentBuilder`
     """
 
     crop_orientation_predictor: Optional[OrientationPredictor]
+    page_orientation_predictor: Optional[OrientationPredictor]
 
     def __init__(
         self,
@@ -36,8 +39,11 @@ class _KIEPredictor(_OCRPredictor):
         straighten_pages: bool = False,
         preserve_aspect_ratio: bool = True,
         symmetric_pad: bool = True,
+        detect_orientation: bool = False,
         **kwargs: Any,
     ) -> None:
-        super().__init__(assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, **kwargs)
+        super().__init__(
+            assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, detect_orientation, **kwargs
+        )
 
         self.doc_builder: KIEDocumentBuilder = KIEDocumentBuilder(**kwargs)

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -101,7 +101,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
             orientations = None
         if self.straighten_pages:
             general_page_orientations = (
-                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)
+                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)  # type: ignore[arg-type]
             )
             origin_page_orientations = (
                 origin_page_orientations

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -97,7 +97,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -111,9 +111,9 @@ class KIEPredictor(nn.Module, _KIEPredictor):
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )
-            # TODO: test the -> expand if page if -90 or 90 degrees rotated
+            # TODO: test the -> expand if page page width is larger than height
             pages = [
-                rotate_image(page, -angle, expand=abs(angle[0]) == 90)  # type: ignore[arg-type]
+                rotate_image(page, -angle, expand=False)  # type: ignore[arg-type]
                 for page, angle in zip(pages, origin_page_orientations)
             ]
             # Forward again to get predictions on straight pages

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -111,8 +111,11 @@ class KIEPredictor(nn.Module, _KIEPredictor):
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )
-            # TODO: expand if width > height
-            pages = [rotate_image(page, -angle, expand=False) for page, angle in zip(pages, origin_page_orientations)]  # type: ignore[arg-type]
+            # TODO: test the -> expand if page if -90 or 90 degrees rotated
+            pages = [
+                rotate_image(page, -angle, expand=abs(angle[0]) == 90)  # type: ignore[arg-type]
+                for page, angle in zip(pages, origin_page_orientations)
+            ]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -97,7 +97,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[assignment]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -13,6 +13,7 @@ from doctr.io.elements import Document
 from doctr.models._utils import get_language, invert_data_structure
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.utils.geometry import detach_scores
 
 from .base import _KIEPredictor
 

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -97,7 +97,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[assignment]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -88,7 +88,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)  # type: ignore[arg-type]
+            general_pages_orientations, origin_pages_orientations = self._get_orientations(pages, seg_maps)  # type: ignore[arg-type]
             orientations = [
                 {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
@@ -97,7 +97,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore
+            pages = self._straighten_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -55,7 +55,13 @@ class KIEPredictor(nn.Module, _KIEPredictor):
         self.det_predictor = det_predictor.eval()  # type: ignore[attr-defined]
         self.reco_predictor = reco_predictor.eval()  # type: ignore[attr-defined]
         _KIEPredictor.__init__(
-            self, assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, **kwargs
+            self,
+            assume_straight_pages,
+            straighten_pages,
+            preserve_aspect_ratio,
+            symmetric_pad,
+            detect_orientation,
+            **kwargs,
         )
         self.detect_orientation = detect_orientation
         self.detect_language = detect_language
@@ -83,18 +89,29 @@ class KIEPredictor(nn.Module, _KIEPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            origin_page_orientations = [estimate_orientation(seq_map) for seq_map in seg_maps]
+            general_page_orientations = self._get_general_page_orientation(pages)
+            origin_page_orientations = [
+                estimate_orientation(seq_map, general_page_orientation=general_orientation)
+                for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
+            ]
             orientations = [
                 {"value": orientation_page, "confidence": None} for orientation_page in origin_page_orientations
             ]
         else:
             orientations = None
         if self.straighten_pages:
+            general_page_orientations = (
+                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)
+            )
             origin_page_orientations = (
                 origin_page_orientations
                 if self.detect_orientation
-                else [estimate_orientation(seq_map) for seq_map in seg_maps]
+                else [
+                    estimate_orientation(seq_map, general_page_orientation=general_orientation)
+                    for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
+                ]
             )
+            # TODO: expand if width > height
             pages = [rotate_image(page, -angle, expand=False) for page, angle in zip(pages, origin_page_orientations)]  # type: ignore[arg-type]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -10,10 +10,9 @@ import torch
 from torch import nn
 
 from doctr.io.elements import Document
-from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
+from doctr.models._utils import get_language, invert_data_structure
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
-from doctr.utils.geometry import detach_scores, rotate_image
 
 from .base import _KIEPredictor
 
@@ -89,33 +88,16 @@ class KIEPredictor(nn.Module, _KIEPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_page_orientations = self._get_general_page_orientation(pages)
-            origin_page_orientations = [
-                estimate_orientation(seq_map, general_page_orientation=general_orientation)
-                for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
-            ]
+            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)  # type: ignore[arg-type]
             orientations = [
-                {"value": orientation_page, "confidence": None} for orientation_page in origin_page_orientations
+                {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
         else:
             orientations = None
+            general_pages_orientations = None
+            origin_pages_orientations = None
         if self.straighten_pages:
-            general_page_orientations = (
-                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)  # type: ignore[arg-type]
-            )
-            origin_page_orientations = (
-                origin_page_orientations
-                if self.detect_orientation
-                else [
-                    estimate_orientation(seq_map, general_page_orientation=general_orientation)
-                    for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
-                ]
-            )
-            # TODO: test the -> expand if page page width is larger than height
-            pages = [
-                rotate_image(page, -angle, expand=False)  # type: ignore[arg-type]
-                for page, angle in zip(pages, origin_page_orientations)
-            ]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -82,7 +82,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)  # type: ignore[arg-type]
+            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)
             orientations = [
                 {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
@@ -91,7 +91,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -95,7 +95,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
             orientations = None
         if self.straighten_pages:
             general_page_orientations = (
-                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)
+                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)  # type: ignore[arg-type]
             )
             origin_page_orientations = (
                 origin_page_orientations

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -105,9 +105,9 @@ class KIEPredictor(NestedObject, _KIEPredictor):
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )
-            # TODO: test the -> expand if page if -90 or 90 degrees rotated
+            # TODO: test the -> expand if page page width is larger than height
             pages = [
-                rotate_image(page, -angle, expand=abs(angle[0]) == 90)  # type: ignore[arg-type]
+                rotate_image(page, -angle, expand=False)  # type: ignore[arg-type]
                 for page, angle in zip(pages, origin_page_orientations)
             ]
             # Forward again to get predictions on straight pages

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -55,7 +55,13 @@ class KIEPredictor(NestedObject, _KIEPredictor):
         self.det_predictor = det_predictor
         self.reco_predictor = reco_predictor
         _KIEPredictor.__init__(
-            self, assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, **kwargs
+            self,
+            assume_straight_pages,
+            straighten_pages,
+            preserve_aspect_ratio,
+            symmetric_pad,
+            detect_orientation,
+            **kwargs,
         )
         self.detect_orientation = detect_orientation
         self.detect_language = detect_language

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -9,10 +9,9 @@ import numpy as np
 import tensorflow as tf
 
 from doctr.io.elements import Document
-from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
+from doctr.models._utils import get_language, invert_data_structure
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
-from doctr.utils.geometry import detach_scores, rotate_image
 from doctr.utils.repr import NestedObject
 
 from .base import _KIEPredictor
@@ -83,33 +82,16 @@ class KIEPredictor(NestedObject, _KIEPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_page_orientations = self._get_general_page_orientation(pages)
-            origin_page_orientations = [
-                estimate_orientation(seq_map, general_orientation)
-                for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
-            ]
+            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)  # type: ignore[arg-type]
             orientations = [
-                {"value": orientation_page, "confidence": None} for orientation_page in origin_page_orientations
+                {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
         else:
             orientations = None
+            general_pages_orientations = None
+            origin_pages_orientations = None
         if self.straighten_pages:
-            general_page_orientations = (
-                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)  # type: ignore[arg-type]
-            )
-            origin_page_orientations = (
-                origin_page_orientations
-                if self.detect_orientation
-                else [
-                    estimate_orientation(seq_map, general_page_orientation=general_orientation)
-                    for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
-                ]
-            )
-            # TODO: test the -> expand if page page width is larger than height
-            pages = [
-                rotate_image(page, -angle, expand=False)  # type: ignore[arg-type]
-                for page, angle in zip(pages, origin_page_orientations)
-            ]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -12,6 +12,7 @@ from doctr.io.elements import Document
 from doctr.models._utils import get_language, invert_data_structure
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.utils.geometry import detach_scores
 from doctr.utils.repr import NestedObject
 
 from .base import _KIEPredictor

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -82,7 +82,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)
+            general_pages_orientations, origin_pages_orientations = self._get_orientations(pages, seg_maps)
             orientations = [
                 {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
@@ -91,7 +91,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)
+            pages = self._straighten_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -105,8 +105,11 @@ class KIEPredictor(NestedObject, _KIEPredictor):
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )
-            # TODO: expand if width > height
-            pages = [rotate_image(page, -angle, expand=False) for page, angle in zip(pages, origin_page_orientations)]
+            # TODO: test the -> expand if page if -90 or 90 degrees rotated
+            pages = [
+                rotate_image(page, -angle, expand=abs(angle[0]) == 90)  # type: ignore[arg-type]
+                for page, angle in zip(pages, origin_page_orientations)
+            ]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -101,7 +101,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
                 origin_page_orientations
                 if self.detect_orientation
                 else [
-                    estimate_orientation(seq_map, general_orientation)
+                    estimate_orientation(seq_map, general_page_orientation=general_orientation)
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )

--- a/doctr/models/predictor/base.py
+++ b/doctr/models/predictor/base.py
@@ -77,7 +77,7 @@ class _OCRPredictor:
     ) -> Tuple[List[Tuple[int, float]], List[int]]:
         general_pages_orientations = self._get_general_pages_orientations(pages)
         origin_page_orientations = [
-            estimate_orientation(seq_map, general_orientation)
+            -estimate_orientation(seq_map, general_orientation)
             for seq_map, general_orientation in zip(seg_maps, general_pages_orientations)
         ]
         return general_pages_orientations, origin_page_orientations
@@ -115,7 +115,6 @@ class _OCRPredictor:
             ]
         )
         # TODO: test the -> expand if page page width is larger than height
-        # rotate image counter clockwise
         return [
             rotate_image(page, angle, expand=page.shape[1] > page.shape[0])
             for page, angle in zip(pages, origin_pages_orientations)

--- a/doctr/models/predictor/base.py
+++ b/doctr/models/predictor/base.py
@@ -104,7 +104,7 @@ class _OCRPredictor:
             pages: list of straightened pages
         """
         general_pages_orientations = (
-            general_pages_orientations if general_pages_orientations else self._get_general_pages_orientations(pages)  # type: ignore[arg-type]
+            general_pages_orientations if general_pages_orientations else self._get_general_pages_orientations(pages)
         )
         origin_pages_orientations = (
             origin_pages_orientations
@@ -116,7 +116,7 @@ class _OCRPredictor:
         )
         # TODO: test the -> expand if page page width is larger than height
         return [
-            rotate_image(page, -angle, expand=page.shape[1] > page.shape[0])  # type: ignore[arg-type]
+            rotate_image(page, -angle, expand=page.shape[1] > page.shape[0])
             for page, angle in zip(pages, origin_pages_orientations)
         ]
 

--- a/doctr/models/predictor/base.py
+++ b/doctr/models/predictor/base.py
@@ -77,7 +77,7 @@ class _OCRPredictor:
     ) -> Tuple[List[Tuple[int, float]], List[int]]:
         general_pages_orientations = self._get_general_pages_orientations(pages)
         origin_page_orientations = [
-            -estimate_orientation(seq_map, general_orientation)
+            estimate_orientation(seq_map, general_orientation)
             for seq_map, general_orientation in zip(seg_maps, general_pages_orientations)
         ]
         return general_pages_orientations, origin_page_orientations

--- a/doctr/models/predictor/base.py
+++ b/doctr/models/predictor/base.py
@@ -115,8 +115,9 @@ class _OCRPredictor:
             ]
         )
         # TODO: test the -> expand if page page width is larger than height
+        # rotate image counter clockwise
         return [
-            rotate_image(page, -angle, expand=page.shape[1] > page.shape[0])
+            rotate_image(page, angle, expand=page.shape[1] > page.shape[0])
             for page, angle in zip(pages, origin_pages_orientations)
         ]
 

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -95,7 +95,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[assignment]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -111,9 +111,9 @@ class OCRPredictor(nn.Module, _OCRPredictor):
             )
             # TODO: test the -> expand if page if -90 or 90 degrees rotated
             pages = [
-                rotate_image(page, -angle, expand=abs(angle[0]) == 90)
+                rotate_image(page, -angle, expand=abs(angle[0]) == 90)  # type: ignore[arg-type]
                 for page, angle in zip(pages, origin_page_orientations)
-            ]  # type: ignore[arg-type]
+            ]
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -13,6 +13,7 @@ from doctr.io.elements import Document
 from doctr.models._utils import get_language
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.utils.geometry import detach_scores
 
 from .base import _OCRPredictor
 

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -95,7 +95,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[assignment]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -86,7 +86,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)  # type: ignore[arg-type]
+            general_pages_orientations, origin_pages_orientations = self._get_orientations(pages, seg_maps)  # type: ignore[arg-type]
             orientations = [
                 {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
@@ -95,7 +95,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore
+            pages = self._straighten_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore
             # Forward again to get predictions on straight pages
             loc_preds = self.det_predictor(pages, **kwargs)
 

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -109,9 +109,9 @@ class OCRPredictor(nn.Module, _OCRPredictor):
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )
-            # TODO: test the -> expand if page if -90 or 90 degrees rotated
+            # TODO: test the -> expand if page page width is larger than height
             pages = [
-                rotate_image(page, -angle, expand=abs(angle[0]) == 90)  # type: ignore[arg-type]
+                rotate_image(page, -angle, expand=False)  # type: ignore[arg-type]
                 for page, angle in zip(pages, origin_page_orientations)
             ]
             # Forward again to get predictions on straight pages

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -99,7 +99,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
             orientations = None
         if self.straighten_pages:
             general_page_orientations = (
-                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)
+                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)  # type: ignore[arg-type]
             )
             origin_page_orientations = (
                 origin_page_orientations

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -12,6 +12,7 @@ from doctr.io.elements import Document
 from doctr.models._utils import get_language
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
+from doctr.utils.geometry import detach_scores
 from doctr.utils.repr import NestedObject
 
 from .base import _OCRPredictor

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -95,7 +95,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[assignment]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)
             # forward again to get predictions on straight pages
             loc_preds_dict = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -105,7 +105,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
                 origin_page_orientations
                 if self.detect_orientation
                 else [
-                    estimate_orientation(seq_map, general_orientation)
+                    estimate_orientation(seq_map, general_page_orientation=general_orientation)
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -56,7 +56,13 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         self.det_predictor = det_predictor
         self.reco_predictor = reco_predictor
         _OCRPredictor.__init__(
-            self, assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, **kwargs
+            self,
+            assume_straight_pages,
+            straighten_pages,
+            preserve_aspect_ratio,
+            symmetric_pad,
+            detect_orientation,
+            **kwargs,
         )
         self.detect_orientation = detect_orientation
         self.detect_language = detect_language
@@ -81,19 +87,33 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            origin_page_orientations = [estimate_orientation(seq_map) for seq_map in seg_maps]
+            general_page_orientations = self._get_general_page_orientation(pages)
+            origin_page_orientations = [
+                estimate_orientation(seq_map, general_orientation)
+                for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
+            ]
             orientations = [
                 {"value": orientation_page, "confidence": None} for orientation_page in origin_page_orientations
             ]
         else:
             orientations = None
         if self.straighten_pages:
+            general_page_orientations = (
+                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)
+            )
             origin_page_orientations = (
                 origin_page_orientations
                 if self.detect_orientation
-                else [estimate_orientation(seq_map) for seq_map in seg_maps]
+                else [
+                    estimate_orientation(seq_map, general_orientation)
+                    for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
+                ]
             )
-            pages = [rotate_image(page, -angle, expand=False) for page, angle in zip(pages, origin_page_orientations)]
+            # TODO: expand if page if -90 or 90 degrees rotated
+            pages = [
+                rotate_image(page, -angle, expand=abs(angle[0]) == 90)
+                for page, angle in zip(pages, origin_page_orientations)
+            ]
             # forward again to get predictions on straight pages
             loc_preds_dict = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -86,7 +86,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)
+            general_pages_orientations, origin_pages_orientations = self._get_orientations(pages, seg_maps)
             orientations = [
                 {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
@@ -95,7 +95,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)
+            pages = self._straighten_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)
             # forward again to get predictions on straight pages
             loc_preds_dict = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -109,9 +109,9 @@ class OCRPredictor(NestedObject, _OCRPredictor):
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )
-            # TODO: test the -> expand if page if -90 or 90 degrees rotated
+            # TODO: test the -> expand if page page width is larger than height
             pages = [
-                rotate_image(page, -angle, expand=abs(angle[0]) == 90)  # type: ignore[arg-type]
+                rotate_image(page, -angle, expand=False)  # type: ignore[arg-type]
                 for page, angle in zip(pages, origin_page_orientations)
             ]
             # forward again to get predictions on straight pages

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -86,7 +86,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)  # type: ignore[arg-type]
+            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)
             orientations = [
                 {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
@@ -95,7 +95,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             general_pages_orientations = None
             origin_pages_orientations = None
         if self.straighten_pages:
-            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[assignment]
             # forward again to get predictions on straight pages
             loc_preds_dict = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -9,10 +9,9 @@ import numpy as np
 import tensorflow as tf
 
 from doctr.io.elements import Document
-from doctr.models._utils import estimate_orientation, get_language
+from doctr.models._utils import get_language
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
-from doctr.utils.geometry import detach_scores, rotate_image
 from doctr.utils.repr import NestedObject
 
 from .base import _OCRPredictor
@@ -87,33 +86,16 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             for out_map in out_maps
         ]
         if self.detect_orientation:
-            general_page_orientations = self._get_general_page_orientation(pages)
-            origin_page_orientations = [
-                estimate_orientation(seq_map, general_orientation)
-                for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
-            ]
+            general_pages_orientations, origin_pages_orientations = self._get_pages_orientations(pages, seg_maps)  # type: ignore[arg-type]
             orientations = [
-                {"value": orientation_page, "confidence": None} for orientation_page in origin_page_orientations
+                {"value": orientation_page, "confidence": None} for orientation_page in origin_pages_orientations
             ]
         else:
             orientations = None
+            general_pages_orientations = None
+            origin_pages_orientations = None
         if self.straighten_pages:
-            general_page_orientations = (
-                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)  # type: ignore[arg-type]
-            )
-            origin_page_orientations = (
-                origin_page_orientations
-                if self.detect_orientation
-                else [
-                    estimate_orientation(seq_map, general_page_orientation=general_orientation)
-                    for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
-                ]
-            )
-            # TODO: test the -> expand if page page width is larger than height
-            pages = [
-                rotate_image(page, -angle, expand=False)  # type: ignore[arg-type]
-                for page, angle in zip(pages, origin_page_orientations)
-            ]
+            pages = self._get_straightened_pages(pages, seg_maps, general_pages_orientations, origin_pages_orientations)  # type: ignore[arg-type]
             # forward again to get predictions on straight pages
             loc_preds_dict = self.det_predictor(pages, **kwargs)  # type: ignore[assignment]
 

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -109,9 +109,9 @@ class OCRPredictor(NestedObject, _OCRPredictor):
                     for seq_map, general_orientation in zip(seg_maps, general_page_orientations)
                 ]
             )
-            # TODO: expand if page if -90 or 90 degrees rotated
+            # TODO: test the -> expand if page if -90 or 90 degrees rotated
             pages = [
-                rotate_image(page, -angle, expand=abs(angle[0]) == 90)
+                rotate_image(page, -angle, expand=abs(angle[0]) == 90)  # type: ignore[arg-type]
                 for page, angle in zip(pages, origin_page_orientations)
             ]
             # forward again to get predictions on straight pages

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -99,7 +99,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
             orientations = None
         if self.straighten_pages:
             general_page_orientations = (
-                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)
+                general_page_orientations if self.detect_orientation else self._get_general_page_orientation(pages)  # type: ignore[arg-type]
             )
             origin_page_orientations = (
                 origin_page_orientations

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -33,20 +33,20 @@ def test_estimate_orientation(mock_image, mock_bitmap, mock_tilted_payslip):
 
     # test binarized image
     angle = estimate_orientation(mock_bitmap)
-    assert abs(angle - 30.0) < 1.0
+    assert abs(angle) - 30 < 1.0
 
     angle = estimate_orientation(mock_bitmap * 255)
-    assert abs(angle - 30.0) < 1.0
+    assert abs(angle) - 30.0 < 1.0
 
     angle = estimate_orientation(mock_image)
-    assert abs(angle - 30.0) < 1.0
+    assert abs(angle) - 30.0 < 1.0
 
-    rotated = geometry.rotate_image(mock_image, -angle)
+    rotated = geometry.rotate_image(mock_image, angle)
     angle_rotated = estimate_orientation(rotated)
-    assert abs(angle_rotated) < 1.0
+    assert abs(angle_rotated) == 0
 
     mock_tilted_payslip = reader.read_img_as_numpy(mock_tilted_payslip)
-    assert (estimate_orientation(mock_tilted_payslip) - 30.0) < 1.0
+    assert estimate_orientation(mock_tilted_payslip) == 0
 
     rotated = geometry.rotate_image(mock_tilted_payslip, -30, expand=True)
     angle_rotated = estimate_orientation(rotated)
@@ -54,6 +54,14 @@ def test_estimate_orientation(mock_image, mock_bitmap, mock_tilted_payslip):
 
     with pytest.raises(AssertionError):
         estimate_orientation(np.ones((10, 10, 10)))
+
+    # test with general_page_orientation
+    assert estimate_orientation(mock_bitmap, (90, 0.9)) in range(140, 160)
+
+    rotated = geometry.rotate_image(mock_tilted_payslip, -150)
+    assert estimate_orientation(rotated, (0, 0.9)) in range(-10, 10)
+
+    assert estimate_orientation(mock_image, (0, 0.9)) - 30 < 1.0
 
 
 def test_get_lang():

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -46,7 +46,7 @@ def test_estimate_orientation(mock_image, mock_bitmap, mock_tilted_payslip):
     assert abs(angle_rotated) == 0
 
     mock_tilted_payslip = reader.read_img_as_numpy(mock_tilted_payslip)
-    assert estimate_orientation(mock_tilted_payslip) == 0
+    assert estimate_orientation(mock_tilted_payslip) == -30
 
     rotated = geometry.rotate_image(mock_tilted_payslip, -30, expand=True)
     angle_rotated = estimate_orientation(rotated)
@@ -58,7 +58,7 @@ def test_estimate_orientation(mock_image, mock_bitmap, mock_tilted_payslip):
     # test with general_page_orientation
     assert estimate_orientation(mock_bitmap, (90, 0.9)) in range(140, 160)
 
-    rotated = geometry.rotate_image(mock_tilted_payslip, -150)
+    rotated = geometry.rotate_image(mock_tilted_payslip, -30)
     assert estimate_orientation(rotated, (0, 0.9)) in range(-10, 10)
 
     assert estimate_orientation(mock_image, (0, 0.9)) - 30 < 1.0

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -64,8 +64,13 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
 
     if assume_straight_pages:
         assert predictor.crop_orientation_predictor is None
+        if predictor.detect_orientation or predictor.straighten_pages:
+            assert isinstance(predictor.page_orientation_predictor, nn.Module)
+        else:
+            assert predictor.page_orientation_predictor is None
     else:
         assert isinstance(predictor.crop_orientation_predictor, nn.Module)
+        assert isinstance(predictor.page_orientation_predictor, nn.Module)
 
     out = predictor(doc)
     assert isinstance(out, Document)
@@ -177,8 +182,13 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
 
     if assume_straight_pages:
         assert predictor.crop_orientation_predictor is None
+        if predictor.detect_orientation or predictor.straighten_pages:
+            assert isinstance(predictor.page_orientation_predictor, nn.Module)
+        else:
+            assert predictor.page_orientation_predictor is None
     else:
         assert isinstance(predictor.crop_orientation_predictor, nn.Module)
+        assert isinstance(predictor.page_orientation_predictor, nn.Module)
 
     out = predictor(doc)
     assert isinstance(out, Document)

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -61,8 +61,13 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
 
     if assume_straight_pages:
         assert predictor.crop_orientation_predictor is None
+        if predictor.detect_orientation or predictor.straighten_pages:
+            assert isinstance(predictor.page_orientation_predictor, NestedObject)
+        else:
+            assert predictor.page_orientation_predictor is None
     else:
         assert isinstance(predictor.crop_orientation_predictor, NestedObject)
+        assert isinstance(predictor.page_orientation_predictor, NestedObject)
 
     out = predictor(doc)
     assert isinstance(out, Document)
@@ -173,8 +178,13 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
 
     if assume_straight_pages:
         assert predictor.crop_orientation_predictor is None
+        if predictor.detect_orientation or predictor.straighten_pages:
+            assert isinstance(predictor.page_orientation_predictor, NestedObject)
+        else:
+            assert predictor.page_orientation_predictor is None
     else:
         assert isinstance(predictor.crop_orientation_predictor, NestedObject)
+        assert isinstance(predictor.page_orientation_predictor, NestedObject)
 
     out = predictor(doc)
     assert isinstance(out, KIEDocument)


### PR DESCRIPTION
This PR:

- refactor `OCRPredictor` logic (limit duplication)
- extend estimate angle function to handle also upside-down images
- correct return value from estimate angle (negative - left side rot / positive - right side rot) -> update tests
- integrate `page_orientation_predictor` 

NOTE: Draft until TF orientation models are merged


Any feedback is welcome :hugs: 

Closes: #1460 