### PR TITLE
[references] Update detection augmentations

### DIFF
--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -278,8 +278,8 @@ def main(args):
             [
                 T.RandomHorizontalFlip(0.15),
                 T.OneOf([
-                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.28),
-                    T.RandomResize(scale_range=(0.4, 0.9), p=0.28),
+                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.25),
+                    T.RandomResize(scale_range=(0.4, 0.9), p=0.25),
                 ]),
                 T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
             ]
@@ -287,8 +287,8 @@ def main(args):
             else [
                 T.RandomHorizontalFlip(0.15),
                 T.OneOf([
-                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.28),
-                    T.RandomResize(scale_range=(0.4, 0.9), p=0.28),
+                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.25),
+                    T.RandomResize(scale_range=(0.4, 0.9), p=0.25),
                 ]),
                 # Rotation augmentation
                 T.Resize(args.input_size, preserve_aspect_ratio=True),

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -256,42 +256,54 @@ def main(args):
         return
 
     st = time.time()
+    # Augmentations
+    # Image augmentations
+    img_transforms = T.OneOf([
+        Compose([
+            T.RandomApply(T.ColorInversion(), 0.3),
+            T.RandomApply(GaussianBlur(kernel_size=5, sigma=(0.1, 4)), 0.2),
+        ]),
+        Compose([
+            T.RandomApply(T.RandomShadow(), 0.3),
+            T.RandomApply(T.GaussianNoise(), 0.1),
+            T.RandomApply(GaussianBlur(kernel_size=5, sigma=(0.1, 4)), 0.3),
+            RandomGrayscale(p=0.15),
+        ]),
+        RandomPhotometricDistort(p=0.3),
+        lambda x: x,  # Identity no transformation
+    ])
+    # Image + target augmentations
+    sample_transforms = T.SampleCompose(
+        (
+            [
+                T.RandomHorizontalFlip(0.15),
+                T.OneOf([
+                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.28),
+                    T.RandomResize(scale_range=(0.4, 0.9), p=0.28),
+                ]),
+                T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+            ]
+            if not args.rotation
+            else [
+                T.RandomHorizontalFlip(0.15),
+                T.OneOf([
+                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.28),
+                    T.RandomResize(scale_range=(0.4, 0.9), p=0.28),
+                ]),
+                # Rotation augmentation
+                T.Resize(args.input_size, preserve_aspect_ratio=True),
+                T.RandomApply(T.RandomRotate(90, expand=True), 0.5),
+                T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
+            ]
+        )
+    )
+
     # Load both train and val data generators
     train_set = DetectionDataset(
         img_folder=os.path.join(args.train_path, "images"),
         label_path=os.path.join(args.train_path, "labels.json"),
-        img_transforms=Compose([
-            # Augmentations
-            T.RandomApply(T.ColorInversion(), 0.1),
-            T.RandomApply(T.GaussianNoise(mean=0.1, std=0.1), 0.1),
-            T.RandomApply(T.RandomShadow(), 0.1),
-            T.RandomApply(GaussianBlur(kernel_size=3), 0.1),
-            RandomPhotometricDistort(p=0.05),
-            RandomGrayscale(p=0.05),
-        ]),
-        sample_transforms=T.SampleCompose(
-            (
-                [
-                    T.RandomHorizontalFlip(0.1),
-                    T.RandomApply(T.RandomCrop(), 0.2),
-                    T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
-                ]
-                if not args.rotation
-                else [
-                    T.RandomHorizontalFlip(0.1),
-                    T.RandomApply(T.RandomCrop(), 0.2),
-                ]
-            )
-            + (
-                [
-                    T.Resize(args.input_size, preserve_aspect_ratio=True),
-                    T.RandomApply(T.RandomRotate(90, expand=True), 0.5),
-                    T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
-                ]
-                if args.rotation
-                else []
-            )
-        ),
+        img_transforms=img_transforms,
+        sample_transforms=sample_transforms,
         use_polygons=args.rotation,
     )
 

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -236,7 +236,7 @@ def main(args):
             [
                 T.RandomHorizontalFlip(0.15),
                 T.OneOf([
-                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.28),
+                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.25),
                     T.RandomResize(scale_range=(0.4, 0.9), p=0.25),
                 ]),
                 T.Resize((args.input_size, args.input_size), preserve_aspect_ratio=True, symmetric_pad=True),
@@ -245,7 +245,7 @@ def main(args):
             else [
                 T.RandomHorizontalFlip(0.15),
                 T.OneOf([
-                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.28),
+                    T.RandomApply(T.RandomCrop(ratio=(0.6, 1.33)), 0.25),
                     T.RandomResize(scale_range=(0.4, 0.9), p=0.25),
                 ]),
                 # Rotation augmentation

--- a/tests/common/test_transforms.py
+++ b/tests/common/test_transforms.py
@@ -21,6 +21,11 @@ def test_oneof():
     transfo = T.OneOf(transfos)
     out = transfo(1)
     assert out == 0 or out == 11
+    # test with target
+    transfos = [lambda x, y: (1 - x, y), lambda x, y: (x + 10, y)]
+    transfo = T.OneOf(transfos)
+    out = transfo(1, np.array([2]))
+    assert out == (0, 2) or out == (11, 2) and isinstance(out[1], np.ndarray)
 
 
 def test_randomapply():


### PR DESCRIPTION
This PR:

- Update det augmentations (more cleaner split now: general | handy/bad copy | diff light etc. | None) 
- Extend OneOf that it can also be used for sample augmentations
- Fix a small issue in RandomCrop 

Tested on a (22K train / 4k val) hf PDFA dataset subset with an general improve of ~ +4% recall +6% precision +3% iou (only as an initial state we need to see how it works on your dataset)

Any feedback is welcome :hugs: 