### PR TITLE
[Fix] close PIL images when loading images to tensor/numpy

### DIFF
--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -186,7 +186,8 @@ def crop_bboxes_from_image(img_path: Union[str, Path], geoms: np.ndarray) -> Lis
     -------
         a list of cropped images
     """
-    img: np.ndarray = np.array(Image.open(img_path).convert("RGB"))
+    with Image.open(img_path) as pil_img:
+        img: np.ndarray = np.array(pil_img.convert("RGB"))
     # Polygon
     if geoms.ndim == 3 and geoms.shape[1:] == (4, 2):
         return extract_rcrops(img, geoms.astype(dtype=int))

--- a/doctr/io/image/pytorch.py
+++ b/doctr/io/image/pytorch.py
@@ -51,9 +51,8 @@ def read_img_as_tensor(img_path: AbstractPath, dtype: torch.dtype = torch.float3
     if dtype not in (torch.uint8, torch.float16, torch.float32):
         raise ValueError("insupported value for dtype")
 
-    pil_img = Image.open(img_path, mode="r").convert("RGB")
-
-    return tensor_from_pil(pil_img, dtype)
+    with Image.open(img_path, mode="r") as pil_img:
+        return tensor_from_pil(pil_img.convert("RGB"), dtype)
 
 
 def decode_img_as_tensor(img_content: bytes, dtype: torch.dtype = torch.float32) -> torch.Tensor:
@@ -71,9 +70,8 @@ def decode_img_as_tensor(img_content: bytes, dtype: torch.dtype = torch.float32)
     if dtype not in (torch.uint8, torch.float16, torch.float32):
         raise ValueError("insupported value for dtype")
 
-    pil_img = Image.open(BytesIO(img_content), mode="r").convert("RGB")
-
-    return tensor_from_pil(pil_img, dtype)
+    with Image.open(BytesIO(img_content), mode="r") as pil_img:
+        return tensor_from_pil(pil_img.convert("RGB"), dtype)
 
 
 def tensor_from_numpy(npy_img: np.ndarray, dtype: torch.dtype = torch.float32) -> torch.Tensor:


### PR DESCRIPTION
The previous behavior opened PIL images, but didn't release their memory, causing a huge memory leak on our training pipeline.
With this PR, the PIL images will be closed immediately after the copy as numpy array or torch tensor is created.