### PR TITLE
[Fix] Fix loading targets in WILDRECEIPT init

### DIFF
--- a/doctr/datasets/wildreceipt.py
+++ b/doctr/datasets/wildreceipt.py
@@ -79,11 +79,11 @@ class WILDRECEIPT(AbstractDataset):
         # Split the text file into separate JSON strings
         json_strings = data.strip().split("\n")
         box: list[float] | np.ndarray
-        _targets = []
 
         for json_string in tqdm(
             iterable=json_strings, desc="Preparing and Loading WILDRECEIPT", total=len(json_strings)
         ):
+            _targets = []
             json_data = json.loads(json_string)
             img_path = json_data["file_name"]
             annotations = json_data["annotations"]

--- a/tests/pytorch/test_datasets_pt.py
+++ b/tests/pytorch/test_datasets_pt.py
@@ -734,7 +734,7 @@ def test_ic03(input_size, num_samples, rotate, recognition, detection, mock_ic03
     "input_size, num_samples, recognition, detection",
     [
         [[512, 512], 2, False, False],  # Actual set has 1268 training samples and 472 test samples
-        [[32, 128], 5, True, False],  # recognition
+        [[32, 128], 3, True, False],  # recognition
         [[512, 512], 2, False, True],  # detection
     ],
 )

--- a/tests/tensorflow/test_datasets_tf.py
+++ b/tests/tensorflow/test_datasets_tf.py
@@ -707,7 +707,7 @@ def test_ic03(input_size, num_samples, rotate, recognition, detection, mock_ic03
     "input_size, num_samples, recognition, detection",
     [
         [[512, 512], 2, False, False],  # Actual set has 1268 training samples and 472 test samples
-        [[32, 128], 5, True, False],  # recognition
+        [[32, 128], 3, True, False],  # recognition
         [[512, 512], 2, False, True],  # detection
     ],
 )


### PR DESCRIPTION
Hey :)
Thanks for the great repo.

While playing around with docTR and the Wildreceipt dataset I may have discovered a small bug.
When I print the labels in the targets for the second image, I also get the labels for the first image.

**Code to recreate bug:**
```
from doctr.datasets import WILDRECEIPT

test_set = WILDRECEIPT(train=False, img_folder=path_to_data + "/", label_path=path_to_data + "/test.txt")
img, target = test_set[1]
print(target["labels"])
```

**Result:**
`['CHOEUN', 'KOREANRESTAURANT', '2621ORANGETHORPEAVE,FULLERTON.', '(714)879-3574', 'THANKYOU!!', 'DATE', '12/30/2016FRI', '19:19', 'BIBIM.OCTOPUT1', 'S-FOODP.CAKT1', 'PORKDUMPLINT1', 'LABEEFRIBT1', '$13.99', '$14.99', '$8.99', '￥17.99', '4.00xITEMS', 'SUBTOTAL', 'TAX1', 'TOTAL', '$55.96', '$4.48', '$60.44','', '', 'TIME', "ILIO'S", 'Restaurant', 'BretonischerRing7', '85630Grasbrunn', 'TEL:', 'Steuer-Nr.:514/78510', 'RechnungNr.2844', 'Datum:', '10.07.13', '21:52', 'Tisch:102/--', '4x', '8x', '3x', '1x', '1x', '1x', '1x', '1x', '2x', '1x', '1x', '1x', '1x', '1x', 'Tee', 'Stifado', 'SchweinefiletMeta', 'BiftekiMetaxa', '', 'GyrosFolie', 'BabyKalamariGefu', 'Gyros', 'VegetarischeVaria', 'GrossesWasser', 'Saft0,25', 'Hefe-Weissbier', 'Weissbierdunkel', 'LowenbrauOriginal', 'a', 'a', 'a', 'a', '9,90', '3,30', '3,30', '3,00', '12,00', '26,40', '9,90', '2,50', '2,40', '9,90', '8,90', '12,90', '19,80', '6,90', '11,90', '13,90', '14,90', '2,10', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', 'Netto(1)', '+19,0%MwSt:', 'Eur129,75', '24,65', 'Summe:', 'EsbedienteSie:George', 'Eur154,40', '089-46169340']`

**Expected result:**
`["ILIO'S", 'Restaurant', 'BretonischerRing7', '85630Grasbrunn', 'TEL:', 'Steuer-Nr.:514/78510', 'RechnungNr.2844', 'Datum:', '10.07.13', '21:52', 'Tisch:102/--', '4x', '8x', '3x', '1x', '1x', '1x', '1x', '1x', '2x', '1x', '1x', '1x', '1x', '1x', 'Tee', 'Stifado', 'SchweinefiletMeta', 'BiftekiMetaxa', '', 'GyrosFolie', 'BabyKalamariGefu', 'Gyros', 'VegetarischeVaria', 'GrossesWasser', 'Saft0,25', 'Hefe-Weissbier', 'Weissbierdunkel', 'LowenbrauOriginal', 'a', 'a', 'a', 'a', '9,90', '3,30', '3,30', '3,00', '12,00', '26,40', '9,90', '2,50', '2,40', '9,90', '8,90', '12,90', '19,80', '6,90', '11,90', '13,90', '14,90', '2,10', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', 'Netto(1)', '+19,0%MwSt:', 'Eur129,75', '24,65', 'Summe:', 'EsbedienteSie:George', 'Eur154,40', '089-46169340']`

Could you confirm that this is a bug and not me doing something wrong? :) 

I provided a quick fix, that seems to solve the problem, but I didn't look too deep into the surrounding code.  
