### PR TITLE
feat: :sparkles: TF `mobilenet_v3_small_*_orientation` checkpoint

### DIFF
--- a/doctr/models/classification/mobilenet/tensorflow.py
+++ b/doctr/models/classification/mobilenet/tensorflow.py
@@ -58,16 +58,16 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
     "mobilenet_v3_small_crop_orientation": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
-        "input_shape": (128, 128, 3),
+        "input_shape": (256, 256, 3),
         "classes": [0, -90, 180, 90],
-        "url": "https://doctr-static.mindee.com/models?id=v0.4.1/classif_mobilenet_v3_small-1ea8db03.zip&src=0",
+        "url": "https://doctr-static.mindee.com/models?id=v0.8.1/mobilenet_v3_small_crop_orientation-d18168ee.zip&src=0",
     },
     "mobilenet_v3_small_page_orientation": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (512, 512, 3),
         "classes": [0, -90, 180, 90],
-        "url": None,
+        "url": "https://doctr-static.mindee.com/models?id=v0.8.1/mobilenet_v3_small_page_orientation-3beb9a43.zip&src=0",
     },
 }
 

--- a/tests/tensorflow/test_models_classification_tf.py
+++ b/tests/tensorflow/test_models_classification_tf.py
@@ -114,8 +114,6 @@ def test_crop_orientation_model(mock_text_box):
     assert all(isinstance(pred, float) for pred in classifier([text_box_0, text_box_270, text_box_180, text_box_90])[2])
 
 
-# TODO: uncomment when model is available
-"""
 def test_page_orientation_model(mock_payslip):
     text_box_0 = cv2.imread(mock_payslip)
     # rotates counter-clockwise
@@ -127,7 +125,6 @@ def test_page_orientation_model(mock_payslip):
     # 270 degrees is equivalent to -90 degrees
     assert classifier([text_box_0, text_box_270, text_box_180, text_box_90])[1] == [0, -90, 180, 90]
     assert all(isinstance(pred, float) for pred in classifier([text_box_0, text_box_270, text_box_180, text_box_90])[2])
-"""
 
 
 # temporarily fix to avoid killing the CI (tf2onnx v1.14 memory leak issue)


### PR DESCRIPTION
This PR includes TF checkpoints for these models:

- mobilenet_v3_small_crop_orientation
- mobilenet_v3_small_page_orientation

Also `test_page_orientation_model` has been enabled.