### PR TITLE
[builder] Add objectness scores

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -147,6 +147,7 @@ should yield
               0.9101580212741838,
               0.2080078125
             ],
+            "objectness_score": 0.5,
             "lines": [
               {
                 "geometry": [
@@ -155,6 +156,7 @@ should yield
                   0.9101580212741838,
                   0.2080078125
                 ],
+                "objectness_score": 0.5,
                 "words": [
                   {
                     "value": "Hello",
@@ -164,6 +166,7 @@ should yield
                       0.8272978149561669,
                       0.20703125
                     ],
+                    "objectness_score": 0.5,
                     "confidence": 1.0,
                     "crop_orientation": {"value": 0, "confidence": null}
                   },
@@ -175,6 +178,7 @@ should yield
                       0.9101580212741838,
                       0.2080078125
                     ],
+                    "objectness_score": 0.5,
                     "confidence": 1.0,
                     "crop_orientation": {"value": 0, "confidence": null}
                   }

--- a/api/app/routes/detection.py
+++ b/api/app/routes/detection.py
@@ -28,7 +28,8 @@ async def text_detection(request: DetectionIn = Depends(), files: List[UploadFil
         DetectionOut(
             name=filename,
             geometries=[
-                geom[:-1].tolist() if len(geom) == 5 else resolve_geometry(geom.tolist()) for geom in doc[CLASS_NAME]
+                geom[:-1].tolist() if geom.shape == (5,) else resolve_geometry(geom[:4].tolist())
+                for geom in doc[CLASS_NAME]
             ],
         )
         for doc, filename in zip(predictor(content), filenames)

--- a/api/app/routes/kie.py
+++ b/api/app/routes/kie.py
@@ -38,6 +38,7 @@ async def perform_kie(request: KIEIn = Depends(), files: List[UploadFile] = [Fil
                         dict(
                             value=prediction.value,
                             geometry=resolve_geometry(prediction.geometry),
+                            objectness_score=round(prediction.objectness_score, 2),
                             confidence=round(prediction.confidence, 2),
                             crop_orientation=prediction.crop_orientation,
                         )

--- a/api/app/routes/ocr.py
+++ b/api/app/routes/ocr.py
@@ -37,13 +37,16 @@ async def perform_ocr(request: OCRIn = Depends(), files: List[UploadFile] = [Fil
                     blocks=[
                         OCRBlock(
                             geometry=resolve_geometry(block.geometry),
+                            objectness_score=round(block.objectness_score, 2),
                             lines=[
                                 OCRLine(
                                     geometry=resolve_geometry(line.geometry),
+                                    objectness_score=round(line.objectness_score, 2),
                                     words=[
                                         OCRWord(
                                             value=word.value,
                                             geometry=resolve_geometry(word.geometry),
+                                            objectness_score=round(word.objectness_score, 2),
                                             confidence=round(word.confidence, 2),
                                             crop_orientation=word.crop_orientation,
                                         )

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -58,18 +58,21 @@ class DetectionOut(BaseModel):
 class OCRWord(BaseModel):
     value: str = Field(..., examples=["example"])
     geometry: List[float] = Field(..., examples=[[0.0, 0.0, 0.0, 0.0]])
+    objectness_score: float = Field(..., examples=[0.99])
     confidence: float = Field(..., examples=[0.99])
     crop_orientation: Dict[str, Any] = Field(..., examples=[{"value": 0, "confidence": None}])
 
 
 class OCRLine(BaseModel):
     geometry: List[float] = Field(..., examples=[[0.0, 0.0, 0.0, 0.0]])
+    objectness_score: float = Field(..., examples=[0.99])
     words: List[OCRWord] = Field(
         ...,
         examples=[
             {
                 "value": "example",
                 "geometry": [0.0, 0.0, 0.0, 0.0],
+                "objectness_score": 0.99,
                 "confidence": 0.99,
                 "crop_orientation": {"value": 0, "confidence": None},
             }
@@ -79,11 +82,13 @@ class OCRLine(BaseModel):
 
 class OCRBlock(BaseModel):
     geometry: List[float] = Field(..., examples=[[0.0, 0.0, 0.0, 0.0]])
+    objectness_score: float = Field(..., examples=[0.99])
     lines: List[OCRLine] = Field(
         ...,
         examples=[
             {
                 "geometry": [0.0, 0.0, 0.0, 0.0],
+                "objectness_score": 0.99,
                 "words": [
                     {
                         "value": "example",
@@ -103,13 +108,16 @@ class OCRPage(BaseModel):
         examples=[
             {
                 "geometry": [0.0, 0.0, 0.0, 0.0],
+                "objectness_score": 0.99,
                 "lines": [
                     {
                         "geometry": [0.0, 0.0, 0.0, 0.0],
+                        "objectness_score": 0.99,
                         "words": [
                             {
                                 "value": "example",
                                 "geometry": [0.0, 0.0, 0.0, 0.0],
+                                "objectness_score": 0.99,
                                 "confidence": 0.99,
                                 "crop_orientation": {"value": 0, "confidence": None},
                             }
@@ -131,13 +139,16 @@ class OCROut(BaseModel):
         examples=[
             {
                 "geometry": [0.0, 0.0, 0.0, 0.0],
+                "objectness_score": 0.99,
                 "lines": [
                     {
                         "geometry": [0.0, 0.0, 0.0, 0.0],
+                        "objectness_score": 0.99,
                         "words": [
                             {
                                 "value": "example",
                                 "geometry": [0.0, 0.0, 0.0, 0.0],
+                                "objectness_score": 0.99,
                                 "confidence": 0.99,
                                 "crop_orientation": {"value": 0, "confidence": None},
                             }
@@ -157,6 +168,7 @@ class KIEElement(BaseModel):
             {
                 "value": "example",
                 "geometry": [0.0, 0.0, 0.0, 0.0],
+                "objectness_score": 0.99,
                 "confidence": 0.99,
                 "crop_orientation": {"value": 0, "confidence": None},
             }

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -84,12 +84,14 @@ def mock_kie_response():
                         {
                             "value": "Hello",
                             "geometry": [0.7471996155154171, 0.1796875, 0.8272978149561669, 0.20703125],
+                            "objectness_score": 0.39,
                             "confidence": 1,
                             "crop_orientation": {"value": 0, "confidence": None},
                         },
                         {
                             "value": "world!",
                             "geometry": [0.8176307908857315, 0.1787109375, 0.9101580212741838, 0.2080078125],
+                            "objectness_score": 0.39,
                             "confidence": 1,
                             "crop_orientation": {"value": 0, "confidence": None},
                         },
@@ -118,6 +120,7 @@ def mock_kie_response():
                                 0.7470247745513916,
                                 0.20540954172611237,
                             ],
+                            "objectness_score": 0.5,
                             "confidence": 0.99,
                             "crop_orientation": {"value": 0, "confidence": 1},
                         },
@@ -133,6 +136,7 @@ def mock_kie_response():
                                 0.8173396587371826,
                                 0.20735852420330048,
                             ],
+                            "objectness_score": 0.5,
                             "confidence": 1,
                             "crop_orientation": {"value": 0, "confidence": 1},
                         },
@@ -156,13 +160,16 @@ def mock_ocr_response():
                     "blocks": [
                         {
                             "geometry": [0.7471996155154171, 0.1787109375, 0.9101580212741838, 0.2080078125],
+                            "objectness_score": 0.39,
                             "lines": [
                                 {
                                     "geometry": [0.7471996155154171, 0.1787109375, 0.9101580212741838, 0.2080078125],
+                                    "objectness_score": 0.39,
                                     "words": [
                                         {
                                             "value": "Hello",
                                             "geometry": [0.7471996155154171, 0.1796875, 0.8272978149561669, 0.20703125],
+                                            "objectness_score": 0.39,
                                             "confidence": 1,
                                             "crop_orientation": {"value": 0, "confidence": None},
                                         },
@@ -174,6 +181,7 @@ def mock_ocr_response():
                                                 0.9101580212741838,
                                                 0.2080078125,
                                             ],
+                                            "objectness_score": 0.39,
                                             "confidence": 1,
                                             "crop_orientation": {"value": 0, "confidence": None},
                                         },
@@ -204,6 +212,7 @@ def mock_ocr_response():
                                 0.7460724711418152,
                                 0.20930007100105286,
                             ],
+                            "objectness_score": 0.5,
                             "lines": [
                                 {
                                     "geometry": [
@@ -216,6 +225,7 @@ def mock_ocr_response():
                                         0.7460724711418152,
                                         0.20930007100105286,
                                     ],
+                                    "objectness_score": 0.5,
                                     "words": [
                                         {
                                             "value": "Hello",
@@ -229,6 +239,7 @@ def mock_ocr_response():
                                                 0.7470247745513916,
                                                 0.20540954172611237,
                                             ],
+                                            "objectness_score": 0.5,
                                             "confidence": 0.99,
                                             "crop_orientation": {"value": 0, "confidence": 1},
                                         },
@@ -244,6 +255,7 @@ def mock_ocr_response():
                                                 0.8173396587371826,
                                                 0.20735852420330048,
                                             ],
+                                            "objectness_score": 0.5,
                                             "confidence": 1,
                                             "crop_orientation": {"value": 0, "confidence": 1},
                                         },

--- a/api/tests/routes/test_kie.py
+++ b/api/tests/routes/test_kie.py
@@ -22,6 +22,7 @@ def common_test(json_response, expected_response):
             assert isinstance(pred_item["value"], str) and pred_item["value"] == expected_pred_item["value"]
             assert isinstance(pred_item["confidence"], (int, float))
             np.testing.assert_allclose(pred_item["geometry"], expected_pred_item["geometry"], rtol=1e-2)
+            assert isinstance(pred_item["objectness_score"], (int, float))
             assert isinstance(pred_item["crop_orientation"], dict)
             assert isinstance(pred_item["crop_orientation"]["value"], int) and isinstance(
                 pred_item["crop_orientation"]["confidence"], (float, int, type(None))

--- a/api/tests/routes/test_ocr.py
+++ b/api/tests/routes/test_ocr.py
@@ -14,10 +14,13 @@ def common_test(json_response, expected_response):
     for item, expected_item in zip(first_pred["items"], expected_response["items"]):
         for block, expected_block in zip(item["blocks"], expected_item["blocks"]):
             np.testing.assert_allclose(block["geometry"], expected_block["geometry"], rtol=1e-2)
+            assert isinstance(block["objectness_score"], (int, float))
             for line, expected_line in zip(block["lines"], expected_block["lines"]):
                 np.testing.assert_allclose(line["geometry"], expected_line["geometry"], rtol=1e-2)
+                assert isinstance(line["objectness_score"], (int, float))
                 for word, expected_word in zip(line["words"], expected_line["words"]):
                     np.testing.assert_allclose(word["geometry"], expected_word["geometry"], rtol=1e-2)
+                    assert isinstance(word["objectness_score"], (int, float))
                     assert isinstance(word["value"], str) and word["value"] == expected_word["value"]
                     assert isinstance(word["confidence"], (int, float))
                     assert isinstance(word["crop_orientation"], dict)

--- a/docs/source/using_doctr/using_models.rst
+++ b/docs/source/using_doctr/using_models.rst
@@ -378,18 +378,21 @@ For reference, here is the export for the same `Document` as above::
                                     'value': 'No.',
                                     'confidence': 0.914085328578949,
                                     'geometry': ((0.5478515625, 0.06640625), (0.5810546875, 0.0966796875)),
+                                    'objectness_score': 0.96,
                                     'crop_orientation': {'value': 0, 'confidence': None},
                                 },
                                 {
                                     'value': 'RECEIPT',
                                     'confidence': 0.9949972033500671,
                                     'geometry': ((0.1357421875, 0.0361328125), (0.51171875, 0.1630859375)),
+                                    'objectness_score': 0.99,
                                     'crop_orientation': {'value': 0, 'confidence': None},
                                 },
                                 {
                                     'value': 'DATE',
                                     'confidence': 0.9578408598899841,
                                     'geometry': ((0.1396484375, 0.3232421875), (0.185546875, 0.3515625)),
+                                    'objectness_score': 0.99,
                                     'crop_orientation': {'value': 0, 'confidence': None},
                                 }
                             ]

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -150,10 +150,11 @@ class DBPostProcessor(DetectionPostProcessor):
                     raise AssertionError("When assume straight pages is false a box is a (4, 2) array (polygon)")
                 _box[:, 0] /= width
                 _box[:, 1] /= height
-                boxes.append(_box)
+                # Add score to box as (0, score)
+                boxes.append(np.vstack([_box, np.array([0.0, score])]))
 
         if not self.assume_straight_pages:
-            return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 4, 2), dtype=pred.dtype)
+            return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 5, 2), dtype=pred.dtype)
         else:
             return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 5), dtype=pred.dtype)
 

--- a/doctr/models/detection/fast/base.py
+++ b/doctr/models/detection/fast/base.py
@@ -138,10 +138,11 @@ class FASTPostProcessor(DetectionPostProcessor):
                 # compute relative box to get rid of img shape
                 _box[:, 0] /= width
                 _box[:, 1] /= height
-                boxes.append(_box)
+                # Add score to box as (0, score)
+                boxes.append(np.vstack([_box, np.array([0.0, score])]))
 
         if not self.assume_straight_pages:
-            return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 4, 2), dtype=pred.dtype)
+            return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 5, 2), dtype=pred.dtype)
         else:
             return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 5), dtype=pred.dtype)
 

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -138,10 +138,11 @@ class LinkNetPostProcessor(DetectionPostProcessor):
                 # compute relative box to get rid of img shape
                 _box[:, 0] /= width
                 _box[:, 1] /= height
-                boxes.append(_box)
+                # Add score to box as (0, score)
+                boxes.append(np.vstack([_box, np.array([0.0, score])]))
 
         if not self.assume_straight_pages:
-            return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 4, 2), dtype=pred.dtype)
+            return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 5, 2), dtype=pred.dtype)
         else:
             return np.clip(np.asarray(boxes), 0, 1) if len(boxes) > 0 else np.zeros((0, 5), dtype=pred.dtype)
 

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -12,7 +12,7 @@ from doctr.io.elements import Document
 from doctr.models._utils import estimate_orientation, get_language, invert_data_structure
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
-from doctr.utils.geometry import rotate_image
+from doctr.utils.geometry import detach_scores, rotate_image
 from doctr.utils.repr import NestedObject
 
 from .base import _KIEPredictor
@@ -101,6 +101,16 @@ class KIEPredictor(NestedObject, _KIEPredictor):
 
         dict_loc_preds: Dict[str, List[np.ndarray]] = invert_data_structure(loc_preds)  # type: ignore
 
+        # Detach objectness scores from loc_preds
+        objectness_scores = {}
+        for class_name, det_preds in dict_loc_preds.items():
+            _loc_preds, _scores = detach_scores(det_preds)
+            dict_loc_preds[class_name] = _loc_preds
+            objectness_scores[class_name] = _scores
+
+        # Rectify crops if aspect ratio
+        dict_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()}
+
         # Apply hooks to loc_preds if any
         for hook in self.hooks:
             dict_loc_preds = hook(dict_loc_preds)
@@ -140,6 +150,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
             )
 
         boxes_per_page: List[Dict] = invert_data_structure(boxes)  # type: ignore[assignment]
+        objectness_scores_per_page: List[Dict] = invert_data_structure(objectness_scores)  # type: ignore[assignment]
         text_preds_per_page: List[Dict] = invert_data_structure(text_preds)  # type: ignore[assignment]
         crop_orientations_per_page: List[Dict] = invert_data_structure(word_crop_orientations)  # type: ignore[assignment]
 
@@ -152,6 +163,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
         out = self.doc_builder(
             pages,
             boxes_per_page,
+            objectness_scores_per_page,
             text_preds_per_page,
             origin_page_shapes,  # type: ignore[arg-type]
             crop_orientations_per_page,

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -108,9 +108,6 @@ class KIEPredictor(NestedObject, _KIEPredictor):
             dict_loc_preds[class_name] = _loc_preds
             objectness_scores[class_name] = _scores
 
-        # Rectify crops if aspect ratio
-        dict_loc_preds = {k: self._remove_padding(pages, loc_pred) for k, loc_pred in dict_loc_preds.items()}
-
         # Apply hooks to loc_preds if any
         for hook in self.hooks:
             dict_loc_preds = hook(dict_loc_preds)

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -13,7 +13,7 @@ from doctr.io.elements import Document
 from doctr.models._utils import estimate_orientation, get_language
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.recognition.predictor import RecognitionPredictor
-from doctr.utils.geometry import rotate_image
+from doctr.utils.geometry import detach_scores, rotate_image
 
 from .base import _OCRPredictor
 
@@ -102,6 +102,8 @@ class OCRPredictor(nn.Module, _OCRPredictor):
         ), "Detection Model in ocr_predictor should output only one class"
 
         loc_preds = [list(loc_pred.values())[0] for loc_pred in loc_preds]
+        # Detach objectness scores from loc_preds
+        loc_preds, objectness_scores = detach_scores(loc_preds)
         # Check whether crop mode should be switched to channels first
         channels_last = len(pages) == 0 or isinstance(pages[0], np.ndarray)
 
@@ -140,6 +142,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
         out = self.doc_builder(
             pages,  # type: ignore[arg-type]
             boxes,
+            objectness_scores,
             text_preds,
             origin_page_shapes,  # type: ignore[arg-type]
             crop_orientations,

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -25,6 +25,7 @@ __all__ = [
     "rotate_abs_geoms",
     "extract_crops",
     "extract_rcrops",
+    "detach_scores",
 ]
 
 
@@ -57,6 +58,28 @@ def polygon_to_bbox(polygon: Polygon4P) -> BoundingBox:
     return (min(x), min(y)), (max(x), max(y))
 
 
+def detach_scores(boxes: List[np.ndarray]) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    """Detach the objectness scores from box predictions
+
+    Args:
+    ----
+        boxes: list of arrays with boxes of shape (N, 5) or (N, 5, 2)
+
+    Returns:
+    -------
+        a tuple of two lists: the first one contains the boxes without the objectness scores,
+        the second one contains the objectness scores
+    """
+
+    def _detach(boxes: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        if boxes.ndim == 2:
+            return boxes[:, :-1], boxes[:, -1]
+        return boxes[:, :-1], boxes[:, -1, -1]
+
+    loc_preds, obj_scores = zip(*(_detach(box) for box in boxes))
+    return list(loc_preds), list(obj_scores)
+
+
 def resolve_enclosing_bbox(bboxes: Union[List[BoundingBox], np.ndarray]) -> Union[BoundingBox, np.ndarray]:
     """Compute enclosing bbox either from:
 
@@ -64,18 +87,18 @@ def resolve_enclosing_bbox(bboxes: Union[List[BoundingBox], np.ndarray]) -> Unio
     ----
         bboxes: boxes in one of the following formats:
 
-            - an array of boxes: (*, 5), where boxes have this shape:
-            (xmin, ymin, xmax, ymax, score)
+            - an array of boxes: (*, 4), where boxes have this shape:
+            (xmin, ymin, xmax, ymax)
 
             - a list of BoundingBox
 
     Returns:
     -------
-        a (1, 5) array (enclosing boxarray), or a BoundingBox
+        a (1, 4) array (enclosing boxarray), or a BoundingBox
     """
     if isinstance(bboxes, np.ndarray):
-        xmin, ymin, xmax, ymax, score = np.split(bboxes, 5, axis=1)
-        return np.array([xmin.min(), ymin.min(), xmax.max(), ymax.max(), score.mean()])
+        xmin, ymin, xmax, ymax = np.split(bboxes, 4, axis=1)
+        return np.array([xmin.min(), ymin.min(), xmax.max(), ymax.max()])
     else:
         x, y = zip(*[point for box in bboxes for point in box])
         return (min(x), min(y)), (max(x), max(y))
@@ -88,15 +111,15 @@ def resolve_enclosing_rbbox(rbboxes: List[np.ndarray], intermed_size: int = 1024
     ----
         rbboxes: boxes in one of the following formats:
 
-            - an array of boxes: (*, 5), where boxes have this shape:
-            (xmin, ymin, xmax, ymax, score)
+            - an array of boxes: (*, 4, 2), where boxes have this shape:
+            (x1, y1), (x2, y2), (x3, y3), (x4, y4)
 
             - a list of BoundingBox
         intermed_size: size of the intermediate image
 
     Returns:
     -------
-        a (1, 5) array (enclosing boxarray), or a BoundingBox
+        a (4, 2) array (enclosing rotated box)
     """
     cloud: np.ndarray = np.concatenate(rbboxes, axis=0)
     # Convert to absolute for minAreaRect
@@ -232,7 +255,7 @@ def rotate_boxes(
 
     Args:
     ----
-        loc_preds: (N, 5) or (N, 4, 2) array of RELATIVE boxes
+        loc_preds: (N, 4) or (N, 4, 2) array of RELATIVE boxes
         angle: angle between -90 and +90 degrees
         orig_shape: shape of the origin image
         min_angle: minimum angle to rotate boxes

--- a/tests/common/test_io_elements.py
+++ b/tests/common/test_io_elements.py
@@ -7,18 +7,20 @@ from doctr.file_utils import CLASS_NAME
 from doctr.io import elements
 
 
-def _mock_words(size=(1.0, 1.0), offset=(0, 0), confidence=0.9):
+def _mock_words(size=(1.0, 1.0), offset=(0, 0), confidence=0.9, objectness_score=0.9):
     return [
         elements.Word(
             "hello",
             confidence,
             ((offset[0], offset[1]), (size[0] / 2 + offset[0], size[1] / 2 + offset[1])),
+            objectness_score,
             {"value": 0, "confidence": None},
         ),
         elements.Word(
             "world",
             confidence,
             ((size[0] / 2 + offset[0], size[1] / 2 + offset[1]), (size[0] + offset[0], size[1] + offset[1])),
+            objectness_score,
             {"value": 0, "confidence": None},
         ),
     ]
@@ -46,18 +48,20 @@ def _mock_lines(size=(1, 1), offset=(0, 0)):
     ]
 
 
-def _mock_prediction(size=(1.0, 1.0), offset=(0, 0), confidence=0.9):
+def _mock_prediction(size=(1.0, 1.0), offset=(0, 0), confidence=0.9, objectness_score=0.9):
     return [
         elements.Prediction(
             "hello",
             confidence,
             ((offset[0], offset[1]), (size[0] / 2 + offset[0], size[1] / 2 + offset[1])),
+            objectness_score,
             {"value": 0, "confidence": None},
         ),
         elements.Prediction(
             "world",
             confidence,
             ((size[0] / 2 + offset[0], size[1] / 2 + offset[1]), (size[0] + offset[0], size[1] + offset[1])),
+            objectness_score,
             {"value": 0, "confidence": None},
         ),
     ]
@@ -127,14 +131,16 @@ def test_element():
 def test_word():
     word_str = "hello"
     conf = 0.8
+    objectness_score = 0.9
     geom = ((0, 0), (1, 1))
     crop_orientation = {"value": 0, "confidence": None}
-    word = elements.Word(word_str, conf, geom, crop_orientation)
+    word = elements.Word(word_str, conf, geom, objectness_score, crop_orientation)
 
     # Attribute checks
     assert word.value == word_str
     assert word.confidence == conf
     assert word.geometry == geom
+    assert word.objectness_score == objectness_score
     assert word.crop_orientation == crop_orientation
 
     # Render
@@ -145,6 +151,7 @@ def test_word():
         "value": word_str,
         "confidence": conf,
         "geometry": geom,
+        "objectness_score": objectness_score,
         "crop_orientation": crop_orientation,
     }
 
@@ -156,6 +163,7 @@ def test_word():
         "value": "there",
         "confidence": 0.1,
         "geometry": ((0, 0), (0.5, 0.5)),
+        "objectness_score": objectness_score,
         "crop_orientation": crop_orientation,
     }
     word = elements.Word.from_dict(state_dict)
@@ -164,6 +172,7 @@ def test_word():
 
 def test_line():
     geom = ((0, 0), (0.5, 0.5))
+    objectness_score = 0.9
     words = _mock_words(size=geom[1], offset=geom[0])
     line = elements.Line(words)
 
@@ -171,12 +180,17 @@ def test_line():
     assert len(line.words) == len(words)
     assert all(isinstance(w, elements.Word) for w in line.words)
     assert line.geometry == geom
+    assert line.objectness_score == objectness_score
 
     # Render
     assert line.render() == "hello world"
 
     # Export
-    assert line.export() == {"words": [w.export() for w in words], "geometry": geom}
+    assert line.export() == {
+        "words": [w.export() for w in words],
+        "geometry": geom,
+        "objectness_score": objectness_score,
+    }
 
     # Repr
     words_str = " " * 4 + ",\n    ".join(repr(word) for word in words) + ","
@@ -192,10 +206,12 @@ def test_line():
                 "value": "there",
                 "confidence": 0.1,
                 "geometry": ((0, 0), (1.0, 1.0)),
+                "objectness_score": objectness_score,
                 "crop_orientation": {"value": 0, "confidence": None},
             }
         ],
         "geometry": ((0, 0), (1.0, 1.0)),
+        "objectness_score": objectness_score,
     }
     line = elements.Line.from_dict(state_dict)
     assert line.export() == state_dict
@@ -226,13 +242,15 @@ def test_prediction():
     prediction_str = "hello"
     conf = 0.8
     geom = ((0, 0), (1, 1))
+    objectness_score = 0.9
     crop_orientation = {"value": 0, "confidence": None}
-    prediction = elements.Prediction(prediction_str, conf, geom, crop_orientation)
+    prediction = elements.Prediction(prediction_str, conf, geom, objectness_score, crop_orientation)
 
     # Attribute checks
     assert prediction.value == prediction_str
     assert prediction.confidence == conf
     assert prediction.geometry == geom
+    assert prediction.objectness_score == objectness_score
     assert prediction.crop_orientation == crop_orientation
 
     # Render
@@ -243,6 +261,7 @@ def test_prediction():
         "value": prediction_str,
         "confidence": conf,
         "geometry": geom,
+        "objectness_score": objectness_score,
         "crop_orientation": crop_orientation,
     }
 
@@ -254,6 +273,7 @@ def test_prediction():
         "value": "there",
         "confidence": 0.1,
         "geometry": ((0, 0), (0.5, 0.5)),
+        "objectness_score": 0.9,
         "crop_orientation": crop_orientation,
     }
     prediction = elements.Prediction.from_dict(state_dict)
@@ -263,6 +283,7 @@ def test_prediction():
 def test_block():
     geom = ((0, 0), (1, 1))
     sub_size = (geom[1][0] / 2, geom[1][0] / 2)
+    objectness_score = 0.9
     lines = _mock_lines(size=sub_size, offset=geom[0])
     artefacts = _mock_artefacts(size=sub_size, offset=sub_size)
     block = elements.Block(lines, artefacts)
@@ -282,6 +303,7 @@ def test_block():
         "lines": [line.export() for line in lines],
         "artefacts": [artefact.export() for artefact in artefacts],
         "geometry": geom,
+        "objectness_score": objectness_score,
     }
 
 

--- a/tests/common/test_models_builder.py
+++ b/tests/common/test_models_builder.py
@@ -23,11 +23,13 @@ def test_documentbuilder():
     pages = [np.zeros((100, 200, 3))] * num_pages
     boxes = np.random.rand(words_per_page, 6)  # array format
     boxes[:2] *= boxes[2:4]
+    objectness_scores = np.array([0.9] * words_per_page)
     # Arg consistency check
     with pytest.raises(ValueError):
         doc_builder(
             pages,
             [boxes, boxes],
+            [objectness_scores, objectness_scores],
             [("hello", 1.0)] * 3,
             [(100, 200), (100, 200)],
             [{"value": 0, "confidence": None}] * 3,
@@ -35,6 +37,7 @@ def test_documentbuilder():
     out = doc_builder(
         pages,
         [boxes, boxes],
+        [objectness_scores, objectness_scores],
         [[("hello", 1.0)] * words_per_page] * num_pages,
         [(100, 200), (100, 200)],
         [[{"value": 0, "confidence": None}] * words_per_page] * num_pages,
@@ -53,14 +56,18 @@ def test_documentbuilder():
     out = doc_builder(
         pages,
         [boxes, boxes],
+        [objectness_scores, objectness_scores],
         [[("hello", 1.0)] * words_per_page] * num_pages,
         [(100, 200), (100, 200)],
         [[{"value": 0, "confidence": None}] * words_per_page] * num_pages,
     )
 
     # No detection
-    boxes = np.zeros((0, 5))
-    out = doc_builder(pages, [boxes, boxes], [[], []], [(100, 200), (100, 200)], [[]])
+    boxes = np.zeros((0, 4))
+    objectness_scores = np.zeros([0])
+    out = doc_builder(
+        pages, [boxes, boxes], [objectness_scores, objectness_scores], [[], []], [(100, 200), (100, 200)], [[]]
+    )
     assert len(out.pages[0].blocks) == 0
 
     # Rotated boxes to export as straight boxes
@@ -68,15 +75,18 @@ def test_documentbuilder():
         [[0.1, 0.1], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15]],
         [[0.5, 0.5], [0.6, 0.6], [0.55, 0.65], [0.45, 0.55]],
     ])
+    objectness_scores = np.array([0.99, 0.99])
     doc_builder_2 = builder.DocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
     out = doc_builder_2(
         [np.zeros((100, 100, 3))],
         [boxes],
+        [objectness_scores],
         [[("hello", 0.99), ("word", 0.99)]],
         [(100, 100)],
         [[{"value": 0, "confidence": None}] * 2],
     )
     assert out.pages[0].blocks[0].lines[0].words[-1].geometry == ((0.45, 0.5), (0.6, 0.65))
+    assert out.pages[0].blocks[0].lines[0].words[-1].objectness_score == 0.99
 
     # Repr
     assert (
@@ -93,11 +103,13 @@ def test_kiedocumentbuilder():
     pages = [np.zeros((100, 200, 3))] * num_pages
     predictions = {CLASS_NAME: np.random.rand(words_per_page, 6)}  # dict format
     predictions[CLASS_NAME][:2] *= predictions[CLASS_NAME][2:4]
+    objectness_scores = {CLASS_NAME: np.array([0.9] * words_per_page)}
     # Arg consistency check
     with pytest.raises(ValueError):
         doc_builder(
             pages,
             [predictions, predictions],
+            [objectness_scores, objectness_scores],
             [{CLASS_NAME: ("hello", 1.0)}] * 3,
             [(100, 200), (100, 200)],
             [{CLASS_NAME: [{"value": 0, "confidence": None}] * 3}],
@@ -105,6 +117,7 @@ def test_kiedocumentbuilder():
     out = doc_builder(
         pages,
         [predictions, predictions],
+        [objectness_scores, objectness_scores],
         [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages,
         [(100, 200), (100, 200)],
         [{CLASS_NAME: [{"value": 0, "confidence": None}] * words_per_page}] * num_pages,
@@ -123,16 +136,20 @@ def test_kiedocumentbuilder():
     out = doc_builder(
         pages,
         [predictions, predictions],
+        [objectness_scores, objectness_scores],
         [{CLASS_NAME: [("hello", 1.0)] * words_per_page}] * num_pages,
         [(100, 200), (100, 200)],
         [{CLASS_NAME: [{"value": 0, "confidence": None}] * words_per_page}] * num_pages,
     )
 
     # No detection
-    predictions = {CLASS_NAME: np.zeros((0, 5))}
+    predictions = {CLASS_NAME: np.zeros((0, 4))}
+    objectness_scores = {CLASS_NAME: np.zeros((1))}
+
     out = doc_builder(
         pages,
         [predictions, predictions],
+        [objectness_scores, objectness_scores],
         [{CLASS_NAME: []}, {CLASS_NAME: []}],
         [(100, 200), (100, 200)],
         [{CLASS_NAME: []}, {CLASS_NAME: []}],
@@ -146,16 +163,19 @@ def test_kiedocumentbuilder():
             [[0.5, 0.5], [0.6, 0.6], [0.55, 0.65], [0.45, 0.55]],
         ])
     }
+    objectness_scores = {CLASS_NAME: np.array([0.99, 0.99])}
     doc_builder_2 = builder.KIEDocumentBuilder(resolve_blocks=False, resolve_lines=False, export_as_straight_boxes=True)
     out = doc_builder_2(
         [np.zeros((100, 100, 3))],
         [predictions],
+        [objectness_scores],
         [{CLASS_NAME: [("hello", 0.99), ("word", 0.99)]}],
         [(100, 100)],
         [{CLASS_NAME: [{"value": 0, "confidence": None}] * 2}],
     )
     assert out.pages[0].predictions[CLASS_NAME][0].geometry == ((0.05, 0.1), (0.2, 0.25))
     assert out.pages[0].predictions[CLASS_NAME][1].geometry == ((0.45, 0.5), (0.6, 0.65))
+    assert out.pages[0].predictions[CLASS_NAME][1].objectness_score == 0.99
 
     # Repr
     assert (

--- a/tests/common/test_models_detection.py
+++ b/tests/common/test_models_detection.py
@@ -19,7 +19,7 @@ def test_dbpostprocessor():
     assert len(out) == 2
     assert all(isinstance(sample, list) and all(isinstance(v, np.ndarray) for v in sample) for sample in out)
     assert all(all(v.shape[1] == 5 for v in sample) for sample in out)
-    assert all(all(v.shape[1] == 4 and v.shape[2] == 2 for v in sample) for sample in r_out)
+    assert all(all(v.shape[1] == 5 and v.shape[2] == 2 for v in sample) for sample in r_out)
     # Relative coords
     assert all(all(np.all(np.logical_and(v[:, :4] >= 0, v[:, :4] <= 1)) for v in sample) for sample in out)
     assert all(all(np.all(np.logical_and(v[:, :4] >= 0, v[:, :4] <= 1)) for v in sample) for sample in r_out)
@@ -75,7 +75,7 @@ def test_linknet_postprocessor():
     assert len(out) == 2
     assert all(isinstance(sample, list) and all(isinstance(v, np.ndarray) for v in sample) for sample in out)
     assert all(all(v.shape[1] == 5 for v in sample) for sample in out)
-    assert all(all(v.shape[1] == 4 and v.shape[2] == 2 for v in sample) for sample in r_out)
+    assert all(all(v.shape[1] == 5 and v.shape[2] == 2 for v in sample) for sample in r_out)
     # Relative coords
     assert all(all(np.all(np.logical_and(v[:4] >= 0, v[:4] <= 1)) for v in sample) for sample in out)
 
@@ -93,6 +93,6 @@ def test_fast_postprocessor():
     assert len(out) == 2
     assert all(isinstance(sample, list) and all(isinstance(v, np.ndarray) for v in sample) for sample in out)
     assert all(all(v.shape[1] == 5 for v in sample) for sample in out)
-    assert all(all(v.shape[1] == 4 and v.shape[2] == 2 for v in sample) for sample in r_out)
+    assert all(all(v.shape[1] == 5 and v.shape[2] == 2 for v in sample) for sample in r_out)
     # Relative coords
     assert all(all(np.all(np.logical_and(v[:4] >= 0, v[:4] <= 1)) for v in sample) for sample in out)

--- a/tests/common/test_utils_geometry.py
+++ b/tests/common/test_utils_geometry.py
@@ -16,10 +16,31 @@ def test_polygon_to_bbox():
     assert geometry.polygon_to_bbox(((0, 0), (1, 0), (0, 1), (1, 1))) == ((0, 0), (1, 1))
 
 
+def test_detach_scores():
+    # box test
+    boxes = np.array([[0.1, 0.1, 0.2, 0.2, 0.9], [0.15, 0.15, 0.2, 0.2, 0.8]])
+    pred = geometry.detach_scores([boxes])
+    target1 = np.array([[0.1, 0.1, 0.2, 0.2], [0.15, 0.15, 0.2, 0.2]])
+    target2 = np.array([0.9, 0.8])
+    assert np.all(pred[0] == target1) and np.all(pred[1] == target2)
+    # polygon test
+    boxes = np.array([
+        [[0.1, 0.1], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15], [0.0, 0.9]],
+        [[0.15, 0.15], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15], [0.0, 0.8]],
+    ])
+    pred = geometry.detach_scores([boxes])
+    target1 = np.array([
+        [[0.1, 0.1], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15]],
+        [[0.15, 0.15], [0.2, 0.2], [0.15, 0.25], [0.05, 0.15]],
+    ])
+    target2 = np.array([0.9, 0.8])
+    assert np.all(pred[0] == target1) and np.all(pred[1] == target2)
+
+
 def test_resolve_enclosing_bbox():
     assert geometry.resolve_enclosing_bbox([((0, 0.5), (1, 0)), ((0.5, 0), (1, 0.25))]) == ((0, 0), (1, 0.5))
-    pred = geometry.resolve_enclosing_bbox(np.array([[0.1, 0.1, 0.2, 0.2, 0.9], [0.15, 0.15, 0.2, 0.2, 0.8]]))
-    assert pred.all() == np.array([0.1, 0.1, 0.2, 0.2, 0.85]).all()
+    pred = geometry.resolve_enclosing_bbox(np.array([[0.1, 0.1, 0.2, 0.2], [0.15, 0.15, 0.2, 0.2]]))
+    assert pred.all() == np.array([0.1, 0.1, 0.2, 0.2]).all()
 
 
 def test_resolve_enclosing_rbbox():


### PR DESCRIPTION
This PR:

- unify detection predictor output (N, 5) / (N, 5, 2)  --> last is objectness_score
- add objectness score to Document output
- update API template
- update docs
- add corresponding tests

Use case: enables the end user to filter out some detected artefacts for example

Any feedback is welcome :hugs: 

NOTE: API tests will fail until merged :)

Related to: #1612 