### PR TITLE
[orientation] augment angle while training

### DIFF
--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -43,7 +43,7 @@ def rnd_rotate(img: torch.Tensor, target):
     idx = CLASSES.index(angle)
     # augment the angle randomly with a probability of 0.5
     if np.random.rand() < 0.5:
-        angle += float(np.random.choice(np.arange(-20, 20, 5)))
+        angle += float(np.random.choice(np.arange(-25, 25, 5)))
     rotated_img = F.rotate(img, angle=-angle, fill=0, expand=False)[:3]
     return rotated_img, idx
 

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -41,6 +41,9 @@ CLASSES = [0, -90, 180, 90]
 def rnd_rotate(img: torch.Tensor, target):
     angle = int(np.random.choice(CLASSES))
     idx = CLASSES.index(angle)
+    # augment the angle randomly with a probability of 0.5
+    if np.random.rand() < 0.5:
+        angle += float(np.random.choice(np.arange(-20, 20, 5)))
     rotated_img = F.rotate(img, angle=-angle, fill=0, expand=False)[:3]
     return rotated_img, idx
 

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -44,7 +44,7 @@ def rnd_rotate(img: torch.Tensor, target):
     # augment the angle randomly with a probability of 0.5
     if np.random.rand() < 0.5:
         angle += float(np.random.choice(np.arange(-25, 25, 5)))
-    rotated_img = F.rotate(img, angle=-angle, fill=0, expand=False)[:3]
+    rotated_img = F.rotate(img, angle=-angle, fill=0, expand=angle not in CLASSES)[:3]
     return rotated_img, idx
 
 

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -36,6 +36,9 @@ CLASSES = [0, -90, 180, 90]
 def rnd_rotate(img: tf.Tensor, target):
     angle = int(np.random.choice(CLASSES))
     idx = CLASSES.index(angle)
+    # augment the angle randomly with a probability of 0.5
+    if np.random.rand() < 0.5:
+        angle += float(np.random.choice(np.arange(-20, 20, 5)))
     # clockwise rotation
     rotated_img = rotated_img_tensor(img, -angle, expand=False)
     return rotated_img, idx

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -40,7 +40,7 @@ def rnd_rotate(img: tf.Tensor, target):
     if np.random.rand() < 0.5:
         angle += float(np.random.choice(np.arange(-25, 25, 5)))
     # clockwise rotation
-    rotated_img = rotated_img_tensor(img, -angle, expand=False)
+    rotated_img = rotated_img_tensor(img, -angle, expand=angle not in CLASSES)
     return rotated_img, idx
 
 

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -38,7 +38,7 @@ def rnd_rotate(img: tf.Tensor, target):
     idx = CLASSES.index(angle)
     # augment the angle randomly with a probability of 0.5
     if np.random.rand() < 0.5:
-        angle += float(np.random.choice(np.arange(-20, 20, 5)))
+        angle += float(np.random.choice(np.arange(-25, 25, 5)))
     # clockwise rotation
     rotated_img = rotated_img_tensor(img, -angle, expand=False)
     return rotated_img, idx


### PR DESCRIPTION
This PR:

- augment randomly the angle while training (+-25 degree) (expand if not directly 0, 90, 180 or -90)
- the idea: the current orientation models works pretty well if the real angle of the page or crop is close to [0, 90, 180, -90] but has some lack with larger deviations like >+- 5 degree

@odulcy-mindee We should test it on the TF orientation model training runs i think this will improve the robustness a lot and then do the same again with the PT models (or we test it directly with the PT models)

