### PR TITLE
[datasets] Allow detection task for built-in datasets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ quality:
 
 # this target runs checks on all files and potentially modifies some of them
 style:
-	ruff check --fix .
 	ruff format .
+	ruff check --fix .
 
 # Run tests for the library
 test:

--- a/docs/source/using_doctr/using_datasets.rst
+++ b/docs/source/using_doctr/using_datasets.rst
@@ -48,9 +48,9 @@ This datasets contains the information to train or validate a text detection mod
 
     from doctr.datasets import CORD
     # Load straight boxes
-    train_set = CORD(train=True, download=True)
+    train_set = CORD(train=True, download=True, detection_task=True)
     # Load rotated boxes
-    train_set = CORD(train=True, download=True, use_polygons=True)
+    train_set = CORD(train=True, download=True, use_polygons=True, detection_task=True)
     img, target = train_set[0]
 
 
@@ -96,6 +96,21 @@ This datasets contains the information to train or validate a text recognition m
     train_set = CORD(train=True, download=True, recognition_task=True)
     # Crop rotated boxes (always regular)
     train_set = CORD(train=True, download=True, use_polygons=True, recognition_task=True)
+    img, target = train_set[0]
+
+
+OCR
+^^^
+
+The same dataset table as for detection, but with information about the bounding boxes and labels.
+
+.. code:: python3
+
+    from doctr.datasets import CORD
+    # Load straight boxes
+    train_set = CORD(train=True, download=True)
+    # Load rotated boxes
+    train_set = CORD(train=True, download=True, use_polygons=True)
     img, target = train_set[0]
 
 

--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -68,8 +68,8 @@ class CORD(VisionDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         # List images

--- a/doctr/datasets/cord.py
+++ b/doctr/datasets/cord.py
@@ -33,6 +33,7 @@ class CORD(VisionDataset):
         train: whether the subset should be the training one
         use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
         recognition_task: whether the dataset should be used for recognition task
+        detection_task: whether the dataset should be used for detection task
         **kwargs: keyword arguments from `VisionDataset`.
     """
 
@@ -53,6 +54,7 @@ class CORD(VisionDataset):
         train: bool = True,
         use_polygons: bool = False,
         recognition_task: bool = False,
+        detection_task: bool = False,
         **kwargs: Any,
     ) -> None:
         url, sha256, name = self.TRAIN if train else self.TEST
@@ -64,10 +66,15 @@ class CORD(VisionDataset):
             pre_transforms=convert_target_to_relative if not recognition_task else None,
             **kwargs,
         )
+        if recognition_task and detection_task:
+            raise ValueError(
+                "recognition_task and detection_task cannot be set to True simultaneously "
+                + "to get the whole dataset with boxes and labels leave both to False"
+            )
 
         # List images
         tmp_root = os.path.join(self.root, "image")
-        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any]]]] = []
+        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any], np.ndarray]]] = []
         self.train = train
         np_dtype = np.float32
         for img_path in tqdm(iterable=os.listdir(tmp_root), desc="Unpacking CORD", total=len(os.listdir(tmp_root))):
@@ -109,6 +116,8 @@ class CORD(VisionDataset):
                 )
                 for crop, label in zip(crops, list(text_targets)):
                     self.data.append((crop, label))
+            elif detection_task:
+                self.data.append((img_path, np.asarray(box_targets, dtype=int).clip(min=0)))
             else:
                 self.data.append((
                     img_path,

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -129,4 +129,6 @@ class _VisionDataset(_AbstractDataset):
             if not dataset_path.is_dir() or overwrite:
                 shutil.unpack_archive(archive_path, dataset_path)
 
+        print(kwargs)
+
         super().__init__(dataset_path if extract_archive else archive_path, **kwargs)

--- a/doctr/datasets/datasets/base.py
+++ b/doctr/datasets/datasets/base.py
@@ -129,6 +129,4 @@ class _VisionDataset(_AbstractDataset):
             if not dataset_path.is_dir() or overwrite:
                 shutil.unpack_archive(archive_path, dataset_path)
 
-        print(kwargs)
-
         super().__init__(dataset_path if extract_archive else archive_path, **kwargs)

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -33,6 +33,7 @@ class FUNSD(VisionDataset):
         train: whether the subset should be the training one
         use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
         recognition_task: whether the dataset should be used for recognition task
+        detection_task: whether the dataset should be used for detection task
         **kwargs: keyword arguments from `VisionDataset`.
     """
 
@@ -45,6 +46,7 @@ class FUNSD(VisionDataset):
         train: bool = True,
         use_polygons: bool = False,
         recognition_task: bool = False,
+        detection_task: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -55,6 +57,12 @@ class FUNSD(VisionDataset):
             pre_transforms=convert_target_to_relative if not recognition_task else None,
             **kwargs,
         )
+        if recognition_task and detection_task:
+            raise ValueError(
+                "recognition_task and detection_task cannot be set to True simultaneously "
+                + "to get the whole dataset with boxes and labels leave both to False"
+            )
+
         self.train = train
         np_dtype = np.float32
 
@@ -63,7 +71,7 @@ class FUNSD(VisionDataset):
 
         # # List images
         tmp_root = os.path.join(self.root, subfolder, "images")
-        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any]]]] = []
+        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any], np.ndarray]]] = []
         for img_path in tqdm(iterable=os.listdir(tmp_root), desc="Unpacking FUNSD", total=len(os.listdir(tmp_root))):
             # File existence check
             if not os.path.exists(os.path.join(tmp_root, img_path)):
@@ -100,6 +108,8 @@ class FUNSD(VisionDataset):
                     # filter labels with unknown characters
                     if not any(char in label for char in ["☑", "☐", "\uf703", "\uf702"]):
                         self.data.append((crop, label))
+            elif detection_task:
+                self.data.append((img_path, np.asarray(box_targets, dtype=np_dtype)))
             else:
                 self.data.append((
                     img_path,

--- a/doctr/datasets/funsd.py
+++ b/doctr/datasets/funsd.py
@@ -59,8 +59,8 @@ class FUNSD(VisionDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         self.train = train

--- a/doctr/datasets/ic03.py
+++ b/doctr/datasets/ic03.py
@@ -32,6 +32,7 @@ class IC03(VisionDataset):
         train: whether the subset should be the training one
         use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
         recognition_task: whether the dataset should be used for recognition task
+        detection_task: whether the dataset should be used for detection task
         **kwargs: keyword arguments from `VisionDataset`.
     """
 
@@ -51,6 +52,7 @@ class IC03(VisionDataset):
         train: bool = True,
         use_polygons: bool = False,
         recognition_task: bool = False,
+        detection_task: bool = False,
         **kwargs: Any,
     ) -> None:
         url, sha256, file_name = self.TRAIN if train else self.TEST
@@ -62,8 +64,14 @@ class IC03(VisionDataset):
             pre_transforms=convert_target_to_relative if not recognition_task else None,
             **kwargs,
         )
+        if recognition_task and detection_task:
+            raise ValueError(
+                "recognition_task and detection_task cannot be set to True simultaneously "
+                + "to get the whole dataset with boxes and labels leave both to False"
+            )
+
         self.train = train
-        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any]]]] = []
+        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any], np.ndarray]]] = []
         np_dtype = np.float32
 
         # Load xml data
@@ -117,6 +125,8 @@ class IC03(VisionDataset):
                     for crop, label in zip(crops, labels):
                         if crop.shape[0] > 0 and crop.shape[1] > 0 and len(label) > 0:
                             self.data.append((crop, label))
+                elif detection_task:
+                    self.data.append((name.text, boxes))
                 else:
                     self.data.append((name.text, dict(boxes=boxes, labels=labels)))
 

--- a/doctr/datasets/ic03.py
+++ b/doctr/datasets/ic03.py
@@ -66,8 +66,8 @@ class IC03(VisionDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         self.train = train

--- a/doctr/datasets/ic13.py
+++ b/doctr/datasets/ic13.py
@@ -56,8 +56,8 @@ class IC13(AbstractDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         # File existence check

--- a/doctr/datasets/ic13.py
+++ b/doctr/datasets/ic13.py
@@ -38,6 +38,7 @@ class IC13(AbstractDataset):
         label_folder: folder with all annotation files for the images
         use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
         recognition_task: whether the dataset should be used for recognition task
+        detection_task: whether the dataset should be used for detection task
         **kwargs: keyword arguments from `AbstractDataset`.
     """
 
@@ -47,11 +48,17 @@ class IC13(AbstractDataset):
         label_folder: str,
         use_polygons: bool = False,
         recognition_task: bool = False,
+        detection_task: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             img_folder, pre_transforms=convert_target_to_relative if not recognition_task else None, **kwargs
         )
+        if recognition_task and detection_task:
+            raise ValueError(
+                "recognition_task and detection_task cannot be set to True simultaneously "
+                + "to get the whole dataset with boxes and labels leave both to False"
+            )
 
         # File existence check
         if not os.path.exists(label_folder) or not os.path.exists(img_folder):
@@ -59,7 +66,7 @@ class IC13(AbstractDataset):
                 f"unable to locate {label_folder if not os.path.exists(label_folder) else img_folder}"
             )
 
-        self.data: List[Tuple[Union[Path, np.ndarray], Union[str, Dict[str, Any]]]] = []
+        self.data: List[Tuple[Union[Path, np.ndarray], Union[str, Dict[str, Any], np.ndarray]]] = []
         np_dtype = np.float32
 
         img_names = os.listdir(img_folder)
@@ -95,5 +102,7 @@ class IC13(AbstractDataset):
                 crops = crop_bboxes_from_image(img_path=img_path, geoms=box_targets)
                 for crop, label in zip(crops, labels):
                     self.data.append((crop, label))
+            elif detection_task:
+                self.data.append((img_path, box_targets))
             else:
                 self.data.append((img_path, dict(boxes=box_targets, labels=labels)))

--- a/doctr/datasets/iiit5k.py
+++ b/doctr/datasets/iiit5k.py
@@ -59,8 +59,8 @@ class IIIT5K(VisionDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         self.train = train

--- a/doctr/datasets/iiit5k.py
+++ b/doctr/datasets/iiit5k.py
@@ -34,6 +34,7 @@ class IIIT5K(VisionDataset):
         train: whether the subset should be the training one
         use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
         recognition_task: whether the dataset should be used for recognition task
+        detection_task: whether the dataset should be used for detection task
         **kwargs: keyword arguments from `VisionDataset`.
     """
 
@@ -45,6 +46,7 @@ class IIIT5K(VisionDataset):
         train: bool = True,
         use_polygons: bool = False,
         recognition_task: bool = False,
+        detection_task: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -55,6 +57,12 @@ class IIIT5K(VisionDataset):
             pre_transforms=convert_target_to_relative if not recognition_task else None,
             **kwargs,
         )
+        if recognition_task and detection_task:
+            raise ValueError(
+                "recognition_task and detection_task cannot be set to True simultaneously "
+                + "to get the whole dataset with boxes and labels leave both to False"
+            )
+
         self.train = train
 
         # Load mat data
@@ -62,7 +70,7 @@ class IIIT5K(VisionDataset):
         mat_file = "trainCharBound" if self.train else "testCharBound"
         mat_data = sio.loadmat(os.path.join(tmp_root, f"{mat_file}.mat"))[mat_file][0]
 
-        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any]]]] = []
+        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any], np.ndarray]]] = []
         np_dtype = np.float32
 
         for img_path, label, box_targets in tqdm(iterable=mat_data, desc="Unpacking IIIT5K", total=len(mat_data)):
@@ -73,24 +81,26 @@ class IIIT5K(VisionDataset):
             if not os.path.exists(os.path.join(tmp_root, _raw_path)):
                 raise FileNotFoundError(f"unable to locate {os.path.join(tmp_root, _raw_path)}")
 
+            if use_polygons:
+                # (x, y) coordinates of top left, top right, bottom right, bottom left corners
+                box_targets = [
+                    [
+                        [box[0], box[1]],
+                        [box[0] + box[2], box[1]],
+                        [box[0] + box[2], box[1] + box[3]],
+                        [box[0], box[1] + box[3]],
+                    ]
+                    for box in box_targets
+                ]
+            else:
+                # xmin, ymin, xmax, ymax
+                box_targets = [[box[0], box[1], box[0] + box[2], box[1] + box[3]] for box in box_targets]
+
             if recognition_task:
                 self.data.append((_raw_path, _raw_label))
+            elif detection_task:
+                self.data.append((_raw_path, np.asarray(box_targets, dtype=np_dtype)))
             else:
-                if use_polygons:
-                    # (x, y) coordinates of top left, top right, bottom right, bottom left corners
-                    box_targets = [
-                        [
-                            [box[0], box[1]],
-                            [box[0] + box[2], box[1]],
-                            [box[0] + box[2], box[1] + box[3]],
-                            [box[0], box[1] + box[3]],
-                        ]
-                        for box in box_targets
-                    ]
-                else:
-                    # xmin, ymin, xmax, ymax
-                    box_targets = [[box[0], box[1], box[0] + box[2], box[1] + box[3]] for box in box_targets]
-
                 # label are casted to list where each char corresponds to the character's bounding box
                 self.data.append((
                     _raw_path,

--- a/doctr/datasets/imgur5k.py
+++ b/doctr/datasets/imgur5k.py
@@ -65,8 +65,8 @@ class IMGUR5K(AbstractDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         # File existence check

--- a/doctr/datasets/imgur5k.py
+++ b/doctr/datasets/imgur5k.py
@@ -46,6 +46,7 @@ class IMGUR5K(AbstractDataset):
         train: whether the subset should be the training one
         use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
         recognition_task: whether the dataset should be used for recognition task
+        detection_task: whether the dataset should be used for detection task
         **kwargs: keyword arguments from `AbstractDataset`.
     """
 
@@ -56,17 +57,23 @@ class IMGUR5K(AbstractDataset):
         train: bool = True,
         use_polygons: bool = False,
         recognition_task: bool = False,
+        detection_task: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             img_folder, pre_transforms=convert_target_to_relative if not recognition_task else None, **kwargs
         )
+        if recognition_task and detection_task:
+            raise ValueError(
+                "recognition_task and detection_task cannot be set to True simultaneously "
+                + "to get the whole dataset with boxes and labels leave both to False"
+            )
 
         # File existence check
         if not os.path.exists(label_path) or not os.path.exists(img_folder):
             raise FileNotFoundError(f"unable to locate {label_path if not os.path.exists(label_path) else img_folder}")
 
-        self.data: List[Tuple[Union[str, Path, np.ndarray], Union[str, Dict[str, Any]]]] = []
+        self.data: List[Tuple[Union[str, Path, np.ndarray], Union[str, Dict[str, Any], np.ndarray]]] = []
         self.train = train
         np_dtype = np.float32
 
@@ -132,6 +139,8 @@ class IMGUR5K(AbstractDataset):
                                 tmp_img = Image.fromarray(crop)
                                 tmp_img.save(os.path.join(reco_folder_path, f"{reco_images_counter}.png"))
                                 reco_images_counter += 1
+                elif detection_task:
+                    self.data.append((img_path, np.asarray(box_targets, dtype=np_dtype)))
                 else:
                     self.data.append((img_path, dict(boxes=np.asarray(box_targets, dtype=np_dtype), labels=labels)))
 

--- a/doctr/datasets/sroie.py
+++ b/doctr/datasets/sroie.py
@@ -67,8 +67,8 @@ class SROIE(VisionDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         self.train = train

--- a/doctr/datasets/svhn.py
+++ b/doctr/datasets/svhn.py
@@ -67,8 +67,8 @@ class SVHN(VisionDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         self.train = train

--- a/doctr/datasets/svhn.py
+++ b/doctr/datasets/svhn.py
@@ -32,6 +32,7 @@ class SVHN(VisionDataset):
         train: whether the subset should be the training one
         use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
         recognition_task: whether the dataset should be used for recognition task
+        detection_task: whether the dataset should be used for detection task
         **kwargs: keyword arguments from `VisionDataset`.
     """
 
@@ -52,6 +53,7 @@ class SVHN(VisionDataset):
         train: bool = True,
         use_polygons: bool = False,
         recognition_task: bool = False,
+        detection_task: bool = False,
         **kwargs: Any,
     ) -> None:
         url, sha256, name = self.TRAIN if train else self.TEST
@@ -63,8 +65,14 @@ class SVHN(VisionDataset):
             pre_transforms=convert_target_to_relative if not recognition_task else None,
             **kwargs,
         )
+        if recognition_task and detection_task:
+            raise ValueError(
+                "recognition_task and detection_task cannot be set to True simultaneously "
+                + "to get the whole dataset with boxes and labels leave both to False"
+            )
+
         self.train = train
-        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any]]]] = []
+        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any], np.ndarray]]] = []
         np_dtype = np.float32
 
         tmp_root = os.path.join(self.root, "train" if train else "test")
@@ -122,6 +130,8 @@ class SVHN(VisionDataset):
                     for crop, label in zip(crops, label_targets):
                         if crop.shape[0] > 0 and crop.shape[1] > 0 and len(label) > 0:
                             self.data.append((crop, label))
+                elif detection_task:
+                    self.data.append((img_name, box_targets))
                 else:
                     self.data.append((img_name, dict(boxes=box_targets, labels=label_targets)))
 

--- a/doctr/datasets/svt.py
+++ b/doctr/datasets/svt.py
@@ -57,8 +57,8 @@ class SVT(VisionDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         self.train = train

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -35,6 +35,7 @@ class SynthText(VisionDataset):
         train: whether the subset should be the training one
         use_polygons: whether polygons should be considered as rotated bounding box (instead of straight ones)
         recognition_task: whether the dataset should be used for recognition task
+        detection_task: whether the dataset should be used for detection task
         **kwargs: keyword arguments from `VisionDataset`.
     """
 
@@ -46,6 +47,7 @@ class SynthText(VisionDataset):
         train: bool = True,
         use_polygons: bool = False,
         recognition_task: bool = False,
+        detection_task: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -56,8 +58,14 @@ class SynthText(VisionDataset):
             pre_transforms=convert_target_to_relative if not recognition_task else None,
             **kwargs,
         )
+        if recognition_task and detection_task:
+            raise ValueError(
+                "recognition_task and detection_task cannot be set to True simultaneously "
+                + "to get the whole dataset with boxes and labels leave both to False"
+            )
+
         self.train = train
-        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any]]]] = []
+        self.data: List[Tuple[Union[str, np.ndarray], Union[str, Dict[str, Any], np.ndarray]]] = []
         np_dtype = np.float32
 
         # Load mat data
@@ -111,6 +119,8 @@ class SynthText(VisionDataset):
                             tmp_img = Image.fromarray(crop)
                             tmp_img.save(os.path.join(reco_folder_path, f"{reco_images_counter}.png"))
                             reco_images_counter += 1
+            elif detection_task:
+                self.data.append((img_path[0], np.asarray(word_boxes, dtype=np_dtype)))
             else:
                 self.data.append((img_path[0], dict(boxes=np.asarray(word_boxes, dtype=np_dtype), labels=labels)))
 

--- a/doctr/datasets/synthtext.py
+++ b/doctr/datasets/synthtext.py
@@ -60,8 +60,8 @@ class SynthText(VisionDataset):
         )
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         self.train = train

--- a/doctr/datasets/utils.py
+++ b/doctr/datasets/utils.py
@@ -169,8 +169,13 @@ def encode_sequences(
     return encoded_data
 
 
-def convert_target_to_relative(img: ImageTensor, target: Dict[str, Any]) -> Tuple[ImageTensor, Dict[str, Any]]:
-    target["boxes"] = convert_to_relative_coords(target["boxes"], get_img_shape(img))
+def convert_target_to_relative(
+    img: ImageTensor, target: Union[np.ndarray, Dict[str, Any]]
+) -> Tuple[ImageTensor, Union[Dict[str, Any], np.ndarray]]:
+    if isinstance(target, np.ndarray):
+        target = convert_to_relative_coords(target, get_img_shape(img))
+    else:
+        target["boxes"] = convert_to_relative_coords(target["boxes"], get_img_shape(img))
     return img, target
 
 

--- a/doctr/datasets/wildreceipt.py
+++ b/doctr/datasets/wildreceipt.py
@@ -60,8 +60,8 @@ class WILDRECEIPT(AbstractDataset):
         # Task check
         if recognition_task and detection_task:
             raise ValueError(
-                "recognition_task and detection_task cannot be set to True simultaneously "
-                + "to get the whole dataset with boxes and labels leave both to False"
+                "`recognition_task` and `detection_task` cannot be set to True simultaneously. "
+                + "To get the whole dataset with boxes and labels leave both parameters to False."
             )
 
         # File existence check

--- a/references/detection/evaluate_tensorflow.py
+++ b/references/detection/evaluate_tensorflow.py
@@ -35,7 +35,7 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
     val_loss, batch_cnt = 0, 0
     for images, targets in tqdm(val_loader):
         images = batch_transforms(images)
-        targets = [{CLASS_NAME: t["boxes"]} for t in targets]
+        targets = [{CLASS_NAME: t} for t in targets]
         out = model(images, targets, training=False, return_preds=True)
         # Compute metric
         loc_preds = out["preds"]
@@ -81,7 +81,10 @@ def main(args):
         train=True,
         download=True,
         use_polygons=args.rotation,
-        sample_transforms=T.Resize(input_shape[:2]),
+        detection_task=True,
+        sample_transforms=T.Resize(
+            input_shape[:2], preserve_aspect_ratio=args.keep_ratio, symmetric_pad=args.symmetric_pad
+        ),
     )
     # Monkeypatch
     subfolder = ds.root.split("/")[-2:]
@@ -91,7 +94,10 @@ def main(args):
         train=False,
         download=True,
         use_polygons=args.rotation,
-        sample_transforms=T.Resize(input_shape[:2]),
+        detection_task=True,
+        sample_transforms=T.Resize(
+            input_shape[:2], preserve_aspect_ratio=args.keep_ratio, symmetric_pad=args.symmetric_pad
+        ),
     )
     subfolder = _ds.root.split("/")[-2:]
     ds.data.extend([(os.path.join(*subfolder, name), target) for name, target in _ds.data])
@@ -129,6 +135,8 @@ def parse_args():
     parser.add_argument("--dataset", type=str, default="FUNSD", help="Dataset to evaluate on")
     parser.add_argument("-b", "--batch_size", type=int, default=2, help="batch size for evaluation")
     parser.add_argument("--size", type=int, default=None, help="model input size, H = W")
+    parser.add_argument("--keep_ratio", action="store_true", help="keep the aspect ratio of the input image")
+    parser.add_argument("--symmetric_pad", action="store_true", help="pad the image symmetrically")
     parser.add_argument("--rotation", dest="rotation", action="store_true", help="inference with rotated bbox")
     parser.add_argument("--resume", type=str, default=None, help="Checkpoint to resume")
     parser.add_argument("--amp", dest="amp", help="Use Automatic Mixed Precision", action="store_true")

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -72,6 +72,36 @@ def _validate_dataset_recognition_part(ds, input_size, batch_size=2):
     assert isinstance(labels, list) and all(isinstance(elt, str) for elt in labels)
 
 
+def _validate_dataset_detection_part(ds, input_size, batch_size=2, is_polygons=False):
+    # Fetch one sample
+    img, target = ds[0]
+
+    assert isinstance(img, torch.Tensor)
+    assert img.shape == (3, *input_size)
+    assert img.dtype == torch.float32
+    assert isinstance(target, np.ndarray) and target.dtype == np.float32
+    if is_polygons:
+        assert target.ndim == 3 and target.shape[1:] == (4, 2)
+    else:
+        assert target.ndim == 2 and target.shape[1:] == (4,)
+    assert np.all(np.logical_and(target <= 1, target >= 0))
+
+    # Check batching
+    loader = DataLoader(
+        ds,
+        batch_size=batch_size,
+        drop_last=True,
+        sampler=RandomSampler(ds),
+        num_workers=0,
+        pin_memory=True,
+        collate_fn=ds.collate_fn,
+    )
+
+    images, targets = next(iter(loader))
+    assert isinstance(images, torch.Tensor) and images.shape == (batch_size, 3, *input_size)
+    assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
+
+
 def test_visiondataset():
     url = "https://github.com/mindee/doctr/releases/download/v0.6.0/mnist.zip"
     with pytest.raises(ValueError):
@@ -282,13 +312,14 @@ def test_artefact_detection(input_size, num_samples, rotate, mock_doc_artefacts)
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 626 training samples and 360 test samples
-        [[32, 128], 15, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 626 training samples and 360 test samples
+        [[32, 128], 15, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_sroie(input_size, num_samples, rotate, recognition, mock_sroie_dataset):
+def test_sroie(input_size, num_samples, rotate, recognition, detection, mock_sroie_dataset):
     # monkeypatch the path to temporary dataset
     datasets.SROIE.TRAIN = (mock_sroie_dataset, None, "sroie2019_train_task1.zip")
 
@@ -298,6 +329,7 @@ def test_sroie(input_size, num_samples, rotate, recognition, mock_sroie_dataset)
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_sroie_dataset.split("/")[:-2]),
         cache_subdir=mock_sroie_dataset.split("/")[-2],
     )
@@ -306,67 +338,93 @@ def test_sroie(input_size, num_samples, rotate, recognition, mock_sroie_dataset)
     assert repr(ds) == f"SROIE(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.SROIE(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.SROIE(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 5, False],  # Actual set has 229 train and 233 test samples
-        [[32, 128], 25, True],  # recognition
+        [[512, 512], 5, False, False],  # Actual set has 229 train and 233 test samples
+        [[32, 128], 25, True, False],  # recognition
+        [[512, 512], 5, False, True],  # detection
     ],
 )
-def test_ic13_dataset(input_size, num_samples, rotate, recognition, mock_ic13):
+def test_ic13_dataset(input_size, num_samples, rotate, recognition, detection, mock_ic13):
     ds = datasets.IC13(
         *mock_ic13,
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
     )
 
     assert len(ds) == num_samples
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.IC13(*mock_ic13, recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.IC13("abc", "abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 7149 train and 796 test samples
-        [[32, 128], 5, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 7149 train and 796 test samples
+        [[32, 128], 5, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_imgur5k_dataset(input_size, num_samples, rotate, recognition, mock_imgur5k):
+def test_imgur5k_dataset(input_size, num_samples, rotate, recognition, detection, mock_imgur5k):
     ds = datasets.IMGUR5K(
         *mock_imgur5k,
         train=True,
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
     )
 
     assert len(ds) == num_samples - 1  # -1 because of the test set 90 / 10 split
     assert repr(ds) == f"IMGUR5K(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.IMGUR5K(*mock_imgur5k, recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.IMGUR5K("abc", "abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[32, 128], 3, False],  # Actual set has 33402 training samples and 13068 test samples
-        [[32, 128], 12, True],  # recognition
+        [[32, 128], 3, False, False],  # Actual set has 33402 training samples and 13068 test samples
+        [[32, 128], 12, True, False],  # recognition
+        [[32, 128], 3, False, True],  # detection
     ],
 )
-def test_svhn(input_size, num_samples, rotate, recognition, mock_svhn_dataset):
+def test_svhn(input_size, num_samples, rotate, recognition, detection, mock_svhn_dataset):
     # monkeypatch the path to temporary dataset
     datasets.SVHN.TRAIN = (mock_svhn_dataset, None, "svhn_train.tar")
 
@@ -376,6 +434,7 @@ def test_svhn(input_size, num_samples, rotate, recognition, mock_svhn_dataset):
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_svhn_dataset.split("/")[:-2]),
         cache_subdir=mock_svhn_dataset.split("/")[-2],
     )
@@ -384,19 +443,27 @@ def test_svhn(input_size, num_samples, rotate, recognition, mock_svhn_dataset):
     assert repr(ds) == f"SVHN(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.SVHN(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.SVHN(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 149 training samples and 50 test samples
-        [[32, 128], 9, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 149 training samples and 50 test samples
+        [[32, 128], 9, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_funsd(input_size, num_samples, rotate, recognition, mock_funsd_dataset):
+def test_funsd(input_size, num_samples, rotate, recognition, detection, mock_funsd_dataset):
     # monkeypatch the path to temporary dataset
     datasets.FUNSD.URL = mock_funsd_dataset
     datasets.FUNSD.SHA256 = None
@@ -408,6 +475,7 @@ def test_funsd(input_size, num_samples, rotate, recognition, mock_funsd_dataset)
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_funsd_dataset.split("/")[:-2]),
         cache_subdir=mock_funsd_dataset.split("/")[-2],
     )
@@ -416,19 +484,27 @@ def test_funsd(input_size, num_samples, rotate, recognition, mock_funsd_dataset)
     assert repr(ds) == f"FUNSD(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.FUNSD(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.FUNSD(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 800 training samples and 100 test samples
-        [[32, 128], 9, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 800 training samples and 100 test samples
+        [[32, 128], 9, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_cord(input_size, num_samples, rotate, recognition, mock_cord_dataset):
+def test_cord(input_size, num_samples, rotate, recognition, detection, mock_cord_dataset):
     # monkeypatch the path to temporary dataset
     datasets.CORD.TRAIN = (mock_cord_dataset, None, "cord_train.zip")
 
@@ -438,6 +514,7 @@ def test_cord(input_size, num_samples, rotate, recognition, mock_cord_dataset):
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_cord_dataset.split("/")[:-2]),
         cache_subdir=mock_cord_dataset.split("/")[-2],
     )
@@ -446,19 +523,27 @@ def test_cord(input_size, num_samples, rotate, recognition, mock_cord_dataset):
     assert repr(ds) == f"CORD(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.CORD(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.CORD(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 2, False],  # Actual set has 772875 training samples and 85875 test samples
-        [[32, 128], 10, True],  # recognition
+        [[512, 512], 2, False, False],  # Actual set has 772875 training samples and 85875 test samples
+        [[32, 128], 10, True, False],  # recognition
+        [[512, 512], 2, False, True],  # detection
     ],
 )
-def test_synthtext(input_size, num_samples, rotate, recognition, mock_synthtext_dataset):
+def test_synthtext(input_size, num_samples, rotate, recognition, detection, mock_synthtext_dataset):
     # monkeypatch the path to temporary dataset
     datasets.SynthText.URL = mock_synthtext_dataset
     datasets.SynthText.SHA256 = None
@@ -469,6 +554,7 @@ def test_synthtext(input_size, num_samples, rotate, recognition, mock_synthtext_
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_synthtext_dataset.split("/")[:-2]),
         cache_subdir=mock_synthtext_dataset.split("/")[-2],
     )
@@ -477,19 +563,27 @@ def test_synthtext(input_size, num_samples, rotate, recognition, mock_synthtext_
     assert repr(ds) == f"SynthText(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.SynthText(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.SynthText(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[32, 128], 1, False],  # Actual set has 2000 training samples and 3000 test samples
-        [[32, 128], 1, True],  # recognition
+        [[32, 128], 1, False, False],  # Actual set has 2000 training samples and 3000 test samples
+        [[32, 128], 1, True, False],  # recognition
+        [[32, 128], 1, False, True],  # detection
     ],
 )
-def test_iiit5k(input_size, num_samples, rotate, recognition, mock_iiit5k_dataset):
+def test_iiit5k(input_size, num_samples, rotate, recognition, detection, mock_iiit5k_dataset):
     # monkeypatch the path to temporary dataset
     datasets.IIIT5K.URL = mock_iiit5k_dataset
     datasets.IIIT5K.SHA256 = None
@@ -500,6 +594,7 @@ def test_iiit5k(input_size, num_samples, rotate, recognition, mock_iiit5k_datase
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_iiit5k_dataset.split("/")[:-2]),
         cache_subdir=mock_iiit5k_dataset.split("/")[-2],
     )
@@ -508,19 +603,27 @@ def test_iiit5k(input_size, num_samples, rotate, recognition, mock_iiit5k_datase
     assert repr(ds) == f"IIIT5K(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size, batch_size=1)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, batch_size=1, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, batch_size=1, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.IIIT5K(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.IIIT5K(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 100 training samples and 249 test samples
-        [[32, 128], 3, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 100 training samples and 249 test samples
+        [[32, 128], 3, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_svt(input_size, num_samples, rotate, recognition, mock_svt_dataset):
+def test_svt(input_size, num_samples, rotate, recognition, detection, mock_svt_dataset):
     # monkeypatch the path to temporary dataset
     datasets.SVT.URL = mock_svt_dataset
     datasets.SVT.SHA256 = None
@@ -531,6 +634,7 @@ def test_svt(input_size, num_samples, rotate, recognition, mock_svt_dataset):
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_svt_dataset.split("/")[:-2]),
         cache_subdir=mock_svt_dataset.split("/")[-2],
     )
@@ -539,19 +643,27 @@ def test_svt(input_size, num_samples, rotate, recognition, mock_svt_dataset):
     assert repr(ds) == f"SVT(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.SVT(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.SVT(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 246 training samples and 249 test samples
-        [[32, 128], 3, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 246 training samples and 249 test samples
+        [[32, 128], 3, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_ic03(input_size, num_samples, rotate, recognition, mock_ic03_dataset):
+def test_ic03(input_size, num_samples, rotate, recognition, detection, mock_ic03_dataset):
     # monkeypatch the path to temporary dataset
     datasets.IC03.TRAIN = (mock_ic03_dataset, None, "ic03_train.zip")
 
@@ -561,6 +673,7 @@ def test_ic03(input_size, num_samples, rotate, recognition, mock_ic03_dataset):
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_ic03_dataset.split("/")[:-2]),
         cache_subdir=mock_ic03_dataset.split("/")[-2],
     )
@@ -569,32 +682,48 @@ def test_ic03(input_size, num_samples, rotate, recognition, mock_ic03_dataset):
     assert repr(ds) == f"IC03(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.IC03(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.IC03(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 2, False],
-        [[32, 128], 5, True],
+        [[512, 512], 2, False, False],  # Actual set has 1268 training samples and 472 test samples
+        [[32, 128], 5, True, False],  # recognition
+        [[512, 512], 2, False, True],  # detection
     ],
 )
-def test_wildreceipt_dataset(input_size, num_samples, rotate, recognition, mock_wildreceipt_dataset):
+def test_wildreceipt_dataset(input_size, num_samples, rotate, recognition, detection, mock_wildreceipt_dataset):
     ds = datasets.WILDRECEIPT(
         *mock_wildreceipt_dataset,
         train=True,
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
     )
     assert len(ds) == num_samples
     assert repr(ds) == f"WILDRECEIPT(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.WILDRECEIPT(*mock_wildreceipt_dataset, recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.WILDRECEIPT("abc", "abc")
 
 
 # NOTE: following datasets are only for recognition task
@@ -611,6 +740,9 @@ def test_mjsynth_dataset(mock_mjsynth_dataset):
     assert repr(ds) == f"MJSynth(train={True})"
     _validate_dataset_recognition_part(ds, input_size)
 
+    with pytest.raises(ValueError):
+        datasets.MJSynth("abc", "abc")
+
 
 def test_iiithws_dataset(mock_iiithws_dataset):
     input_size = (32, 128)
@@ -622,3 +754,6 @@ def test_iiithws_dataset(mock_iiithws_dataset):
     assert len(ds) == 4  # Actual set has 7141797 train and 793533 test samples
     assert repr(ds) == f"IIITHWS(train={True})"
     _validate_dataset_recognition_part(ds, input_size)
+
+    with pytest.raises(ValueError):
+        datasets.IIITHWS("abc", "abc")

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -344,9 +344,14 @@ def test_sroie(input_size, num_samples, rotate, recognition, detection, mock_sro
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.SROIE(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.SROIE(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.SROIE(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_sroie_dataset.split("/")[:-2]),
+            cache_subdir=mock_sroie_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -377,8 +382,6 @@ def test_ic13_dataset(input_size, num_samples, rotate, recognition, detection, m
 
     with pytest.raises(ValueError):
         datasets.IC13(*mock_ic13, recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.IC13("abc", "abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -410,9 +413,7 @@ def test_imgur5k_dataset(input_size, num_samples, rotate, recognition, detection
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.IMGUR5K(*mock_imgur5k, recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.IMGUR5K("abc", "abc")
+        datasets.IMGUR5K(*mock_imgur5k, train=True, recognition_task=True, detection_task=True)
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -449,9 +450,14 @@ def test_svhn(input_size, num_samples, rotate, recognition, detection, mock_svhn
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.SVHN(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.SVHN(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.SVHN(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_svhn_dataset.split("/")[:-2]),
+            cache_subdir=mock_svhn_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -490,9 +496,14 @@ def test_funsd(input_size, num_samples, rotate, recognition, detection, mock_fun
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.FUNSD(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.FUNSD(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.FUNSD(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_funsd_dataset.split("/")[:-2]),
+            cache_subdir=mock_funsd_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -529,9 +540,14 @@ def test_cord(input_size, num_samples, rotate, recognition, detection, mock_cord
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.CORD(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.CORD(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.CORD(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_cord_dataset.split("/")[:-2]),
+            cache_subdir=mock_cord_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -569,9 +585,14 @@ def test_synthtext(input_size, num_samples, rotate, recognition, detection, mock
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.SynthText(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.SynthText(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.SynthText(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_synthtext_dataset.split("/")[:-2]),
+            cache_subdir=mock_synthtext_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -609,9 +630,14 @@ def test_iiit5k(input_size, num_samples, rotate, recognition, detection, mock_ii
         _validate_dataset(ds, input_size, batch_size=1, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.IIIT5K(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.IIIT5K(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.IIIT5K(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_iiit5k_dataset.split("/")[:-2]),
+            cache_subdir=mock_iiit5k_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -649,9 +675,14 @@ def test_svt(input_size, num_samples, rotate, recognition, detection, mock_svt_d
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.SVT(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.SVT(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.SVT(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_svt_dataset.split("/")[:-2]),
+            cache_subdir=mock_svt_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -688,9 +719,14 @@ def test_ic03(input_size, num_samples, rotate, recognition, detection, mock_ic03
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.IC03(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.IC03(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.IC03(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_ic03_dataset.split("/")[:-2]),
+            cache_subdir=mock_ic03_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -721,9 +757,7 @@ def test_wildreceipt_dataset(input_size, num_samples, rotate, recognition, detec
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.WILDRECEIPT(*mock_wildreceipt_dataset, recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.WILDRECEIPT("abc", "abc")
+        datasets.WILDRECEIPT(*mock_wildreceipt_dataset, train=True, recognition_task=True, detection_task=True)
 
 
 # NOTE: following datasets are only for recognition task
@@ -740,9 +774,6 @@ def test_mjsynth_dataset(mock_mjsynth_dataset):
     assert repr(ds) == f"MJSynth(train={True})"
     _validate_dataset_recognition_part(ds, input_size)
 
-    with pytest.raises(ValueError):
-        datasets.MJSynth("abc", "abc")
-
 
 def test_iiithws_dataset(mock_iiithws_dataset):
     input_size = (32, 128)
@@ -754,6 +785,3 @@ def test_iiithws_dataset(mock_iiithws_dataset):
     assert len(ds) == 4  # Actual set has 7141797 train and 793533 test samples
     assert repr(ds) == f"IIITHWS(train={True})"
     _validate_dataset_recognition_part(ds, input_size)
-
-    with pytest.raises(ValueError):
-        datasets.IIITHWS("abc", "abc")

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -54,6 +54,27 @@ def _validate_dataset_recognition_part(ds, input_size, batch_size=2):
     assert isinstance(labels, list) and all(isinstance(elt, str) for elt in labels)
 
 
+def _validate_dataset_detection_part(ds, input_size, is_polygons=False, batch_size=2):
+    # Fetch one sample
+    img, target = ds[0]
+    assert isinstance(img, tf.Tensor)
+    assert img.shape == (*input_size, 3)
+    assert img.dtype == tf.float32
+    assert isinstance(target, np.ndarray) and target.dtype == np.float32
+    if is_polygons:
+        assert target.ndim == 3 and target.shape[1:] == (4, 2)
+    else:
+        assert target.ndim == 2 and target.shape[1:] == (4,)
+    assert np.all(np.logical_and(target <= 1, target >= 0))
+
+    # Check batching
+    loader = DataLoader(ds, batch_size=batch_size)
+
+    images, targets = next(iter(loader))
+    assert isinstance(images, tf.Tensor) and images.shape == (batch_size, *input_size, 3)
+    assert isinstance(targets, list) and all(isinstance(elt, np.ndarray) for elt in targets)
+
+
 def test_visiondataset():
     url = "https://github.com/mindee/doctr/releases/download/v0.6.0/mnist.zip"
     with pytest.raises(ValueError):
@@ -264,13 +285,14 @@ def test_artefact_detection(input_size, num_samples, rotate, mock_doc_artefacts)
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 626 training samples and 360 test samples
-        [[32, 128], 15, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 626 training samples and 360 test samples
+        [[32, 128], 15, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_sroie(input_size, num_samples, rotate, recognition, mock_sroie_dataset):
+def test_sroie(input_size, num_samples, rotate, recognition, detection, mock_sroie_dataset):
     # monkeypatch the path to temporary dataset
     datasets.SROIE.TRAIN = (mock_sroie_dataset, None, "sroie2019_train_task1.zip")
 
@@ -280,6 +302,7 @@ def test_sroie(input_size, num_samples, rotate, recognition, mock_sroie_dataset)
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_sroie_dataset.split("/")[:-2]),
         cache_subdir=mock_sroie_dataset.split("/")[-2],
     )
@@ -288,67 +311,93 @@ def test_sroie(input_size, num_samples, rotate, recognition, mock_sroie_dataset)
     assert repr(ds) == f"SROIE(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.SROIE(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.SROIE(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 5, False],  # Actual set has 229 train and 233 test samples
-        [[32, 128], 25, True],  # recognition
+        [[512, 512], 5, False, False],  # Actual set has 229 train and 233 test samples
+        [[32, 128], 25, True, False],  # recognition
+        [[512, 512], 5, False, True],  # detection
     ],
 )
-def test_ic13_dataset(input_size, num_samples, rotate, recognition, mock_ic13):
+def test_ic13_dataset(input_size, num_samples, rotate, recognition, detection, mock_ic13):
     ds = datasets.IC13(
         *mock_ic13,
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
     )
 
     assert len(ds) == num_samples
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.IC13(*mock_ic13, recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.IC13("abc", "abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 7149 train and 796 test samples
-        [[32, 128], 5, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 7149 train and 796 test samples
+        [[32, 128], 5, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_imgur5k_dataset(input_size, num_samples, rotate, recognition, mock_imgur5k):
+def test_imgur5k_dataset(input_size, num_samples, rotate, recognition, detection, mock_imgur5k):
     ds = datasets.IMGUR5K(
         *mock_imgur5k,
         train=True,
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
     )
 
     assert len(ds) == num_samples - 1  # -1 because of the test set 90 / 10 split
     assert repr(ds) == f"IMGUR5K(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.IMGUR5K(*mock_imgur5k, recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.IMGUR5K("abc", "abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[32, 128], 3, False],  # Actual set has 33402 training samples and 13068 test samples
-        [[32, 128], 12, True],  # recognition
+        [[32, 128], 3, False, False],  # Actual set has 33402 training samples and 13068 test samples
+        [[32, 128], 12, True, False],  # recognition
+        [[32, 128], 3, False, True],  # detection
     ],
 )
-def test_svhn(input_size, num_samples, rotate, recognition, mock_svhn_dataset):
+def test_svhn(input_size, num_samples, rotate, recognition, detection, mock_svhn_dataset):
     # monkeypatch the path to temporary dataset
     datasets.SVHN.TRAIN = (mock_svhn_dataset, None, "svhn_train.tar")
 
@@ -358,6 +407,7 @@ def test_svhn(input_size, num_samples, rotate, recognition, mock_svhn_dataset):
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_svhn_dataset.split("/")[:-2]),
         cache_subdir=mock_svhn_dataset.split("/")[-2],
     )
@@ -366,19 +416,27 @@ def test_svhn(input_size, num_samples, rotate, recognition, mock_svhn_dataset):
     assert repr(ds) == f"SVHN(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.SVHN(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.SVHN(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 149 training samples and 50 test samples
-        [[32, 128], 9, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 149 training samples and 50 test samples
+        [[32, 128], 9, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_funsd(input_size, num_samples, rotate, recognition, mock_funsd_dataset):
+def test_funsd(input_size, num_samples, rotate, recognition, detection, mock_funsd_dataset):
     # monkeypatch the path to temporary dataset
     datasets.FUNSD.URL = mock_funsd_dataset
     datasets.FUNSD.SHA256 = None
@@ -390,6 +448,7 @@ def test_funsd(input_size, num_samples, rotate, recognition, mock_funsd_dataset)
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_funsd_dataset.split("/")[:-2]),
         cache_subdir=mock_funsd_dataset.split("/")[-2],
     )
@@ -398,19 +457,27 @@ def test_funsd(input_size, num_samples, rotate, recognition, mock_funsd_dataset)
     assert repr(ds) == f"FUNSD(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.FUNSD(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.FUNSD(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 800 training samples and 100 test samples
-        [[32, 128], 9, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 800 training samples and 100 test samples
+        [[32, 128], 9, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_cord(input_size, num_samples, rotate, recognition, mock_cord_dataset):
+def test_cord(input_size, num_samples, rotate, recognition, detection, mock_cord_dataset):
     # monkeypatch the path to temporary dataset
     datasets.CORD.TRAIN = (mock_cord_dataset, None, "cord_train.zip")
 
@@ -420,6 +487,7 @@ def test_cord(input_size, num_samples, rotate, recognition, mock_cord_dataset):
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_cord_dataset.split("/")[:-2]),
         cache_subdir=mock_cord_dataset.split("/")[-2],
     )
@@ -428,19 +496,27 @@ def test_cord(input_size, num_samples, rotate, recognition, mock_cord_dataset):
     assert repr(ds) == f"CORD(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.CORD(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.CORD(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 2, False],  # Actual set has 772875 training samples and 85875 test samples
-        [[32, 128], 10, True],  # recognition
+        [[512, 512], 2, False, False],  # Actual set has 772875 training samples and 85875 test samples
+        [[32, 128], 10, True, False],  # recognition
+        [[512, 512], 2, False, True],  # detection
     ],
 )
-def test_synthtext(input_size, num_samples, rotate, recognition, mock_synthtext_dataset):
+def test_synthtext(input_size, num_samples, rotate, recognition, detection, mock_synthtext_dataset):
     # monkeypatch the path to temporary dataset
     datasets.SynthText.URL = mock_synthtext_dataset
     datasets.SynthText.SHA256 = None
@@ -451,6 +527,7 @@ def test_synthtext(input_size, num_samples, rotate, recognition, mock_synthtext_
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_synthtext_dataset.split("/")[:-2]),
         cache_subdir=mock_synthtext_dataset.split("/")[-2],
     )
@@ -459,19 +536,27 @@ def test_synthtext(input_size, num_samples, rotate, recognition, mock_synthtext_
     assert repr(ds) == f"SynthText(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.SynthText(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.SynthText(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[32, 128], 1, False],  # Actual set has 2000 training samples and 3000 test samples
-        [[32, 128], 1, True],  # recognition
+        [[32, 128], 1, False, False],  # Actual set has 2000 training samples and 3000 test samples
+        [[32, 128], 1, True, False],  # recognition
+        [[32, 128], 1, False, True],  # detection
     ],
 )
-def test_iiit5k(input_size, num_samples, rotate, recognition, mock_iiit5k_dataset):
+def test_iiit5k(input_size, num_samples, rotate, recognition, detection, mock_iiit5k_dataset):
     # monkeypatch the path to temporary dataset
     datasets.IIIT5K.URL = mock_iiit5k_dataset
     datasets.IIIT5K.SHA256 = None
@@ -482,6 +567,7 @@ def test_iiit5k(input_size, num_samples, rotate, recognition, mock_iiit5k_datase
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_iiit5k_dataset.split("/")[:-2]),
         cache_subdir=mock_iiit5k_dataset.split("/")[-2],
     )
@@ -490,19 +576,27 @@ def test_iiit5k(input_size, num_samples, rotate, recognition, mock_iiit5k_datase
     assert repr(ds) == f"IIIT5K(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size, batch_size=1)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, batch_size=1, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, batch_size=1, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.IIIT5K(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.IIIT5K(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 100 training samples and 249 test samples
-        [[32, 128], 3, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 100 training samples and 249 test samples
+        [[32, 128], 3, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_svt(input_size, num_samples, rotate, recognition, mock_svt_dataset):
+def test_svt(input_size, num_samples, rotate, recognition, detection, mock_svt_dataset):
     # monkeypatch the path to temporary dataset
     datasets.SVT.URL = mock_svt_dataset
     datasets.SVT.SHA256 = None
@@ -513,6 +607,7 @@ def test_svt(input_size, num_samples, rotate, recognition, mock_svt_dataset):
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_svt_dataset.split("/")[:-2]),
         cache_subdir=mock_svt_dataset.split("/")[-2],
     )
@@ -521,19 +616,27 @@ def test_svt(input_size, num_samples, rotate, recognition, mock_svt_dataset):
     assert repr(ds) == f"SVT(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.SVT(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.SVT(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 3, False],  # Actual set has 246 training samples and 249 test samples
-        [[32, 128], 3, True],  # recognition
+        [[512, 512], 3, False, False],  # Actual set has 246 training samples and 249 test samples
+        [[32, 128], 3, True, False],  # recognition
+        [[512, 512], 3, False, True],  # detection
     ],
 )
-def test_ic03(input_size, num_samples, rotate, recognition, mock_ic03_dataset):
+def test_ic03(input_size, num_samples, rotate, recognition, detection, mock_ic03_dataset):
     # monkeypatch the path to temporary dataset
     datasets.IC03.TRAIN = (mock_ic03_dataset, None, "ic03_train.zip")
 
@@ -543,6 +646,7 @@ def test_ic03(input_size, num_samples, rotate, recognition, mock_ic03_dataset):
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
         cache_dir="/".join(mock_ic03_dataset.split("/")[:-2]),
         cache_subdir=mock_ic03_dataset.split("/")[-2],
     )
@@ -551,32 +655,48 @@ def test_ic03(input_size, num_samples, rotate, recognition, mock_ic03_dataset):
     assert repr(ds) == f"IC03(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.IC03(recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.IC03(train=True, cache_dir="abc", cache_subdir="abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
 @pytest.mark.parametrize(
-    "input_size, num_samples, recognition",
+    "input_size, num_samples, recognition, detection",
     [
-        [[512, 512], 2, False],
-        [[32, 128], 5, True],
+        [[512, 512], 2, False, False],  # Actual set has 1268 training samples and 472 test samples
+        [[32, 128], 5, True, False],  # recognition
+        [[512, 512], 2, False, True],  # detection
     ],
 )
-def test_wildreceipt_dataset(input_size, num_samples, rotate, recognition, mock_wildreceipt_dataset):
+def test_wildreceipt_dataset(input_size, num_samples, rotate, recognition, detection, mock_wildreceipt_dataset):
     ds = datasets.WILDRECEIPT(
         *mock_wildreceipt_dataset,
         train=True,
         img_transforms=Resize(input_size),
         use_polygons=rotate,
         recognition_task=recognition,
+        detection_task=detection,
     )
     assert len(ds) == num_samples
     assert repr(ds) == f"WILDRECEIPT(train={True})"
     if recognition:
         _validate_dataset_recognition_part(ds, input_size)
+    elif detection:
+        _validate_dataset_detection_part(ds, input_size, is_polygons=rotate)
     else:
         _validate_dataset(ds, input_size, is_polygons=rotate)
+
+    with pytest.raises(ValueError):
+        datasets.WILDRECEIPT(*mock_wildreceipt_dataset, recognition_task=True, detection_task=True)
+    with pytest.raises(ValueError):
+        datasets.WILDRECEIPT("abc", "abc")
 
 
 # NOTE: following datasets are only for recognition task
@@ -593,6 +713,9 @@ def test_mjsynth_dataset(mock_mjsynth_dataset):
     assert repr(ds) == f"MJSynth(train={True})"
     _validate_dataset_recognition_part(ds, input_size)
 
+    with pytest.raises(ValueError):
+        datasets.MJSynth("abc", "abc")
+
 
 def test_iiithws_dataset(mock_iiithws_dataset):
     input_size = (32, 128)
@@ -604,3 +727,6 @@ def test_iiithws_dataset(mock_iiithws_dataset):
     assert len(ds) == 4  # Actual set has 7141797 train and 793533 test samples
     assert repr(ds) == f"IIITHWS(train={True})"
     _validate_dataset_recognition_part(ds, input_size)
+
+    with pytest.raises(ValueError):
+        datasets.IIITHWS("abc", "abc")

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -317,9 +317,14 @@ def test_sroie(input_size, num_samples, rotate, recognition, detection, mock_sro
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.SROIE(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.SROIE(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.SROIE(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_sroie_dataset.split("/")[:-2]),
+            cache_subdir=mock_sroie_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -350,8 +355,6 @@ def test_ic13_dataset(input_size, num_samples, rotate, recognition, detection, m
 
     with pytest.raises(ValueError):
         datasets.IC13(*mock_ic13, recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.IC13("abc", "abc")
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -383,9 +386,7 @@ def test_imgur5k_dataset(input_size, num_samples, rotate, recognition, detection
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.IMGUR5K(*mock_imgur5k, recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.IMGUR5K("abc", "abc")
+        datasets.IMGUR5K(*mock_imgur5k, train=True, recognition_task=True, detection_task=True)
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -422,9 +423,14 @@ def test_svhn(input_size, num_samples, rotate, recognition, detection, mock_svhn
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.SVHN(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.SVHN(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.SVHN(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_svhn_dataset.split("/")[:-2]),
+            cache_subdir=mock_svhn_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -463,9 +469,14 @@ def test_funsd(input_size, num_samples, rotate, recognition, detection, mock_fun
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.FUNSD(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.FUNSD(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.FUNSD(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_funsd_dataset.split("/")[:-2]),
+            cache_subdir=mock_funsd_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -502,9 +513,14 @@ def test_cord(input_size, num_samples, rotate, recognition, detection, mock_cord
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.CORD(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.CORD(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.CORD(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_cord_dataset.split("/")[:-2]),
+            cache_subdir=mock_cord_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -542,9 +558,14 @@ def test_synthtext(input_size, num_samples, rotate, recognition, detection, mock
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.SynthText(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.SynthText(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.SynthText(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_synthtext_dataset.split("/")[:-2]),
+            cache_subdir=mock_synthtext_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -582,9 +603,14 @@ def test_iiit5k(input_size, num_samples, rotate, recognition, detection, mock_ii
         _validate_dataset(ds, input_size, batch_size=1, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.IIIT5K(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.IIIT5K(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.IIIT5K(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_iiit5k_dataset.split("/")[:-2]),
+            cache_subdir=mock_iiit5k_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -622,9 +648,14 @@ def test_svt(input_size, num_samples, rotate, recognition, detection, mock_svt_d
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.SVT(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.SVT(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.SVT(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_svt_dataset.split("/")[:-2]),
+            cache_subdir=mock_svt_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -661,9 +692,14 @@ def test_ic03(input_size, num_samples, rotate, recognition, detection, mock_ic03
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.IC03(recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.IC03(train=True, cache_dir="abc", cache_subdir="abc")
+        datasets.IC03(
+            train=True,
+            download=True,
+            recognition_task=True,
+            detection_task=True,
+            cache_dir="/".join(mock_ic03_dataset.split("/")[:-2]),
+            cache_subdir=mock_ic03_dataset.split("/")[-2],
+        )
 
 
 @pytest.mark.parametrize("rotate", [True, False])
@@ -694,9 +730,7 @@ def test_wildreceipt_dataset(input_size, num_samples, rotate, recognition, detec
         _validate_dataset(ds, input_size, is_polygons=rotate)
 
     with pytest.raises(ValueError):
-        datasets.WILDRECEIPT(*mock_wildreceipt_dataset, recognition_task=True, detection_task=True)
-    with pytest.raises(ValueError):
-        datasets.WILDRECEIPT("abc", "abc")
+        datasets.WILDRECEIPT(*mock_wildreceipt_dataset, train=True, recognition_task=True, detection_task=True)
 
 
 # NOTE: following datasets are only for recognition task
@@ -713,9 +747,6 @@ def test_mjsynth_dataset(mock_mjsynth_dataset):
     assert repr(ds) == f"MJSynth(train={True})"
     _validate_dataset_recognition_part(ds, input_size)
 
-    with pytest.raises(ValueError):
-        datasets.MJSynth("abc", "abc")
-
 
 def test_iiithws_dataset(mock_iiithws_dataset):
     input_size = (32, 128)
@@ -727,6 +758,3 @@ def test_iiithws_dataset(mock_iiithws_dataset):
     assert len(ds) == 4  # Actual set has 7141797 train and 793533 test samples
     assert repr(ds) == f"IIITHWS(train={True})"
     _validate_dataset_recognition_part(ds, input_size)
-
-    with pytest.raises(ValueError):
-        datasets.IIITHWS("abc", "abc")


### PR DESCRIPTION
This PR:

- makes it possible to use built-in datasets also to plug in the detection training script
- extend tests
- update eval scripts - no it works with different args out of the box

Any feedback is welcome