### PR TITLE
[metrics] speed up polygon iou (for --rotation) by keeping balanced memory footprint

### DIFF
--- a/references/detection/evaluate_pytorch.py
+++ b/references/detection/evaluate_pytorch.py
@@ -14,7 +14,6 @@ import multiprocessing as mp
 import time
 from pathlib import Path
 
-import psutil
 import torch
 from torch.utils.data import DataLoader, SequentialSampler
 from torchvision.transforms import Normalize
@@ -66,7 +65,6 @@ def main(args):
         args.workers = min(16, mp.cpu_count())
 
     torch.backends.cudnn.benchmark = True
-    system_available_memory = int(psutil.virtual_memory().available / 1024**3)
 
     # Load docTR model
     model = detection.__dict__[args.arch](
@@ -134,11 +132,7 @@ def main(args):
         model = model.cuda()
 
     # Metrics
-    metric = LocalizationConfusion(
-        use_polygons=args.rotation,
-        mask_shape=input_shape,
-        use_broadcasting=True if system_available_memory > 62 else False,
-    )
+    metric = LocalizationConfusion(use_polygons=args.rotation)
 
     print("Running evaluation")
     val_loss, recall, precision, mean_iou = evaluate(model, test_loader, batch_transforms, metric, amp=args.amp)

--- a/references/detection/evaluate_tensorflow.py
+++ b/references/detection/evaluate_tensorflow.py
@@ -14,7 +14,6 @@ import multiprocessing as mp
 import time
 from pathlib import Path
 
-import psutil
 import tensorflow as tf
 from tensorflow.keras import mixed_precision
 from tqdm import tqdm
@@ -59,8 +58,6 @@ def main(args):
 
     if not isinstance(args.workers, int):
         args.workers = min(16, mp.cpu_count())
-
-    system_available_memory = int(psutil.virtual_memory().available / 1024**3)
 
     # AMP
     if args.amp:
@@ -115,11 +112,7 @@ def main(args):
     batch_transforms = T.Normalize(mean=mean, std=std)
 
     # Metrics
-    metric = LocalizationConfusion(
-        use_polygons=args.rotation,
-        mask_shape=input_shape[:2],
-        use_broadcasting=True if system_available_memory > 62 else False,
-    )
+    metric = LocalizationConfusion(use_polygons=args.rotation)
 
     print("Running evaluation")
     val_loss, recall, precision, mean_iou = evaluate(model, test_loader, batch_transforms, metric)

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -14,7 +14,6 @@ import multiprocessing as mp
 import time
 
 import numpy as np
-import psutil
 import torch
 import wandb
 from torch.optim.lr_scheduler import CosineAnnealingLR, MultiplicativeLR, OneCycleLR, PolynomialLR
@@ -178,7 +177,6 @@ def main(args):
         args.workers = min(16, mp.cpu_count())
 
     torch.backends.cudnn.benchmark = True
-    system_available_memory = int(psutil.virtual_memory().available / 1024**3)
 
     st = time.time()
     val_set = DetectionDataset(
@@ -246,11 +244,7 @@ def main(args):
         model = model.cuda()
 
     # Metrics
-    val_metric = LocalizationConfusion(
-        use_polygons=args.rotation and not args.eval_straight,
-        mask_shape=(args.input_size, args.input_size),
-        use_broadcasting=True if system_available_memory > 62 else False,
-    )
+    val_metric = LocalizationConfusion(use_polygons=args.rotation and not args.eval_straight)
 
     if args.test_only:
         print("Running evaluation")

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -14,7 +14,6 @@ import multiprocessing as mp
 import time
 
 import numpy as np
-import psutil
 import tensorflow as tf
 from tensorflow.keras import mixed_precision
 from tqdm.auto import tqdm
@@ -136,8 +135,6 @@ def main(args):
     if not isinstance(args.workers, int):
         args.workers = min(16, mp.cpu_count())
 
-    system_available_memory = int(psutil.virtual_memory().available / 1024**3)
-
     # AMP
     if args.amp:
         mixed_precision.set_global_policy("mixed_float16")
@@ -200,11 +197,8 @@ def main(args):
         print("Done.")
 
     # Metrics
-    val_metric = LocalizationConfusion(
-        use_polygons=args.rotation and not args.eval_straight,
-        mask_shape=(args.input_size, args.input_size),
-        use_broadcasting=True if system_available_memory > 62 else False,
-    )
+    val_metric = LocalizationConfusion(use_polygons=args.rotation and not args.eval_straight)
+
     if args.test_only:
         print("Running evaluation")
         val_loss, recall, precision, mean_iou = evaluate(model, val_loader, batch_transforms, val_metric)

--- a/references/requirements.txt
+++ b/references/requirements.txt
@@ -1,6 +1,5 @@
 -e .
 tqdm
 wandb>=0.10.31
-psutil>=5.9.0
 clearml>=1.11.1
 matplotlib>=3.1.0

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -56,16 +56,9 @@ def main(args):
         sets = [train_set, val_set]
 
     reco_metric = TextMatch()
-    if args.mask_shape:
-        det_metric = LocalizationConfusion(
-            iou_thresh=args.iou, use_polygons=not args.eval_straight, mask_shape=(args.mask_shape, args.mask_shape)
-        )
-        e2e_metric = OCRMetric(
-            iou_thresh=args.iou, use_polygons=not args.eval_straight, mask_shape=(args.mask_shape, args.mask_shape)
-        )
-    else:
-        det_metric = LocalizationConfusion(iou_thresh=args.iou, use_polygons=not args.eval_straight)
-        e2e_metric = OCRMetric(iou_thresh=args.iou, use_polygons=not args.eval_straight)
+
+    det_metric = LocalizationConfusion(iou_thresh=args.iou, use_polygons=not args.eval_straight)
+    e2e_metric = OCRMetric(iou_thresh=args.iou, use_polygons=not args.eval_straight)
 
     sample_idx = 0
     extraction_fn = extract_crops if args.eval_straight else extract_rcrops
@@ -197,7 +190,6 @@ def parse_args():
     parser.add_argument("--label_file", type=str, default=None, help="Only for local sets, path to labels")
     parser.add_argument("--rotation", dest="rotation", action="store_true", help="run rotated OCR + postprocessing")
     parser.add_argument("-b", "--batch_size", type=int, default=32, help="batch size for recognition")
-    parser.add_argument("--mask_shape", type=int, default=None, help="mask shape for mask iou (only for rotation)")
     parser.add_argument("--samples", type=int, default=None, help="evaluate only on the N first samples")
     parser.add_argument(
         "--eval-straight",

--- a/scripts/evaluate_kie.py
+++ b/scripts/evaluate_kie.py
@@ -58,16 +58,9 @@ def main(args):
         sets = [train_set, val_set]
 
     reco_metric = TextMatch()
-    if args.mask_shape:
-        det_metric = LocalizationConfusion(
-            iou_thresh=args.iou, use_polygons=not args.eval_straight, mask_shape=(args.mask_shape, args.mask_shape)
-        )
-        e2e_metric = OCRMetric(
-            iou_thresh=args.iou, use_polygons=not args.eval_straight, mask_shape=(args.mask_shape, args.mask_shape)
-        )
-    else:
-        det_metric = LocalizationConfusion(iou_thresh=args.iou, use_polygons=not args.eval_straight)
-        e2e_metric = OCRMetric(iou_thresh=args.iou, use_polygons=not args.eval_straight)
+
+    det_metric = LocalizationConfusion(iou_thresh=args.iou, use_polygons=not args.eval_straight)
+    e2e_metric = OCRMetric(iou_thresh=args.iou, use_polygons=not args.eval_straight)
 
     sample_idx = 0
     extraction_fn = extract_crops if args.eval_straight else extract_rcrops
@@ -194,7 +187,6 @@ def parse_args():
     parser.add_argument("--label_file", type=str, default=None, help="Only for local sets, path to labels")
     parser.add_argument("--rotation", dest="rotation", action="store_true", help="run rotated OCR + postprocessing")
     parser.add_argument("-b", "--batch_size", type=int, default=32, help="batch size for recognition")
-    parser.add_argument("--mask_shape", type=int, default=None, help="mask shape for mask iou (only for rotation)")
     parser.add_argument("--samples", type=int, default=None, help="evaluate only on the N first samples")
     parser.add_argument(
         "--eval-straight",

--- a/tests/common/test_utils_metrics.py
+++ b/tests/common/test_utils_metrics.py
@@ -46,34 +46,6 @@ def test_box_iou(box1, box2, iou, abs_tol):
 
 
 @pytest.mark.parametrize(
-    "mask1, mask2, iou, abs_tol",
-    [
-        [
-            [[[True, True, False], [True, True, False]]],
-            [[[True, True, False], [True, True, False]]],
-            1,
-            0,
-        ],  # Perfect match
-        [
-            [[[True, False, False], [False, False, False]]],
-            [[[True, True, False], [True, True, False]]],
-            0.25,
-            0,
-        ],  # Partial match
-    ],
-)
-def test_mask_iou(mask1, mask2, iou, abs_tol):
-    iou_mat = metrics.mask_iou(np.asarray(mask1), np.asarray(mask2))
-    assert iou_mat.shape == (len(mask1), len(mask2))
-    if iou_mat.size > 0:
-        assert abs(iou_mat - iou) <= abs_tol
-
-    # Incompatible spatial shapes
-    with pytest.raises(AssertionError):
-        metrics.mask_iou(np.zeros((2, 3, 5), dtype=bool), np.ones((3, 2, 5), dtype=bool))
-
-
-@pytest.mark.parametrize(
     "rbox1, rbox2, iou, abs_tol",
     [
         [[[[0, 0], [0.5, 0], [0.5, 0.5], [0, 0.5]]], [[[0, 0], [0.5, 0], [0.5, 0.5], [0, 0.5]]], 1, 0],  # Perfect match
@@ -101,35 +73,18 @@ def test_mask_iou(mask1, mask2, iou, abs_tol):
     ],
 )
 def test_polygon_iou(rbox1, rbox2, iou, abs_tol):
-    mask_shape = (256, 256)
-    iou_mat = metrics.polygon_iou(np.asarray(rbox1), np.asarray(rbox2), mask_shape)
+    iou_mat = metrics.polygon_iou(np.asarray(rbox1), np.asarray(rbox2))
     assert iou_mat.shape == (len(rbox1), len(rbox2))
     if iou_mat.size > 0:
         assert abs(iou_mat - iou) <= abs_tol
 
     # Ensure broadcasting doesn't change the result
-    iou_matbis = metrics.polygon_iou(np.asarray(rbox1), np.asarray(rbox2), mask_shape, use_broadcasting=False)
+    iou_matbis = metrics.polygon_iou(np.asarray(rbox1), np.asarray(rbox2))
     assert np.all((iou_mat - iou_matbis) <= 1e-7)
 
     # Incorrect boxes
     with pytest.raises(AssertionError):
-        metrics.polygon_iou(np.zeros((2, 5), dtype=float), np.ones((3, 4), dtype=float), mask_shape)
-
-
-@pytest.mark.parametrize(
-    "box, shape, mask",
-    [
-        [
-            [[0, 0], [0.5, 0], [0.5, 0.5], [0, 0.5]],
-            (2, 2),
-            [[True, False], [False, False]],
-        ],
-    ],
-)
-def test_rbox_to_mask(box, shape, mask):
-    masks = metrics.rbox_to_mask(np.asarray(box)[None, ...], shape)
-    assert masks.shape == (1, *shape)
-    assert np.all(masks[0] == np.asarray(mask, dtype=bool))
+        metrics.polygon_iou(np.zeros((2, 5), dtype=float), np.ones((3, 4), dtype=float))
 
 
 @pytest.mark.parametrize(
@@ -190,7 +145,7 @@ def test_localization_confusion(gts, preds, iou_thresh, recall, precision, mean_
     ],
 )
 def test_r_localization_confusion(gts, preds, iou_thresh, recall, precision, mean_iou):
-    metric = metrics.LocalizationConfusion(iou_thresh, use_polygons=True, mask_shape=(1000, 1000))
+    metric = metrics.LocalizationConfusion(iou_thresh, use_polygons=True)
     for _gts, _preds in zip(gts, preds):
         metric.update(np.asarray(_gts), np.zeros((0, 5)) if _preds is None else np.asarray(_preds))
     assert metric.summary()[:2] == (recall, precision)
@@ -334,13 +289,3 @@ def test_nms():
     ]
     to_keep = metrics.nms(np.asarray(boxes), thresh=0.2)
     assert to_keep == [0, 2]
-
-
-def test_box_ioa():
-    boxes = [
-        [0.1, 0.1, 0.2, 0.2],
-        [0.15, 0.15, 0.2, 0.2],
-    ]
-    mat = metrics.box_ioa(np.array(boxes), np.array(boxes))
-    assert mat[1, 0] == mat[0, 0] == mat[1, 1] == 1.0
-    assert abs(mat[0, 1] - 0.25) <= 1e-7


### PR DESCRIPTION
This PR:

- boost polygon iou (from hours to a few minutes) and try to keep an balanced memory consumption
- remove now unused functions in `metrics.py`
- remove unused `use_broadcasting` / `mask_shape` and `psutil` requirements for references
- memory usage tested with oversampled funsd validation dataset (~4K samples) tooks around 6.5 GB RAM

Any feedback is welcome :hugs: 

Closes: #1472 