### PR TITLE
ci(dependabot): remove frgfm from automatic reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
       interval: weekly
       day: sunday
     reviewers:
-      - "frgfm"
       - "charlesmindee"
       - "felixdittrich92"
       - "odulcy-mindee"
@@ -22,7 +21,6 @@ updates:
       interval: weekly
       day: sunday
     reviewers:
-      - "frgfm"
       - "charlesmindee"
       - "felixdittrich92"
       - "odulcy-mindee"


### PR DESCRIPTION
This PR simply removes me from the automatically tagged people on dependabot updates!

More than happy to help when there is a problem, but right now, it's more noise than anything else 😅 