### PR TITLE
[builder] disable resolve blocks by default

### DIFF
--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -25,7 +25,7 @@ class KIEIn(BaseModel):
 
 class OCRIn(KIEIn, BaseModel):
     resolve_lines: bool = Field(default=True, examples=[True])
-    resolve_blocks: bool = Field(default=True, examples=[True])
+    resolve_blocks: bool = Field(default=False, examples=[False])
     paragraph_break: float = Field(default=0.0035, examples=[0.0035])
 
 

--- a/docs/source/using_doctr/using_models.rst
+++ b/docs/source/using_doctr/using_models.rst
@@ -311,7 +311,7 @@ Additionally, you can change the batch size of the underlying detection and reco
 To modify the output structure you can pass the following arguments to the predictor which will be handled by the underlying `DocumentBuilder`:
 
 * `resolve_lines`: whether words should be automatically grouped into lines (default: True)
-* `resolve_blocks`: whether lines should be automatically grouped into blocks (default: True)
+* `resolve_blocks`: whether lines should be automatically grouped into blocks (default: False)
 * `paragraph_break`: relative length of the minimum space separating paragraphs (default: 0.035)
 
 For example to disable the automatic grouping of lines into blocks:

--- a/doctr/models/builder.py
+++ b/doctr/models/builder.py
@@ -31,7 +31,7 @@ class DocumentBuilder(NestedObject):
     def __init__(
         self,
         resolve_lines: bool = True,
-        resolve_blocks: bool = True,
+        resolve_blocks: bool = False,
         paragraph_break: float = 0.035,
         export_as_straight_boxes: bool = False,
     ) -> None:

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -182,6 +182,8 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         straighten_pages=straighten_pages,
         detect_orientation=True,
         detect_language=True,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
 
     if assume_straight_pages:

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -103,6 +103,8 @@ def test_trained_ocr_predictor(mock_payslip):
         assume_straight_pages=True,
         straighten_pages=True,
         preserve_aspect_ratio=False,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
 
     out = predictor(doc)
@@ -131,6 +133,8 @@ def test_trained_ocr_predictor(mock_payslip):
         straighten_pages=True,
         preserve_aspect_ratio=True,
         symmetric_pad=True,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
     # test hooks
     predictor.add_hook(_DummyCallback())
@@ -221,6 +225,8 @@ def test_trained_kie_predictor(mock_payslip):
         assume_straight_pages=True,
         straighten_pages=True,
         preserve_aspect_ratio=False,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
     # test hooks
     predictor.add_hook(_DummyCallback())
@@ -252,6 +258,8 @@ def test_trained_kie_predictor(mock_payslip):
         straighten_pages=True,
         preserve_aspect_ratio=True,
         symmetric_pad=True,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
 
     out = predictor(doc)

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -102,6 +102,8 @@ def test_trained_ocr_predictor(mock_payslip):
         assume_straight_pages=True,
         straighten_pages=True,
         preserve_aspect_ratio=False,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
     # test hooks
     predictor.add_hook(_DummyCallback())
@@ -132,6 +134,8 @@ def test_trained_ocr_predictor(mock_payslip):
         straighten_pages=True,
         preserve_aspect_ratio=True,
         symmetric_pad=True,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
 
     out = predictor(doc)
@@ -174,6 +178,8 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         straighten_pages=straighten_pages,
         detect_orientation=True,
         detect_language=True,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
 
     if assume_straight_pages:
@@ -219,6 +225,8 @@ def test_trained_kie_predictor(mock_payslip):
         assume_straight_pages=True,
         straighten_pages=True,
         preserve_aspect_ratio=False,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
     # test hooks
     predictor.add_hook(_DummyCallback())
@@ -250,6 +258,8 @@ def test_trained_kie_predictor(mock_payslip):
         straighten_pages=True,
         preserve_aspect_ratio=True,
         symmetric_pad=True,
+        resolve_blocks=True,
+        resolve_lines=True,
     )
 
     out = predictor(doc)


### PR DESCRIPTION
**soft breaking change**

This PR:

- disable resolving blocks by default

resolving blocks doesn't works well in the most cases and leads to confiusion by users .. so i suggest to set it to False ftm. --> fixes also the `.render()` issue in a temp state --> lines are sorted correct

Additional:
There are some options for clustering:  DBSCAN / HDBSCAN / (OPTICS ?) seems to be more valuable algorithms #1586 instead of the h-clustering we use actual from scipy

scikit-learn / HDBSCAN (https://github.com/scikit-learn-contrib/hdbscan)

@odulcy-mindee wdyt ?
CC @frgfm @charlesmindee 