### PR TITLE
[datasets] feat: add croatian vocabulary

### DIFF
--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -116,6 +116,9 @@ of vocabs.
    * - german
      - 108
      - 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~°£€¥¢฿äöüßÄÖÜẞ
+   * - croatian
+     - 110
+     - 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~°£€¥¢฿ČčĆćĐđŠšŽž
    * - french
      - 126
      - 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~°£€¥¢฿àâéèêëîïôùûüçÀÂÉÈÊËÎÏÔÙÛÜÇ
@@ -189,5 +192,5 @@ of vocabs.
      - 115
      - абвгдежзийклмнопрстуфхцчшщьюяАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЮЯ0123456789!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~°£€¥¢฿ґіїєҐІЇЄ₴
    * - multilingual
-     - 195
-     - english & french & german & italian & spanish & portuguese & czech & polish & dutch & norwegian & danish & finnish & swedish & §
+     - 205
+     - english & french & german & italian & spanish & portuguese & czech & croatian & polish & dutch & norwegian & danish & finnish & swedish & §

--- a/doctr/datasets/vocabs.py
+++ b/doctr/datasets/vocabs.py
@@ -63,6 +63,8 @@ VOCABS["finnish"] = VOCABS["english"] + "äöÄÖ"
 
 VOCABS["german"] = VOCABS["english"] + "äöüßÄÖÜẞ"
 
+VOCABS["croatian"] = VOCABS["english"] + "ČčĆćĐđŠšŽž"
+
 VOCABS["hebrew"] = (
     VOCABS["english"]
     + VOCABS["hebrew_letters"]
@@ -140,6 +142,7 @@ VOCABS["multilingual"] = "".join(
         + VOCABS["spanish"]
         + VOCABS["german"]
         + VOCABS["czech"]
+        + VOCABS["croatian"]
         + VOCABS["polish"]
         + VOCABS["dutch"]
         + VOCABS["italian"]


### PR DESCRIPTION
I have two questions:

1. How do you want to handle languages that use a dual writing system (e.g., Serbian)? Do you want to be able to address them individually so they can be blacklisted/whitelisted or just put them in the same bucket?
2. Can I contribute wordlists? I don't know how you're generating them at the moment.

