### PR TITLE
Fixed assume_straight_pages for custom models

### DIFF
--- a/doctr/models/detection/zoo.py
+++ b/doctr/models/detection/zoo.py
@@ -61,6 +61,7 @@ def _predictor(arch: Any, pretrained: bool, assume_straight_pages: bool = True, 
 
         _model = arch
         _model.assume_straight_pages = assume_straight_pages
+        _model.postprocessor.assume_straight_pages = assume_straight_pages
 
     kwargs.pop("pretrained_backbone", None)
 


### PR DESCRIPTION
When loading a custom model using `ocr_predictor` with `assume_straight_pages = False`, the preprocessor will be initialized with `assume_straight_pages = True`, resulting in a crash. This behavior happens in any custom detection models.
Example with the default db_resnet50:
```python
from doctr.models import ocr_predictor, db_resnet50
from torch import load
from cv2 import imread

det_arch = db_resnet50(pretrained=False, pretrained_backbone=False)
params = load("db_resnet50-79bd7d70.pt", map_location="cpu")
det_arch.load_state_dict(params)

reader = ocr_predictor(det_arch=det_arch, assume_straight_pages=False)

img = imread("<img>")
print(
    reader([img])
)  # => IndexError: too many indices for array: array is 2-dimensional, but 3 were indexed

```