### PR TITLE
[Fix / transforms] RandomHorizontalFlip & RandomCrop

### DIFF
--- a/doctr/transforms/modules/pytorch.py
+++ b/doctr/transforms/modules/pytorch.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 import math
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -159,13 +159,16 @@ class RandomHorizontalFlip(T.RandomHorizontalFlip):
     """Randomly flip the input image horizontally"""
 
     def forward(
-        self, img: Union[torch.Tensor, Image], target: Dict[str, Any]
-    ) -> Tuple[Union[torch.Tensor, Image], Dict[str, Any]]:
+        self, img: Union[torch.Tensor, Image], target: np.ndarray
+    ) -> Tuple[Union[torch.Tensor, Image], np.ndarray]:
         if torch.rand(1) < self.p:
             _img = F.hflip(img)
             _target = target.copy()
             # Changing the relative bbox coordinates
-            _target["boxes"][:, ::2] = 1 - target["boxes"][:, [2, 0]]
+            if target.shape[1:] == (4,):
+                _target[:, ::2] = 1 - target[:, [2, 0]]
+            else:
+                _target[..., 0] = 1 - target[..., 0]
             return _img, _target
         return img, target
 

--- a/doctr/transforms/modules/tensorflow.py
+++ b/doctr/transforms/modules/tensorflow.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 import random
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import tensorflow as tf
@@ -457,10 +457,7 @@ class RandomHorizontalFlip(NestedObject):
     >>> from doctr.transforms import RandomHorizontalFlip
     >>> transfo = RandomHorizontalFlip(p=0.5)
     >>> image = tf.random.uniform(shape=[64, 64, 3], minval=0, maxval=1)
-    >>> target = {
-    >>> "boxes": np.array([[0.1, 0.1, 0.4, 0.5] ], dtype= np.float32),
-    >>> "labels": np.ones(1, dtype= np.int64)
-    >>> }
+    >>> target = np.array([[0.1, 0.1, 0.4, 0.5] ], dtype= np.float32)
     >>> out = transfo(image, target)
 
     Args:
@@ -472,12 +469,15 @@ class RandomHorizontalFlip(NestedObject):
         super().__init__()
         self.p = p
 
-    def __call__(self, img: Union[tf.Tensor, np.ndarray], target: Dict[str, Any]) -> Tuple[tf.Tensor, Dict[str, Any]]:
+    def __call__(self, img: Union[tf.Tensor, np.ndarray], target: np.ndarray) -> Tuple[tf.Tensor, np.ndarray]:
         if np.random.rand(1) <= self.p:
             _img = tf.image.flip_left_right(img)
             _target = target.copy()
             # Changing the relative bbox coordinates
-            _target["boxes"][:, ::2] = 1 - target["boxes"][:, [2, 0]]
+            if target.shape[1:] == (4,):
+                _target[:, ::2] = 1 - target[:, [2, 0]]
+            else:
+                _target[..., 0] = 1 - target[..., 0]
             return _img, _target
         return img, target
 

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -184,9 +184,12 @@ def main(args):
         label_path=os.path.join(args.val_path, "labels.json"),
         sample_transforms=T.SampleCompose(
             (
-                [T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True)]
+                [
+                    T.RandomCrop(),
+                    T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+                ]
                 if not args.rotation or args.eval_straight
-                else []
+                else [T.RandomCrop()]
             )
             + (
                 [
@@ -271,9 +274,16 @@ def main(args):
         ]),
         sample_transforms=T.SampleCompose(
             (
-                [T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True)]
+                [
+                    T.RandomHorizontalFlip(0.9),
+                    T.RandomApply(T.RandomCrop(), 0.9),
+                    T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+                ]
                 if not args.rotation
-                else []
+                else [
+                    T.RandomHorizontalFlip(0.9),
+                    T.RandomApply(T.RandomCrop(), 0.9),
+                ]
             )
             + (
                 [

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -275,14 +275,14 @@ def main(args):
         sample_transforms=T.SampleCompose(
             (
                 [
-                    T.RandomHorizontalFlip(0.9),
-                    T.RandomApply(T.RandomCrop(), 0.9),
+                    T.RandomHorizontalFlip(0.1),
+                    T.RandomApply(T.RandomCrop(), 0.2),
                     T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
                 ]
                 if not args.rotation
                 else [
-                    T.RandomHorizontalFlip(0.9),
-                    T.RandomApply(T.RandomCrop(), 0.9),
+                    T.RandomHorizontalFlip(0.1),
+                    T.RandomApply(T.RandomCrop(), 0.2),
                 ]
             )
             + (

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -184,12 +184,9 @@ def main(args):
         label_path=os.path.join(args.val_path, "labels.json"),
         sample_transforms=T.SampleCompose(
             (
-                [
-                    T.RandomCrop(),
-                    T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
-                ]
+                [T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True)]
                 if not args.rotation or args.eval_straight
-                else [T.RandomCrop()]
+                else []
             )
             + (
                 [

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -218,7 +218,7 @@ def main(args):
             T.RandomApply(T.ColorInversion(), 0.1),
             T.RandomJpegQuality(60),
             T.RandomApply(T.GaussianNoise(mean=0.1, std=0.1), 0.1),
-            T.RandomApply(T.RandomShadow(), 0.1),
+            # T.RandomApply(T.RandomShadow(), 0.1), # Broken atm on GPU
             T.RandomApply(T.GaussianBlur(kernel_shape=3, std=(0.1, 0.1)), 0.1),
             T.RandomSaturation(0.3),
             T.RandomContrast(0.3),
@@ -227,9 +227,16 @@ def main(args):
         ]),
         sample_transforms=T.SampleCompose(
             (
-                [T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True)]
+                [
+                    T.RandomHorizontalFlip(0.1),
+                    T.RandomApply(T.RandomCrop(), 0.2),
+                    T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+                ]
                 if not args.rotation
-                else []
+                else [
+                    T.RandomHorizontalFlip(0.1),
+                    T.RandomApply(T.RandomCrop(), 0.2),
+                ]
             )
             + (
                 [

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -229,7 +229,7 @@ def main(args):
                 T.RandomSaturation(0.3),
                 T.RandomContrast(0.3),
                 T.RandomBrightness(0.3),
-                T.RandomApply(T.RandomShadow(), 0.4),
+                # T.RandomApply(T.RandomShadow(), 0.4), # Broken atm on GPU
                 T.RandomApply(T.GaussianNoise(mean=0.1, std=0.1), 0.1),
                 T.RandomApply(T.GaussianBlur(kernel_shape=3, std=(0.1, 0.1)), 0.3),
             ]),

--- a/tests/tensorflow/test_transforms_tf.py
+++ b/tests/tensorflow/test_transforms_tf.py
@@ -322,14 +322,14 @@ def test_random_crop():
     transfo = T.RandomCrop(scale=(0.5, 1.0), ratio=(0.75, 1.33))
     input_t = tf.ones((50, 50, 3), dtype=tf.float32)
     boxes = np.array([[15, 20, 35, 30]])
-    img, target = transfo(input_t, dict(boxes=boxes))
+    img, target = transfo(input_t, boxes)
     # Check the scale (take a margin)
     assert img.shape[0] * img.shape[1] >= 0.4 * input_t.shape[0] * input_t.shape[1]
     # Check aspect ratio (take a margin)
     assert 0.65 <= img.shape[0] / img.shape[1] <= 1.5
     # Check the target
-    assert np.all(target["boxes"] >= 0)
-    assert np.all(target["boxes"][:, [0, 2]] <= img.shape[1]) and np.all(target["boxes"][:, [1, 3]] <= img.shape[0])
+    assert np.all(target >= 0)
+    assert np.all(target[:, [0, 2]] <= img.shape[1]) and np.all(target[:, [1, 3]] <= img.shape[0])
 
 
 def test_gaussian_blur():
@@ -394,27 +394,24 @@ def test_randomhorizontalflip(p):
     input_t = np.ones((32, 32, 3))
     input_t[:, :16, :] = 0
     input_t = tf.convert_to_tensor(input_t)
-    target = {"boxes": np.array([[0.1, 0.1, 0.3, 0.4]], dtype=np.float32), "labels": np.ones(1, dtype=np.int64)}
+    target = np.array([[0.1, 0.1, 0.3, 0.4]], dtype=np.float32)
     transformed, _target = transform(input_t, target)
     assert isinstance(transformed, tf.Tensor)
     assert transformed.shape == input_t.shape
     assert transformed.dtype == input_t.dtype
     # integrity check of targets
-    assert isinstance(_target, dict)
-    assert all(isinstance(val, np.ndarray) for val in _target.values())
-    assert _target["boxes"].dtype == np.float32
-    assert _target["labels"].dtype == np.int64
+    assert isinstance(_target, np.ndarray)
+    assert _target.dtype == np.float32
     if p == 1:
-        assert np.all(_target["boxes"] == np.array([[0.7, 0.1, 0.9, 0.4]], dtype=np.float32))
+        assert np.all(_target == np.array([[0.7, 0.1, 0.9, 0.4]], dtype=np.float32))
         assert tf.reduce_all(
             tf.math.reduce_mean(transformed, (0, 2)) == tf.constant([1] * 16 + [0] * 16, dtype=tf.float64)
         )
     elif p == 0:
-        assert np.all(_target["boxes"] == np.array([[0.1, 0.1, 0.3, 0.4]], dtype=np.float32))
+        assert np.all(_target == np.array([[0.1, 0.1, 0.3, 0.4]], dtype=np.float32))
         assert tf.reduce_all(
             tf.math.reduce_mean(transformed, (0, 2)) == tf.constant([0] * 16 + [1] * 16, dtype=tf.float64)
         )
-    assert np.all(_target["labels"] == np.ones(1, dtype=np.int64))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR:

- fix both augmentations
- add augmentations

(flip instead of changing the max rotation angle to 180 because it's faster and needs less computation / RandomCrop should help to make the detection more robust on edges)

Any feedback is welcome :hugs: 

NOTE: Before we do some experiments for version > 0.9.0 i will create and test some augmentation clusters so for the moment added as the others to the augmentation pipe

Still missing:

- RandomZoomOut -> To get rid of small text instances
- Halftone ?

@odulcy-mindee Any missing augmentations in mind ? 