### PR TITLE
[Fix] Fix tqdm slack message write : monkeypatch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: no-commit-to-branch
         args: ['--branch', 'main']
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.3
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/references/classification/train_pytorch_character.py
+++ b/references/classification/train_pytorch_character.py
@@ -190,7 +190,13 @@ def evaluate(model, val_loader, batch_transforms, amp=False, log=None):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if args.push_to_hub:

--- a/references/classification/train_pytorch_orientation.py
+++ b/references/classification/train_pytorch_orientation.py
@@ -201,7 +201,13 @@ def evaluate(model, val_loader, batch_transforms, amp=False, log=None):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if args.push_to_hub:

--- a/references/classification/train_tensorflow_character.py
+++ b/references/classification/train_tensorflow_character.py
@@ -157,7 +157,13 @@ def collate_fn(samples):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if args.push_to_hub:

--- a/references/classification/train_tensorflow_orientation.py
+++ b/references/classification/train_tensorflow_orientation.py
@@ -171,7 +171,13 @@ def collate_fn(samples):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if args.push_to_hub:

--- a/references/detection/evaluate_pytorch.py
+++ b/references/detection/evaluate_pytorch.py
@@ -62,7 +62,13 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if not isinstance(args.workers, int):

--- a/references/detection/evaluate_tensorflow.py
+++ b/references/detection/evaluate_tensorflow.py
@@ -61,7 +61,13 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     # AMP

--- a/references/detection/train_pytorch.py
+++ b/references/detection/train_pytorch.py
@@ -185,7 +185,13 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False, log=Non
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if args.push_to_hub:

--- a/references/detection/train_pytorch_ddp.py
+++ b/references/detection/train_pytorch_ddp.py
@@ -194,8 +194,14 @@ def main(rank: int, world_size: int, args):
         world_size (int): number of processes participating in the job
         args: other arguments passed through the CLI
     """
-    pbar = tqdm(disable=True)
-    pbar.write(args)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
+    pbar.write(str(args))
 
     if rank == 0 and args.push_to_hub:
         login_to_hub()

--- a/references/detection/train_tensorflow.py
+++ b/references/detection/train_tensorflow.py
@@ -155,7 +155,13 @@ def evaluate(model, val_loader, batch_transforms, val_metric, log=None):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if args.push_to_hub:

--- a/references/recognition/evaluate_pytorch.py
+++ b/references/recognition/evaluate_pytorch.py
@@ -64,7 +64,13 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     torch.backends.cudnn.benchmark = True

--- a/references/recognition/evaluate_tensorflow.py
+++ b/references/recognition/evaluate_tensorflow.py
@@ -63,7 +63,13 @@ def evaluate(model, val_loader, batch_transforms, val_metric):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     # AMP

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -191,7 +191,13 @@ def evaluate(model, val_loader, batch_transforms, val_metric, amp=False, log=Non
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if args.push_to_hub:

--- a/references/recognition/train_pytorch_ddp.py
+++ b/references/recognition/train_pytorch_ddp.py
@@ -125,7 +125,13 @@ def main(rank: int, world_size: int, args):
         world_size (int): number of processes participating in the job
         args: other arguments passed through the CLI
     """
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if rank == 0 and args.push_to_hub:

--- a/references/recognition/train_tensorflow.py
+++ b/references/recognition/train_tensorflow.py
@@ -153,7 +153,13 @@ def evaluate(model, val_loader, batch_transforms, val_metric, log=None):
 
 
 def main(args):
-    pbar = tqdm(disable=True)
+    slack_token = os.getenv("TQDM_SLACK_TOKEN")
+    slack_channel = os.getenv("TQDM_SLACK_CHANNEL")
+
+    pbar = tqdm(disable=False if slack_token and slack_channel else True)
+    if slack_token and slack_channel:
+        # Monkey patch tqdm write method to send messages directly to Slack
+        pbar.write = lambda msg: pbar.sio.client.chat_postMessage(channel=slack_channel, text=msg)
     pbar.write(str(args))
 
     if args.push_to_hub:


### PR DESCRIPTION
This PR:

- monkeypatch `tqdm.write` if Slack logging is set to send messages directly to the Slack channel
- pbar needs to be "enabled" with Slack logging otherwise it can be disabled