### PR TITLE
[Fix] Remove image padding after rotation correction with `straighten_pages=True`

### DIFF
--- a/doctr/models/predictor/base.py
+++ b/doctr/models/predictor/base.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import numpy as np
 
 from doctr.models.builder import DocumentBuilder
-from doctr.utils.geometry import extract_crops, extract_rcrops, rotate_image
+from doctr.utils.geometry import extract_crops, extract_rcrops, remove_image_padding, rotate_image
 
 from .._utils import estimate_orientation, rectify_crops, rectify_loc_preds
 from ..classification import crop_orientation_predictor, page_orientation_predictor
@@ -101,8 +101,8 @@ class _OCRPredictor:
             ]
         )
         return [
-            # expand if height and width are not equal
-            rotate_image(page, angle, expand=page.shape[0] != page.shape[1])
+            # expand if height and width are not equal, afterwards remove padding
+            remove_image_padding(rotate_image(page, angle, expand=page.shape[0] != page.shape[1]))
             for page, angle in zip(pages, origin_pages_orientations)
         ]
 

--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -20,6 +20,7 @@ __all__ = [
     "rotate_boxes",
     "compute_expanded_shape",
     "rotate_image",
+    "remove_image_padding",
     "estimate_page_angle",
     "convert_to_relative_coords",
     "rotate_abs_geoms",
@@ -349,6 +350,26 @@ def rotate_image(
             rot_img = cv2.resize(rot_img, image.shape[:-1][::-1], interpolation=cv2.INTER_LINEAR)
 
     return rot_img
+
+
+def remove_image_padding(image: np.ndarray) -> np.ndarray:
+    """Remove black border padding from an image
+
+    Args:
+    ----
+        image: numpy tensor to remove padding from
+
+    Returns:
+    -------
+        Image with padding removed
+    """
+    # Find the bounding box of the non-black region
+    rows = np.any(image, axis=1)
+    cols = np.any(image, axis=0)
+    rmin, rmax = np.where(rows)[0][[0, -1]]
+    cmin, cmax = np.where(cols)[0][[0, -1]]
+
+    return image[rmin : rmax + 1, cmin : cmax + 1]
 
 
 def estimate_page_angle(polys: np.ndarray) -> float:

--- a/tests/common/test_utils_geometry.py
+++ b/tests/common/test_utils_geometry.py
@@ -142,6 +142,17 @@ def test_rotate_image():
     assert rotated[0, :, 0].sum() <= 1
 
 
+def test_remove_image_padding():
+    img = np.ones((32, 64, 3), dtype=np.float32)
+    padded = np.pad(img, ((10, 10), (20, 20), (0, 0)))
+    cropped = geometry.remove_image_padding(padded)
+    assert np.all(cropped == img)
+
+    # No padding
+    cropped = geometry.remove_image_padding(img)
+    assert np.all(cropped == img)
+
+
 @pytest.mark.parametrize(
     "abs_geoms, img_size, rel_geoms",
     [


### PR DESCRIPTION
This PR:

- Fix padding removal after rotation correction
- Add function to remove the padding + corresponding test

Before:

![Screenshot from 2024-09-25 08-45-05](https://github.com/user-attachments/assets/3851f501-d3a7-4005-b68c-ecfbde6ee106)

After:

![Screenshot from 2024-09-25 09-00-45](https://github.com/user-attachments/assets/6fb30ad4-00cb-4a48-a31b-0a515ace889e)

Any feedback is welcome :hugs: 