### PR TITLE
Use OpenCV instead of Shapely to compute area & length

### DIFF
--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -58,9 +58,8 @@ class DBPostProcessor(DetectionPostProcessor):
             area = (rect[1][0] + 1) * (1 + rect[1][1])
             length = 2 * (rect[1][0] + rect[1][1]) + 2
         else:
-            poly = Polygon(points)
-            area = poly.area
-            length = poly.length
+            area = cv2.contourArea(points)
+            length = cv2.arcLength(points, True)  # True specifies that the polygon is closed
         distance = area * self.unclip_ratio / length  # compute distance to expand polygon
         offset = pyclipper.PyclipperOffset()
         offset.AddPath(points, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)

--- a/doctr/models/detection/differentiable_binarization/base.py
+++ b/doctr/models/detection/differentiable_binarization/base.py
@@ -59,7 +59,7 @@ class DBPostProcessor(DetectionPostProcessor):
             length = 2 * (rect[1][0] + rect[1][1]) + 2
         else:
             area = cv2.contourArea(points)
-            length = cv2.arcLength(points, True)  # True specifies that the polygon is closed
+            length = cv2.arcLength(points, closed=True)
         distance = area * self.unclip_ratio / length  # compute distance to expand polygon
         offset = pyclipper.PyclipperOffset()
         offset.AddPath(points, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)

--- a/doctr/models/detection/fast/base.py
+++ b/doctr/models/detection/fast/base.py
@@ -56,9 +56,8 @@ class FASTPostProcessor(DetectionPostProcessor):
             area = (rect[1][0] + 1) * (1 + rect[1][1])
             length = 2 * (rect[1][0] + rect[1][1]) + 2
         else:
-            poly = Polygon(points)
-            area = poly.area
-            length = poly.length
+            area = cv2.contourArea(points)
+            length = cv2.arcLength(points, closed=True)
         distance = area * self.unclip_ratio / length  # compute distance to expand polygon
         offset = pyclipper.PyclipperOffset()
         offset.AddPath(points, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)

--- a/doctr/models/detection/linknet/base.py
+++ b/doctr/models/detection/linknet/base.py
@@ -56,9 +56,8 @@ class LinkNetPostProcessor(DetectionPostProcessor):
             area = (rect[1][0] + 1) * (1 + rect[1][1])
             length = 2 * (rect[1][0] + rect[1][1]) + 2
         else:
-            poly = Polygon(points)
-            area = poly.area
-            length = poly.length
+            area = cv2.contourArea(points)
+            length = cv2.arcLength(points, closed=True)
         distance = area * self.unclip_ratio / length  # compute distance to expand polygon
         offset = pyclipper.PyclipperOffset()
         offset.AddPath(points, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)


### PR DESCRIPTION
I've recently had the occasion to profile doctr under the following conditions:
* PyTorch with CUDA support
* Models: db_resnet50 & crnn_mobilenet_v3_large
* Approximately 100 png pages at DPI 144, all like:
```
image0199.png PNG 1225x1592 1225x1592+0+0 8-bit Grayscale Gray 256c 623356B 0.000u 0:00.000
```

I performed this profiling using the following command:
```
python scripts/detect_text.py \
  --detection db_resnet50 \
  --recognition crnn_mobilenet_v3_large \
  --profile \
  --gpu \
  -f txt \
  ~/ocr-test-data-small
```
This uses the `--profile` feature added by [my other PR `lachesis/speedup`](https://github.com/mindee/doctr/pull/1921).

When running this profiling against the main branch, there was one particular hot-spot that stood out to me: `DBPostProcessor.bitmap_to_boxes`.

Here's the summary of profile results from `main` branch:
```
name                                  ncall  tsub      ttot      tavg
..ts/detect_text.py:31 _process_file  100    0.002690  30.82888  0.308289
..iateLayerGetter._wrapped_call_impl  108..  0.173479  29.58701  0.000274
..IntermediateLayerGetter._call_impl  108..  0.276560  29.58619  0.000274
..contextlib.py:113 decorate_context  300..  0.011787  29.53269  0.098442
..pytorch.py:68 OCRPredictor.forward  100    0.102630  29.52088  0.295209
..h.py:36 DetectionPredictor.forward  100    0.023595  20.83610  0.208361
..orch/_dynamo/eval_frame.py:738 _fn  436    0.002926  19.46826  0.044652
..ation/pytorch.py:182 DBNet.forward  100    0.002712  19.18771  0.191877
..zation/pytorch.py:209 _postprocess  100    0.004042  18.27577  0.182758
..threading.py:1001 DummyProcess.run  6400   0.030777  16.96338  0.002651
../multiprocessing/pool.py:97 worker  6400   0.113530  16.93260  0.002646
..ore.py:67 DBPostProcessor.__call__  100    0.032652  16.82873  0.168287
..87 DBPostProcessor.bitmap_to_boxes  100    0.513065  16.76806  0.167681
..multiprocessing/pool.py:47 mapstar  6273   0.091664  16.66083  0.002656
..:63 PreProcessor.sample_transforms  36156  1.210768  15.51966  0.000429
...py:1735 Resize._wrapped_call_impl  36156  0.129941  11.56882  0.000320
..:41 DBPostProcessor.polygon_to_box  36056  0.590418  11.54334  0.000320
..s/module.py:1743 Resize._call_impl  36156  0.247052  11.43888  0.000316
..dules/pytorch.py:46 Resize.forward  36156  0.546462  11.12890  0.000308
..ometry/polygon.py:227 type.__new__  36056  0.124436  10.14139  0.000281
```

Digging in a bit more to bitmap_to_boxes, I found that it spends most of its time in polygon_to_box. Following the chain one step deeper, I see that polygon_to_box spends most of its time constructing Polygon objects from shapely.

```
index: 1507
full_name: /home/eswanson/build/doctr/doctr/models/detection/differentiable_binarization/base.py:41 DBPostProcessor.polygon_to_
box
ncall: 36056/36056
ttot: 11.54334
tsub: 0.590418
children:
[...snip...]
     index: 1508
     child_full_name: /home/eswanson/.virtualenvs/doctr/lib/python3.12/site-packages/shapely/geometry/polygon.py:227 type.__new__
     ncall: 36056/36056
     ttot: 10.14139
     tsub: 0.124436
 ```
 
When I read the code, I found that the only use of the Polygon object is to determine the length and area of the polygon. This can be done more quickly with OpenCV, which I did in this patch.

After my change, here are the profiling results. First, the overview:

```
name                                  ncall  tsub      ttot      tavg
..ts/detect_text.py:31 _process_file  100    0.002764  19.76283  0.197628
..iateLayerGetter._wrapped_call_impl  108..  0.175892  18.55127  0.000172
..IntermediateLayerGetter._call_impl  108..  0.283103  18.55051  0.000172
..contextlib.py:113 decorate_context  300..  0.012536  18.49680  0.061656
..pytorch.py:68 OCRPredictor.forward  100    0.105497  18.48428  0.184843
..threading.py:1001 DummyProcess.run  6400   0.026669  16.99363  0.002655
../multiprocessing/pool.py:97 worker  6400   0.113410  16.96696  0.002651
..multiprocessing/pool.py:47 mapstar  6273   0.089179  16.70031  0.002662
..:63 PreProcessor.sample_transforms  36156  1.209691  15.60890  0.000432
...py:1735 Resize._wrapped_call_impl  36156  0.128980  11.63751  0.000322
..s/module.py:1743 Resize._call_impl  36156  0.161906  11.50853  0.000318
..dules/pytorch.py:46 Resize.forward  36156  0.547900  11.28371  0.000312
..h.py:36 DetectionPredictor.forward  100    0.018017  9.696090  0.096961
..ransforms/functional.py:387 resize  36156  0.400305  9.659155  0.000267
..orch/_dynamo/eval_frame.py:738 _fn  436    0.003053  8.349256  0.019150
..s/_functional_tensor.py:441 resize  36080  0.426427  8.143900  0.000226
..ation/pytorch.py:182 DBNet.forward  100    0.002784  8.051557  0.080516
```

Second, the detailed breakdown for bitmap_to_boxes:
```
index: 1481
full_name: /home/eswanson/build/doctr/doctr/models/detection/differentiable_binarization/base.py:86 DBPostProcessor.bitmap_to_boxes
ncall: 100/100
ttot: 5.625161
tsub: 0.429655
children:
[...snip...]
     index: 1508
     child_full_name: /home/eswanson/build/doctr/doctr/models/detection/differentiable_binarization/base.py:41 DBPostProcessor.polygon_to_box
     ncall: 36056/36056
     ttot: 0.799733
     tsub: 0.475089

     index: 1493
     child_full_name: /home/eswanson/build/doctr/doctr/models/detection/core.py:33 box_score
     ncall: 36056/36056
     ttot: 3.645177
     tsub: 0.628202
```

With this change, a step that took almost 12 seconds of CPU time over 100 images is reduced to using less than 1 second of CPU time.

Here are the full fast and slow profile results as well as a ZIP of the test data files (which had to be split into two because of Github file size limits).

[slow-results.txt](https://github.com/user-attachments/files/19814732/slow-results.txt)
[fast-results.txt](https://github.com/user-attachments/files/19814733/fast-results.txt)
[ocr-test-data-small.002.zip](https://github.com/user-attachments/files/19814753/ocr-test-data-small.002.zip)
[ocr-test-data-small.001.zip](https://github.com/user-attachments/files/19814755/ocr-test-data-small.001.zip)

