### PR TITLE
[build] Fix tensorflow build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ dependencies = [
 [project.optional-dependencies]
 tf = [
     # cf. https://github.com/mindee/doctr/pull/1461
-    "tensorflow[and-cuda]>=2.15.0,<3.0.0; sys_platform != 'darwin'",
-    "tensorflow>=2.15.0,<3.0.0; sys_platform == 'darwin'", # TensorFlow compatible for macOS
+    "tensorflow[and-cuda]>=2.15.0,<3.0.0; sys_platform == 'linux'",
+    "tensorflow>=2.15.0,<3.0.0; sys_platform != 'linux'", # TensorFlow compatible for macOS and Windows
     "tf-keras>=2.15.0,<3.0.0",  # Keep keras 2 compatibility
     "tf2onnx>=1.16.0,<2.0.0",  # cf. https://github.com/onnx/tensorflow-onnx/releases/tag/v1.16.0
 ]
@@ -98,8 +98,8 @@ docs = [
 dev = [
     # Tensorflow
     # cf. https://github.com/mindee/doctr/pull/1461
-    "tensorflow[and-cuda]>=2.15.0,<3.0.0; sys_platform != 'darwin'",
-    "tensorflow>=2.15.0,<3.0.0; sys_platform == 'darwin'", # TensorFlow compatible for macOS
+    "tensorflow[and-cuda]>=2.15.0,<3.0.0; sys_platform == 'linux'",
+    "tensorflow>=2.15.0,<3.0.0; sys_platform != 'linux'", # TensorFlow compatible for macOS and Windows
     "tf-keras>=2.15.0,<3.0.0",  # Keep keras 2 compatibility
     "tf2onnx>=1.16.0,<2.0.0",  # cf. https://github.com/onnx/tensorflow-onnx/releases/tag/v1.16.0
     # PyTorch


### PR DESCRIPTION
This PR:

- the extra "[and-cuda]" is only available on linux
- for windows only WSL2 (linux) supports direct GPU support - where our logic would match - for native windows the extra does not exist same for MacOS

ref.: https://www.tensorflow.org/install/pip#windows-native