### PR TITLE
Feature/assume straight text

### DIFF
--- a/doctr/models/kie_predictor/base.py
+++ b/doctr/models/kie_predictor/base.py
@@ -36,6 +36,7 @@ class _KIEPredictor(_OCRPredictor):
     def __init__(
         self,
         assume_straight_pages: bool = True,
+        assume_straight_text: bool = False,
         straighten_pages: bool = False,
         preserve_aspect_ratio: bool = True,
         symmetric_pad: bool = True,
@@ -43,7 +44,13 @@ class _KIEPredictor(_OCRPredictor):
         **kwargs: Any,
     ) -> None:
         super().__init__(
-            assume_straight_pages, straighten_pages, preserve_aspect_ratio, symmetric_pad, detect_orientation, **kwargs
+            assume_straight_pages,
+            assume_straight_text,
+            straighten_pages,
+            preserve_aspect_ratio,
+            symmetric_pad,
+            detect_orientation,
+            **kwargs,
         )
 
         self.doc_builder: KIEDocumentBuilder = KIEDocumentBuilder(**kwargs)

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -29,6 +29,8 @@ class KIEPredictor(nn.Module, _KIEPredictor):
         reco_predictor: recognition module
         assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
             without rotated textual elements.
+        assume_straight_text: if True, speeds up the inference by assuming you only pass straight text
+            without rotated textual elements.
         straighten_pages: if True, estimates the page general orientation based on the median line orientation.
             Then, rotates page before passing it to the deep learning modules. The final predictions will be remapped
             accordingly. Doing so will improve performances for documents with page-uniform rotations.
@@ -44,6 +46,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
         det_predictor: DetectionPredictor,
         reco_predictor: RecognitionPredictor,
         assume_straight_pages: bool = True,
+        assume_straight_text: bool = False,
         straighten_pages: bool = False,
         preserve_aspect_ratio: bool = True,
         symmetric_pad: bool = True,
@@ -57,6 +60,7 @@ class KIEPredictor(nn.Module, _KIEPredictor):
         _KIEPredictor.__init__(
             self,
             assume_straight_pages,
+            assume_straight_text,
             straighten_pages,
             preserve_aspect_ratio,
             symmetric_pad,
@@ -129,10 +133,11 @@ class KIEPredictor(nn.Module, _KIEPredictor):
                 dict_loc_preds[class_name],
                 channels_last=channels_last,
                 assume_straight_pages=self.assume_straight_pages,
+                assume_straight_text=self.assume_straight_text,
             )
         # Rectify crop orientation
         crop_orientations: Any = {}
-        if not self.assume_straight_pages:
+        if not self.assume_straight_pages and not self.assume_straight_text:
             for class_name in dict_loc_preds.keys():
                 crops[class_name], dict_loc_preds[class_name], word_orientations = self._rectify_crops(
                     crops[class_name], dict_loc_preds[class_name]

--- a/doctr/models/kie_predictor/tensorflow.py
+++ b/doctr/models/kie_predictor/tensorflow.py
@@ -29,6 +29,8 @@ class KIEPredictor(NestedObject, _KIEPredictor):
         reco_predictor: recognition module
         assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
             without rotated textual elements.
+        assume_straight_text: if True, speeds up the inference by assuming you only pass straight text
+            without rotated textual elements.
         straighten_pages: if True, estimates the page general orientation based on the median line orientation.
             Then, rotates page before passing it to the deep learning modules. The final predictions will be remapped
             accordingly. Doing so will improve performances for documents with page-uniform rotations.
@@ -46,6 +48,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
         det_predictor: DetectionPredictor,
         reco_predictor: RecognitionPredictor,
         assume_straight_pages: bool = True,
+        assume_straight_text: bool = False,
         straighten_pages: bool = False,
         preserve_aspect_ratio: bool = True,
         symmetric_pad: bool = True,
@@ -58,6 +61,7 @@ class KIEPredictor(NestedObject, _KIEPredictor):
         _KIEPredictor.__init__(
             self,
             assume_straight_pages,
+            assume_straight_text,
             straighten_pages,
             preserve_aspect_ratio,
             symmetric_pad,
@@ -122,12 +126,16 @@ class KIEPredictor(NestedObject, _KIEPredictor):
         crops = {}
         for class_name in dict_loc_preds.keys():
             crops[class_name], dict_loc_preds[class_name] = self._prepare_crops(
-                pages, dict_loc_preds[class_name], channels_last=True, assume_straight_pages=self.assume_straight_pages
+                pages,
+                dict_loc_preds[class_name],
+                channels_last=True,
+                assume_straight_pages=self.assume_straight_pages,
+                assume_straight_text=self.assume_straight_text,
             )
 
         # Rectify crop orientation
         crop_orientations: Any = {}
-        if not self.assume_straight_pages:
+        if not self.assume_straight_pages and not self.assume_straight_text:
             for class_name in dict_loc_preds.keys():
                 crops[class_name], dict_loc_preds[class_name], word_orientations = self._rectify_crops(
                     crops[class_name], dict_loc_preds[class_name]

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -29,6 +29,8 @@ class OCRPredictor(nn.Module, _OCRPredictor):
         reco_predictor: recognition module
         assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
             without rotated textual elements.
+        assume_straight_text: if True, speeds up the inference by assuming you only pass straight text
+            without rotated textual elements.
         straighten_pages: if True, estimates the page general orientation based on the median line orientation.
             Then, rotates page before passing it to the deep learning modules. The final predictions will be remapped
             accordingly. Doing so will improve performances for documents with page-uniform rotations.
@@ -44,6 +46,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
         det_predictor: DetectionPredictor,
         reco_predictor: RecognitionPredictor,
         assume_straight_pages: bool = True,
+        assume_straight_text: bool = False,
         straighten_pages: bool = False,
         preserve_aspect_ratio: bool = True,
         symmetric_pad: bool = True,
@@ -57,6 +60,7 @@ class OCRPredictor(nn.Module, _OCRPredictor):
         _OCRPredictor.__init__(
             self,
             assume_straight_pages,
+            assume_straight_text,
             straighten_pages,
             preserve_aspect_ratio,
             symmetric_pad,
@@ -123,10 +127,11 @@ class OCRPredictor(nn.Module, _OCRPredictor):
             loc_preds,
             channels_last=channels_last,
             assume_straight_pages=self.assume_straight_pages,
+            assume_straight_text=self.assume_straight_text,
         )
         # Rectify crop orientation and get crop orientation predictions
         crop_orientations: Any = []
-        if not self.assume_straight_pages:
+        if not self.assume_straight_pages and not self.assume_straight_text:
             crops, loc_preds, _crop_orientations = self._rectify_crops(crops, loc_preds)
             crop_orientations = [
                 {"value": orientation[0], "confidence": orientation[1]} for orientation in _crop_orientations

--- a/doctr/models/predictor/tensorflow.py
+++ b/doctr/models/predictor/tensorflow.py
@@ -29,6 +29,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         reco_predictor: recognition module
         assume_straight_pages: if True, speeds up the inference by assuming you only pass straight pages
             without rotated textual elements.
+        assume_straight_text: if True, speeds up the inference by assuming you only pass straight text
         straighten_pages: if True, estimates the page general orientation based on the median line orientation.
             Then, rotates page before passing it to the deep learning modules. The final predictions will be remapped
             accordingly. Doing so will improve performances for documents with page-uniform rotations.
@@ -46,6 +47,7 @@ class OCRPredictor(NestedObject, _OCRPredictor):
         det_predictor: DetectionPredictor,
         reco_predictor: RecognitionPredictor,
         assume_straight_pages: bool = True,
+        assume_straight_text: bool = False,
         straighten_pages: bool = False,
         preserve_aspect_ratio: bool = True,
         symmetric_pad: bool = True,

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -153,7 +153,6 @@ def test_trained_ocr_predictor(mock_payslip):
         pretrained=True,
         batch_size=2,
         assume_straight_pages=True,
-        assume_straight_text=False,
         preserve_aspect_ratio=True,
         symmetric_pad=True,
     )

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -25,14 +25,17 @@ class _DummyCallback:
 
 
 @pytest.mark.parametrize(
-    "assume_straight_pages, straighten_pages",
+    "assume_straight_pages, straighten_pages, assume_straight_text",
     [
-        [True, False],
-        [False, False],
-        [True, True],
+        [True, False, False],
+        [False, False, False],
+        [True, True, False],
+        [True, False, True],
+        [False, False, True],
+        [True, True, True],
     ],
 )
-def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages):
+def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages, assume_straight_text):
     det_bsize = 4
     det_predictor = DetectionPredictor(
         PreProcessor(output_size=(512, 512), batch_size=det_bsize),
@@ -59,6 +62,7 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         det_predictor,
         reco_predictor,
         assume_straight_pages=assume_straight_pages,
+        assume_straight_text=assume_straight_text,
         straighten_pages=straighten_pages,
         detect_orientation=True,
         detect_language=True,
@@ -73,7 +77,10 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         else:
             assert predictor.page_orientation_predictor is None
     else:
-        assert isinstance(predictor.crop_orientation_predictor, nn.Module)
+        if not assume_straight_text:
+            assert isinstance(predictor.crop_orientation_predictor, nn.Module)
+        else:
+            assert predictor.crop_orientation_predictor is None
         assert isinstance(predictor.page_orientation_predictor, nn.Module)
 
     out = predictor(doc)
@@ -97,8 +104,9 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
             predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
             predictor.page_orientation_predictor = page_orientation_predictor(custom_page_orientation_model)
     else:
-        # Overwrite the default orientation models
-        predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
+        if not assume_straight_text:
+            # Overwrite the default orientation models
+            predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
         predictor.page_orientation_predictor = page_orientation_predictor(custom_page_orientation_model)
 
     out = predictor(doc)
@@ -114,6 +122,7 @@ def test_trained_ocr_predictor(mock_payslip):
         pretrained=True,
         batch_size=2,
         assume_straight_pages=True,
+        assume_straight_text=False,
         symmetric_pad=True,
         preserve_aspect_ratio=False,
     )
@@ -144,6 +153,7 @@ def test_trained_ocr_predictor(mock_payslip):
         pretrained=True,
         batch_size=2,
         assume_straight_pages=True,
+        assume_straight_text=False,
         preserve_aspect_ratio=True,
         symmetric_pad=True,
     )
@@ -152,6 +162,7 @@ def test_trained_ocr_predictor(mock_payslip):
         det_predictor,
         reco_predictor,
         assume_straight_pages=True,
+        assume_straight_text=False,
         straighten_pages=True,
         preserve_aspect_ratio=True,
         symmetric_pad=True,
@@ -167,14 +178,17 @@ def test_trained_ocr_predictor(mock_payslip):
 
 
 @pytest.mark.parametrize(
-    "assume_straight_pages, straighten_pages",
+    "assume_straight_pages, straighten_pages, assume_straight_text",
     [
-        [True, False],
-        [False, False],
-        [True, True],
+        [True, False, False],
+        [False, False, False],
+        [True, True, False],
+        [True, False, True],
+        [False, False, True],
+        [True, True, True],
     ],
 )
-def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages):
+def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages, assume_straight_text):
     det_bsize = 4
     det_predictor = DetectionPredictor(
         PreProcessor(output_size=(512, 512), batch_size=det_bsize),
@@ -201,6 +215,7 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         det_predictor,
         reco_predictor,
         assume_straight_pages=assume_straight_pages,
+        assume_straight_text=assume_straight_text,
         straighten_pages=straighten_pages,
         detect_orientation=True,
         detect_language=True,
@@ -215,7 +230,10 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         else:
             assert predictor.page_orientation_predictor is None
     else:
-        assert isinstance(predictor.crop_orientation_predictor, nn.Module)
+        if not assume_straight_text:
+            assert isinstance(predictor.crop_orientation_predictor, nn.Module)
+        else:
+            assert predictor.crop_orientation_predictor is None
         assert isinstance(predictor.page_orientation_predictor, nn.Module)
 
     out = predictor(doc)
@@ -239,8 +257,9 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
             predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
             predictor.page_orientation_predictor = page_orientation_predictor(custom_page_orientation_model)
     else:
-        # Overwrite the default orientation models
-        predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
+        if not assume_straight_text:
+            # Overwrite the default orientation models
+            predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
         predictor.page_orientation_predictor = page_orientation_predictor(custom_page_orientation_model)
 
     out = predictor(doc)
@@ -265,6 +284,7 @@ def test_trained_kie_predictor(mock_payslip):
         det_predictor,
         reco_predictor,
         assume_straight_pages=True,
+        assume_straight_text=False,
         straighten_pages=True,
         preserve_aspect_ratio=False,
         resolve_blocks=True,
@@ -297,6 +317,7 @@ def test_trained_kie_predictor(mock_payslip):
         det_predictor,
         reco_predictor,
         assume_straight_pages=True,
+        assume_straight_text=False,
         straighten_pages=True,
         preserve_aspect_ratio=True,
         symmetric_pad=True,

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -122,7 +122,6 @@ def test_trained_ocr_predictor(mock_payslip):
         pretrained=True,
         batch_size=2,
         assume_straight_pages=True,
-        assume_straight_text=False,
         symmetric_pad=True,
         preserve_aspect_ratio=False,
     )
@@ -132,6 +131,7 @@ def test_trained_ocr_predictor(mock_payslip):
         det_predictor,
         reco_predictor,
         assume_straight_pages=True,
+        assume_straight_text=False,
         straighten_pages=True,
         preserve_aspect_ratio=False,
         resolve_blocks=True,

--- a/tests/tensorflow/test_models_zoo_tf.py
+++ b/tests/tensorflow/test_models_zoo_tf.py
@@ -25,14 +25,17 @@ class _DummyCallback:
 
 
 @pytest.mark.parametrize(
-    "assume_straight_pages, straighten_pages",
+    "assume_straight_pages, straighten_pages, assume_straight_text",
     [
-        [True, False],
-        [False, False],
-        [True, True],
+        [True, False, False],
+        [False, False, False],
+        [True, True, False],
+        [True, False, True],
+        [False, False, True],
+        [True, True, True],
     ],
 )
-def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages):
+def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages, assume_straight_text):
     det_bsize = 4
     det_predictor = DetectionPredictor(
         PreProcessor(output_size=(512, 512), batch_size=det_bsize),
@@ -56,6 +59,7 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         det_predictor,
         reco_predictor,
         assume_straight_pages=assume_straight_pages,
+        assume_straight_text=assume_straight_text,
         straighten_pages=straighten_pages,
         detect_orientation=True,
         detect_language=True,
@@ -70,7 +74,8 @@ def test_ocrpredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         else:
             assert predictor.page_orientation_predictor is None
     else:
-        assert isinstance(predictor.crop_orientation_predictor, NestedObject)
+        if not assume_straight_text:
+            assert isinstance(predictor.crop_orientation_predictor, NestedObject)
         assert isinstance(predictor.page_orientation_predictor, NestedObject)
 
     out = predictor(doc)
@@ -122,6 +127,7 @@ def test_trained_ocr_predictor(mock_payslip):
         det_predictor,
         reco_predictor,
         assume_straight_pages=True,
+        assume_straight_text=False,
         straighten_pages=True,
         preserve_aspect_ratio=False,
         resolve_blocks=True,
@@ -153,6 +159,7 @@ def test_trained_ocr_predictor(mock_payslip):
         det_predictor,
         reco_predictor,
         assume_straight_pages=True,
+        assume_straight_text=False,
         straighten_pages=True,
         preserve_aspect_ratio=True,
         symmetric_pad=True,
@@ -166,14 +173,17 @@ def test_trained_ocr_predictor(mock_payslip):
 
 
 @pytest.mark.parametrize(
-    "assume_straight_pages, straighten_pages",
+    "assume_straight_pages, straighten_pages, assume_straight_text",
     [
-        [True, False],
-        [False, False],
-        [True, True],
+        [True, False, False],
+        [False, False, False],
+        [True, True, False],
+        [True, False, True],
+        [False, False, True],
+        [True, True, True],
     ],
 )
-def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages):
+def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pages, assume_straight_text):
     det_bsize = 4
     det_predictor = DetectionPredictor(
         PreProcessor(output_size=(512, 512), batch_size=det_bsize),
@@ -197,6 +207,7 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         det_predictor,
         reco_predictor,
         assume_straight_pages=assume_straight_pages,
+        assume_straight_text=assume_straight_text,
         straighten_pages=straighten_pages,
         detect_orientation=True,
         detect_language=True,
@@ -211,7 +222,8 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
         else:
             assert predictor.page_orientation_predictor is None
     else:
-        assert isinstance(predictor.crop_orientation_predictor, NestedObject)
+        if not assume_straight_text:
+            assert isinstance(predictor.crop_orientation_predictor, NestedObject)
         assert isinstance(predictor.page_orientation_predictor, NestedObject)
 
     out = predictor(doc)
@@ -237,8 +249,9 @@ def test_kiepredictor(mock_pdf, mock_vocab, assume_straight_pages, straighten_pa
             predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
             predictor.page_orientation_predictor = page_orientation_predictor(custom_page_orientation_model)
     else:
-        # Overwrite the default orientation models
-        predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
+        if not assume_straight_text:
+            # Overwrite the default orientation models
+            predictor.crop_orientation_predictor = crop_orientation_predictor(custom_crop_orientation_model)
         predictor.page_orientation_predictor = page_orientation_predictor(custom_page_orientation_model)
 
     out = predictor(doc)
@@ -263,6 +276,7 @@ def test_trained_kie_predictor(mock_payslip):
         det_predictor,
         reco_predictor,
         assume_straight_pages=True,
+        assume_straight_text=False,
         straighten_pages=True,
         preserve_aspect_ratio=False,
         resolve_blocks=True,
@@ -295,6 +309,7 @@ def test_trained_kie_predictor(mock_payslip):
         det_predictor,
         reco_predictor,
         assume_straight_pages=True,
+        assume_straight_text=False,
         straighten_pages=True,
         preserve_aspect_ratio=True,
         symmetric_pad=True,


### PR DESCRIPTION
Modifying the ocr_predictor API to support assume_straight_text as an argument.
When used with assume_straight_pages=False this reduces the reliance on an unreliable crop orientation model when the text is almost straight and additionally reduces speed of execution. It should alleviate the issue mentioned in https://github.com/mindee/doctr/issues/1455 if the use-case is one where the text is straight i.e. no rotations of 90, 180 and 270 degrees.

The main contribution to the pipeline is the logic around a new geometry function which extracts the crops while dewarping the images based on the corners of the text detection, which returns polygons (when assume_straight_pages=False and assume_straight_text=True).