### PR TITLE
[Fix] Improve merge for recognition of long words (#1936)

### DIFF
--- a/doctr/models/recognition/predictor/_utils.py
+++ b/doctr/models/recognition/predictor/_utils.py
@@ -4,6 +4,8 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 
+from math import ceil, floor
+
 import numpy as np
 
 from ..utils import merge_multi_strings
@@ -15,60 +17,94 @@ def split_crops(
     crops: list[np.ndarray],
     max_ratio: float,
     target_ratio: int,
-    dilation: float,
+    target_overlap_ratio: float,
     channels_last: bool = True,
-) -> tuple[list[np.ndarray], list[int | tuple[int, int]], bool]:
-    """Chunk crops horizontally to match a given aspect ratio
+) -> tuple[list[np.ndarray], list[int | tuple[int, int, float]], bool]:
+    """Split crops horizontally to match a given aspect ratio
 
     Args:
+    ----
         crops: list of numpy array of shape (H, W, 3) if channels_last or (3, H, W) otherwise
-        max_ratio: the maximum aspect ratio that won't trigger the chunk
-        target_ratio: when crops are chunked, they will be chunked to match this aspect ratio
-        dilation: the width dilation of final chunks (to provide some overlaps)
+        max_ratio: the maximum aspect ratio that won't trigger the splitting
+        target_ratio: when a crop are split, it will be split to match this aspect ratio.
+          The default value of 4 corresponds to the recognition models' input size of 32 times 128 pixels
+        target_overlap_ratio: the target ratio how much a split overlaps with a neighboring split
         channels_last: whether the numpy array has dimensions in channels last order
 
     Returns:
+    -------
         a tuple with the new crops, their mapping, and a boolean specifying whether any remap is required
     """
     _remap_required = False
-    crop_map: list[int | tuple[int, int]] = []
+    splits_map: list[int | tuple[int, int, float]] = []
     new_crops: list[np.ndarray] = []
     for crop in crops:
         h, w = crop.shape[:2] if channels_last else crop.shape[-2:]
-        aspect_ratio = w / h
-        if aspect_ratio > max_ratio:
-            # Determine the number of crops, reference aspect ratio = 4 = 128 / 32
-            num_subcrops = int(aspect_ratio // target_ratio)
-            # Find the new widths, additional dilation factor to overlap crops
-            width = dilation * w / num_subcrops
-            centers = [(w / num_subcrops) * (1 / 2 + idx) for idx in range(num_subcrops)]
-            # Get the crops
-            if channels_last:
-                _crops = [
-                    crop[:, max(0, int(round(center - width / 2))) : min(w - 1, int(round(center + width / 2))), :]
-                    for center in centers
-                ]
-            else:
-                _crops = [
-                    crop[:, :, max(0, int(round(center - width / 2))) : min(w - 1, int(round(center + width / 2)))]
-                    for center in centers
-                ]
+        actual_crop_ratio = w / h
+        if actual_crop_ratio > max_ratio:
+            target_split_width = ceil(h * target_ratio)
+            target_split_overlap_width = floor(target_split_width * target_overlap_ratio)
+
+            splits, last_overlap_ratio = _split_horizontally(
+                crop,
+                target_split_width,
+                target_split_overlap_width,
+                channels_last,
+            )
+
             # Avoid sending zero-sized crops
-            _crops = [crop for crop in _crops if all(s > 0 for s in crop.shape)]
+            splits = [split for split in splits if all(s > 0 for s in split.shape)]
             # Record the slice of crops
-            crop_map.append((len(new_crops), len(new_crops) + len(_crops)))
-            new_crops.extend(_crops)
+            splits_map.append((len(new_crops), len(new_crops) + len(splits), last_overlap_ratio))
+            new_crops.extend(splits)
             # At least one crop will require merging
             _remap_required = True
         else:
-            crop_map.append(len(new_crops))
+            splits_map.append(len(new_crops))
             new_crops.append(crop)
 
-    return new_crops, crop_map, _remap_required
+    return new_crops, splits_map, _remap_required
+
+
+def _split_horizontally(
+    image: np.ndarray, split_width: int, split_overlap_width: int, channels_last: bool
+) -> tuple[list[np.ndarray], float]:
+    image_width = image.shape[1] if channels_last else image.shape[-1]
+    if image_width <= split_width:
+        return [image], 0
+
+    splits = []
+    current_split_start_column = 0
+    previous_split_end_column = 0
+    last_overlap_ratio = 0.0
+    has_reached_end_of_image = False
+    while not has_reached_end_of_image:
+        current_split_end_column = current_split_start_column + split_width
+        current_split_end_column = min(current_split_end_column, image_width)
+
+        # Increase overlap of last split to prevent narrow last split
+        has_reached_end_of_image = current_split_end_column == image_width
+        if has_reached_end_of_image:
+            current_split_start_column = max(0, image_width - split_width)
+
+        if channels_last:
+            image_split = image[:, current_split_start_column:current_split_end_column, :]
+        else:
+            image_split = image[:, :, current_split_start_column:current_split_end_column]
+
+        # Save overlap ratio of the last split, because this one might be larger than other overlap ratios
+        if has_reached_end_of_image:
+            current_overlap_width = previous_split_end_column - current_split_start_column
+            last_overlap_ratio = current_overlap_width / split_width
+
+        splits.append(image_split)
+        previous_split_end_column = current_split_end_column
+        current_split_start_column = current_split_end_column - split_overlap_width
+    return splits, last_overlap_ratio
 
 
 def remap_preds(
-    preds: list[tuple[str, float]], crop_map: list[int | tuple[int, int]], dilation: float
+    preds: list[tuple[str, float]], crop_map: list[int | tuple[int, int, float]], split_overlap_ratio: float
 ) -> list[tuple[str, float]]:
     remapped_out = []
     for _idx in crop_map:
@@ -76,8 +112,9 @@ def remap_preds(
         if isinstance(_idx, int):
             remapped_out.append(preds[_idx])
         else:
-            # unzip
             vals, probs = zip(*preds[_idx[0] : _idx[1]])
+            last_split_overlap_ratio = _idx[2]
             # Merge the string values
-            remapped_out.append((merge_multi_strings(vals, dilation), min(probs)))  # type: ignore[arg-type]
+            merged_string = (merge_multi_strings(vals, split_overlap_ratio, last_split_overlap_ratio), min(probs))
+            remapped_out.append(merged_string)
     return remapped_out

--- a/doctr/models/recognition/predictor/pytorch.py
+++ b/doctr/models/recognition/predictor/pytorch.py
@@ -38,7 +38,7 @@ class RecognitionPredictor(nn.Module):
         self.model = model.eval()
         self.split_wide_crops = split_wide_crops
         self.critical_ar = 8  # Critical aspect ratio
-        self.dil_factor = 1.4  # Dilation factor to overlap the crops
+        self.overlap_ratio = 0.5  # Ratio of overlap between neighboring crops
         self.target_ar = 6  # Target aspect ratio
 
     @torch.inference_mode()
@@ -60,7 +60,7 @@ class RecognitionPredictor(nn.Module):
                 crops,  # type: ignore[arg-type]
                 self.critical_ar,
                 self.target_ar,
-                self.dil_factor,
+                self.overlap_ratio,
                 isinstance(crops[0], np.ndarray),
             )
             if remapped:
@@ -81,6 +81,6 @@ class RecognitionPredictor(nn.Module):
 
         # Remap crops
         if self.split_wide_crops and remapped:
-            out = remap_preds(out, crop_map, self.dil_factor)
+            out = remap_preds(out, crop_map, self.overlap_ratio)
 
         return out

--- a/doctr/models/recognition/predictor/tensorflow.py
+++ b/doctr/models/recognition/predictor/tensorflow.py
@@ -39,7 +39,7 @@ class RecognitionPredictor(NestedObject):
         self.model = model
         self.split_wide_crops = split_wide_crops
         self.critical_ar = 8  # Critical aspect ratio
-        self.dil_factor = 1.4  # Dilation factor to overlap the crops
+        self.overlap_ratio = 0.5  # Ratio of overlap between neighboring crops
         self.target_ar = 6  # Target aspect ratio
 
     def __call__(
@@ -56,7 +56,7 @@ class RecognitionPredictor(NestedObject):
         # Split crops that are too wide
         remapped = False
         if self.split_wide_crops:
-            new_crops, crop_map, remapped = split_crops(crops, self.critical_ar, self.target_ar, self.dil_factor)
+            new_crops, crop_map, remapped = split_crops(crops, self.critical_ar, self.target_ar, self.overlap_ratio)
             if remapped:
                 crops = new_crops
 
@@ -74,6 +74,6 @@ class RecognitionPredictor(NestedObject):
 
         # Remap crops
         if self.split_wide_crops and remapped:
-            out = remap_preds(out, crop_map, self.dil_factor)
+            out = remap_preds(out, crop_map, self.overlap_ratio)
 
         return out

--- a/doctr/models/recognition/utils.py
+++ b/doctr/models/recognition/utils.py
@@ -4,81 +4,117 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 
-from rapidfuzz.distance import Levenshtein
+from rapidfuzz.distance import Hamming
 
 __all__ = ["merge_strings", "merge_multi_strings"]
 
 
-def merge_strings(a: str, b: str, dil_factor: float) -> str:
+def merge_strings(a: str, b: str, overlap_ratio: float) -> str:
     """Merges 2 character sequences in the best way to maximize the alignment of their overlapping characters.
 
     Args:
         a: first char seq, suffix should be similar to b's prefix.
         b: second char seq, prefix should be similar to a's suffix.
-        dil_factor: dilation factor of the boxes to overlap, should be > 1. This parameter is
-            only used when the mother sequence is splitted on a character repetition
+        overlap_ratio: estimated ratio of overlapping characters.
 
     Returns:
         A merged character sequence.
 
     Example::
-        >>> from doctr.models.recognition.utils import merge_sequences
-        >>> merge_sequences('abcd', 'cdefgh', 1.4)
+        >>> from doctr.models.recognition.utils import merge_strings
+        >>> merge_strings('abcd', 'cdefgh', 0.33)
         'abcdefgh'
-        >>> merge_sequences('abcdi', 'cdefgh', 1.4)
+        >>> merge_strings('abcdi', 'cdefgh', 0.5)
         'abcdefgh'
     """
-    seq_len = min(len(a), len(b))
-    if seq_len == 0:  # One sequence is empty, return the other
-        return b if len(a) == 0 else a
+    lower_inputs_len = min(len(a), len(b))
+    if lower_inputs_len <= 1:  # One sequence is empty or will be after cropping in next step, return the other
+        return b if len(a) == lower_inputs_len else a
 
-    # Initialize merging index and corresponding score (mean Levenstein)
-    min_score, index = 1.0, 0  # No overlap, just concatenate
+    # Remove last letter of "a" and first of "b", because they might be cut off. The removed characters are still
+    # present in the other string due to overlap
+    a_crop = a[:-1]
+    b_crop = b[1:]
 
-    scores = [Levenshtein.distance(a[-i:], b[:i], processor=None) / i for i in range(1, seq_len + 1)]
+    # Increase overlap step by step and compute number of different characters per overlap
+    max_overlap = min(len(a_crop), len(b_crop))
+    scores = [Hamming.distance(a_crop[-i:], b_crop[:i], processor=None) for i in range(1, max_overlap + 1)]
 
-    # Edge case (split in the middle of char repetitions): if it starts with 2 or more 0
-    if len(scores) > 1 and (scores[0], scores[1]) == (0, 0):
-        # Compute n_overlap (number of overlapping chars, geometrically determined)
-        n_overlap = round(len(b) * (dil_factor - 1) / dil_factor)
-        # Find the number of consecutive zeros in the scores list
-        # Impossible to have a zero after a non-zero score in that case
-        n_zeros = sum(val == 0 for val in scores)
-        # Index is bounded by the geometrical overlap to avoid collapsing repetitions
-        min_score, index = 0, min(n_zeros, n_overlap)
+    indexes_of_zero_scores = [i for i, score in enumerate(scores) if score == 0]
 
-    else:  # Common case: choose the min score index
-        for i, score in enumerate(scores):
-            if score < min_score:
-                min_score, index = score, i + 1  # Add one because first index is an overlap of 1 char
+    # Case 1: One perfect match - exactly one zero score - just merge there
+    has_exactly_one_perfect_match = len(indexes_of_zero_scores) == 1
+    if has_exactly_one_perfect_match:
+        index_of_zero_score = indexes_of_zero_scores[0]
+        return a_crop + b_crop[index_of_zero_score + 1 :]
 
-    # Merge with correct overlap
-    if index == 0:
-        return a + b
-    return a[:-1] + b[index - 1 :]
+    # Case 2: Multiple perfect matches - Indicates repetitions of characters in overlap: Use estimated number of
+    # characters in overlap to estimate which zero score fits bests
+
+    # Estimate the number of characters in the overlap - use "b" because "a" might be a merged string already
+    number_of_chars_in_overlap = round(len(b) * overlap_ratio)
+    # Account for the cropped letters in a and b
+    number_of_chars_in_cropped_overlap = number_of_chars_in_overlap - 2
+
+    has_multiple_perfect_matches = len(indexes_of_zero_scores) > 1
+    if has_multiple_perfect_matches:
+        closest_index_of_zero_score_to_expected_overlap = _get_index_closest_to_target_index(
+            indexes_of_zero_scores, number_of_chars_in_cropped_overlap
+        )
+        return a_crop + b_crop[closest_index_of_zero_score_to_expected_overlap + 1 :]
+
+    # Absence of zero scores indicates that the same character in the image was recognized differently OR that the
+    # overlap was too small and we just need to merge the crops fully
+
+    # Case 3: Merge crops fully
+    if number_of_chars_in_cropped_overlap < 1:
+        return a_crop + b_crop
+
+    # Case 4: Merge where low score fits best to estimated number of characters in overlap
+    combined_scores = []
+    for i, score in enumerate(scores):
+        distance_to_estimated_overlap = abs(number_of_chars_in_cropped_overlap - i)
+        combined_scores.append(score + distance_to_estimated_overlap)
+    index_of_min_combined_score = combined_scores.index(min(combined_scores))
+    return a_crop + b_crop[index_of_min_combined_score + 1 :]
 
 
-def merge_multi_strings(seq_list: list[str], dil_factor: float) -> str:
-    """Recursively merges consecutive string sequences with overlapping characters.
+def _get_index_closest_to_target_index(indexes: list[int], target_index: int) -> int:
+    closest_index_to_target = -1
+    min_distance = float("inf")
+    for i in indexes:
+        distance_to_target_index = abs(target_index - i)
+        if distance_to_target_index < min_distance:
+            min_distance = distance_to_target_index
+            closest_index_to_target = i
+    return closest_index_to_target
+
+
+def merge_multi_strings(seq_list: list[str], overlap_ratio: float, last_overlap_ratio: float) -> str:
+    """Merges consecutive string sequences with overlapping characters.
 
     Args:
+    ----
         seq_list: list of sequences to merge. Sequences need to be ordered from left to right.
-        dil_factor: dilation factor of the boxes to overlap, should be > 1. This parameter is
-            only used when the mother sequence is splitted on a character repetition
+        overlap_ratio: Estimated ratio of overlapping letters between neighboring strings.
+        last_overlap_ratio: Estimated ratio of overlapping letters for the last element in seq_list.
 
     Returns:
+    -------
         A merged character sequence
 
     Example::
-        >>> from doctr.models.recognition.utils import merge_multi_sequences
-        >>> merge_multi_sequences(['abc', 'bcdef', 'difghi', 'aijkl'], 1.4)
+        >>> from doctr.models.recognition.utils import merge_multi_strings
+        >>> merge_multi_strings(['abc', 'bcdef', 'difghi', 'aijkl'], 0.5, 0.1)
         'abcdefghijkl'
     """
+    result = seq_list[0]
+    for i in range(1, len(seq_list)):
+        text_a = result
+        text_b = seq_list[i]
+        if len(seq_list) == i + 1:
+            overlap_ratio = last_overlap_ratio
 
-    def _recursive_merge(a: str, seq_list: list[str], dil_factor: float) -> str:
-        # Recursive version of compute_overlap
-        if len(seq_list) == 1:
-            return merge_strings(a, seq_list[0], dil_factor)
-        return _recursive_merge(merge_strings(a, seq_list[0], dil_factor), seq_list[1:], dil_factor)
+        result = merge_strings(text_a, text_b, overlap_ratio)
 
-    return _recursive_merge("", seq_list, dil_factor)
+    return result

--- a/tests/common/test_models_recognition_predictor.py
+++ b/tests/common/test_models_recognition_predictor.py
@@ -5,35 +5,160 @@ from doctr.models.recognition.predictor._utils import remap_preds, split_crops
 
 
 @pytest.mark.parametrize(
-    "crops, max_ratio, target_ratio, dilation, channels_last, num_crops",
+    "crops, max_ratio, target_ratio, target_overlap_ratio, channels_last, num_crops",
     [
         # No split required
-        [[np.zeros((32, 128, 3), dtype=np.uint8)], 8, 4, 1.4, True, 1],
-        [[np.zeros((3, 32, 128), dtype=np.uint8)], 8, 4, 1.4, False, 1],
+        [[np.zeros((32, 128, 3), dtype=np.uint8)], 8, 4, 0.5, True, 1],
+        [[np.zeros((3, 32, 128), dtype=np.uint8)], 8, 4, 0.5, False, 1],
         # Split required
-        [[np.zeros((32, 1024, 3), dtype=np.uint8)], 8, 6, 1.4, True, 5],
-        [[np.zeros((3, 32, 1024), dtype=np.uint8)], 8, 6, 1.4, False, 5],
+        [[np.zeros((32, 1024, 3), dtype=np.uint8)], 8, 6, 0.5, True, 10],
+        [[np.zeros((3, 32, 1024), dtype=np.uint8)], 8, 6, 0.5, False, 10],
     ],
 )
-def test_split_crops(crops, max_ratio, target_ratio, dilation, channels_last, num_crops):
-    new_crops, crop_map, should_remap = split_crops(crops, max_ratio, target_ratio, dilation, channels_last)
+def test_split_crops(crops, max_ratio, target_ratio, target_overlap_ratio, channels_last, num_crops):
+    new_crops, crop_map, should_remap = split_crops(crops, max_ratio, target_ratio, target_overlap_ratio, channels_last)
     assert len(new_crops) == num_crops
     assert len(crop_map) == len(crops)
     assert should_remap == (len(crops) != len(new_crops))
 
 
 @pytest.mark.parametrize(
-    "preds, crop_map, dilation, pred",
+    "preds, crop_map, split_overlap_ratio, pred",
     [
         # Nothing to remap
-        [[("hello", 0.5)], [0], 1.4, [("hello", 0.5)]],
+        ([("hello", 0.5)], [0], 0.5, [("hello", 0.5)]),
         # Merge
-        [[("hellowo", 0.5), ("loworld", 0.6)], [(0, 2)], 1.4, [("helloworld", 0.5)]],
+        ([("hellowo", 0.5), ("loworld", 0.6)], [(0, 2, 0.5)], 0.5, [("helloworld", 0.5)]),
     ],
 )
-def test_remap_preds(preds, crop_map, dilation, pred):
-    preds = remap_preds(preds, crop_map, dilation)
+def test_remap_preds(preds, crop_map, split_overlap_ratio, pred):
+    preds = remap_preds(preds, crop_map, split_overlap_ratio)
     assert len(preds) == len(pred)
     assert preds == pred
     assert all(isinstance(pred, tuple) for pred in preds)
     assert all(isinstance(pred[0], str) and isinstance(pred[1], float) for pred in preds)
+
+
+def test_dont_split_if_not_necessary():
+    max_ratio = 4
+    inputs = [np.zeros((32, 32 * max_ratio, 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio, target_ratio=4, target_overlap_ratio=0.5)
+
+    assert not _remap_required
+    assert len(inputs) == len(new_crops)
+    assert len(new_crops) == 1
+    assert np.array_equal(inputs[0], new_crops[0])
+    assert crop_map[0] == 0
+
+
+def test_split_if_necessary():
+    max_ratio = 4
+    inputs = [np.zeros((32, 32 * max_ratio + 1, 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio, target_ratio=4, target_overlap_ratio=0.5)
+
+    assert _remap_required
+    assert len(inputs) < len(new_crops)
+    assert len(new_crops) == 2
+    assert not np.array_equal(inputs[0], new_crops[0])
+    assert crop_map[0] == (0, 2, 0.9921875)
+
+
+def test_split_only_if_necessary_with_larger_max_ratio():
+    max_ratio = 8
+    inputs = [np.zeros((32, 32 * max_ratio, 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio, target_ratio=4, target_overlap_ratio=0.5)
+
+    assert not _remap_required
+    assert len(inputs) == len(new_crops)
+    assert len(new_crops) == 1
+    assert np.array_equal(inputs[0], new_crops[0])
+    assert crop_map[0] == 0
+
+
+def test_split_in_two_equally_shaped_crops_with_half_overlap():
+    inputs = [np.zeros((32, 128 + int(128 / 2), 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio=4, target_ratio=4, target_overlap_ratio=0.5)
+
+    assert _remap_required
+    assert len(new_crops) == 2
+    for crop in new_crops:
+        assert crop.shape == (32, 128, 3)
+    assert crop_map[0] == (0, 2, 0.5)
+
+
+def test_split_in_two_equally_shaped_crops_with_half_overlap_channels_first():
+    inputs = [np.zeros((3, 32, 128 + int(128 / 2)))]
+
+    new_crops, crop_map, _remap_required = split_crops(
+        inputs, max_ratio=4, target_ratio=4, target_overlap_ratio=0.5, channels_last=False
+    )
+
+    assert _remap_required
+    assert len(new_crops) == 2
+    for crop in new_crops:
+        assert crop.shape == (3, 32, 128)
+    assert crop_map[0] == (0, 2, 0.5)
+
+
+def test_split_in_two_equally_shaped_crops_with_half_overlap_with_max_ratio_below_target_split_ratio():
+    inputs = [np.zeros((32, 128 + int(128 / 2), 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio=2, target_ratio=4, target_overlap_ratio=0.5)
+
+    assert _remap_required
+    assert len(new_crops) == 2
+    for crop in new_crops:
+        assert crop.shape == (32, 128, 3)
+    assert crop_map[0] == (0, 2, 0.5)
+
+
+def test_split_in_two_equally_shaped_crops_with_greater_than_half_last_overlap_ratio():
+    inputs = [np.zeros((32, 128 + int(128 / 4), 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio=4, target_ratio=4, target_overlap_ratio=0.5)
+
+    assert _remap_required
+    assert len(new_crops) == 2
+    for crop in new_crops:
+        assert crop.shape == (32, 128, 3)
+    assert crop_map[0] == (0, 2, 0.75)
+
+
+def test_split_in_three_equally_shaped_crops_with_half_last_overlap_ratio():
+    inputs = [np.zeros((32, 128 + 128, 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio=4, target_ratio=4, target_overlap_ratio=0.5)
+
+    assert _remap_required
+    assert len(new_crops) == 3
+    for crop in new_crops:
+        assert crop.shape == (32, 128, 3)
+    assert crop_map[0] == (0, 3, 0.5)
+
+
+def test_split_in_three_equally_shaped_crops_with_greater_than_half_last_overlap_ratio():
+    inputs = [np.zeros((32, 128 + int(128 / 2) + int(128 / 4), 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio=4, target_ratio=4, target_overlap_ratio=0.5)
+
+    assert _remap_required
+    assert len(new_crops) == 3
+    for crop in new_crops:
+        assert crop.shape == (32, 128, 3)
+    assert crop_map[0] == (0, 3, 0.75)
+
+
+def test_split_into_larger_crops():
+    inputs = [np.zeros((32, 192 * 2, 3))]
+
+    new_crops, crop_map, _remap_required = split_crops(inputs, max_ratio=4, target_ratio=6, target_overlap_ratio=0.5)
+
+    assert _remap_required
+    assert len(new_crops) == 3
+    for crop in new_crops:
+        assert crop.shape == (32, 192, 3)
+    assert crop_map[0] == (0, 3, 0.5)

--- a/tests/common/test_models_recognition_utils.py
+++ b/tests/common/test_models_recognition_utils.py
@@ -1,31 +1,206 @@
 import pytest
 
-from doctr.models.recognition.utils import merge_multi_strings, merge_strings
+from doctr.models.recognition.utils import _get_index_closest_to_target_index, merge_multi_strings, merge_strings
+
+
+# Last character of first string and first of last string will be cropped when merging - indicated by X
+@pytest.mark.parametrize(
+    "a, b, overlap_ratio, merged",
+    [
+        ("abcX", "Xdef", 0.25, "abcdef"),
+        ("abcdX", "Xdef", 0.75, "abcdef"),
+        ("abcdeX", "Xdef", 0.9, "abcdef"),
+        ("abcdefX", "Xdef", 0.9, "abcdef"),
+        ("abccccX", "Xcccccc", 0.4, "abcccccccc"),
+        ("abc", "", 0.5, "abc"),
+        ("", "abc", 0.5, "abc"),
+    ],
+)
+def test_merge_strings(a, b, overlap_ratio, merged):
+    assert merged == merge_strings(a, b, overlap_ratio)
 
 
 @pytest.mark.parametrize(
-    "a, b, merged",
+    "seq_list, overlap_ratio, last_overlap_ratio, merged",
     [
-        ["abc", "def", "abcdef"],
-        ["abcd", "def", "abcdef"],
-        ["abcde", "def", "abcdef"],
-        ["abcdef", "def", "abcdef"],
-        ["abcccc", "cccccc", "abcccccccc"],
-        ["abc", "", "abc"],
-        ["", "abc", "abc"],
+        (["abcX", "Xdef"], 0.25, 0.25, "abcdef"),
+        (["abcdX", "XdefX", "XefghX", "Xijk"], 0.5, 0.5, "abcdefghijk"),
+        (["abcdX", "XdefX", "XefghiX", "Xaijk"], 0.5, 0.8, "abcdefghijk"),
     ],
 )
-def test_merge_strings(a, b, merged):
-    assert merged == merge_strings(a, b, 1.4)
+def test_merge_multi_strings(seq_list, overlap_ratio, last_overlap_ratio, merged):
+    assert merged == merge_multi_strings(seq_list, overlap_ratio, last_overlap_ratio)
 
 
-@pytest.mark.parametrize(
-    "seq_list, merged",
-    [
-        [["abc", "def"], "abcdef"],
-        [["abcd", "def", "efgh", "ijk"], "abcdefghijk"],
-        [["abcdi", "defk", "efghi", "aijk"], "abcdefghijk"],
-    ],
-)
-def test_merge_multi_strings(seq_list, merged):
-    assert merged == merge_multi_strings(seq_list, 1.4)
+def test_example_from_docs_1():
+    a = "abcd"
+    b__ = "cdefgh"
+    # weirdly named b__ to easily see where a and b overlap
+    expected_result = "abcdefgh"
+    overlap_ratio = 0.33
+
+    result = merge_strings(a, b__, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_example_from_docs_2():
+    a = "abcdi"
+    b__ = "cdefgh"
+    # weirdly named b__ to easily see where a and b overlap
+    expected_result = "abcdefgh"
+    overlap_ratio = 0.5
+
+    result = merge_strings(a, b__, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_no_overlap_after_crop():
+    a = "abcdX"
+    b___ = "Xefghi"
+    expected_result = "abcdefghi"
+    overlap_ratio = 0.33
+
+    result = merge_strings(a, b___, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_no_overlap_after_crop_shorter():
+    a = "bcdX"
+    b__ = "Xefgh"
+    expected_result = "bcdefgh"
+    overlap_ratio = 0.4
+
+    result = merge_strings(a, b__, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_no_overlap_after_crop_even_shorter():
+    a = "cdX"
+    b_ = "Xefg"
+    expected_result = "cdefg"
+    overlap_ratio = 0.5
+
+    result = merge_strings(a, b_, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_full_overlap():
+    a = "abcdX"
+    b = "Xbcde"
+    expected_result = "abcde"
+    overlap_ratio = 1.0
+
+    result = merge_strings(a, b, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_one_repetition():
+    a = "ababX"
+    b_ = "Xabde"
+    expected_result = "ababde"
+    overlap_ratio = 0.8
+
+    result = merge_strings(a, b_, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_multiple_repetitions():
+    a = "ababX"
+    b_ = "Xabab"
+    expected_result = "ababab"
+    overlap_ratio = 0.8
+
+    result = merge_strings(a, b_, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_multiple_repetitions_shorter():
+    a = "abaX"
+    b = "Xbab"
+    expected_result = "abab"
+    overlap_ratio = 1.0
+
+    result = merge_strings(a, b, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_multiple_repetitions_full_overlap():
+    a_ = "ababX"
+    b = "Xabab"
+    expected_result = "abab"
+    overlap_ratio = 1.0
+
+    result = merge_strings(a_, b, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_longer_multiple_repetitions_half_overlap():
+    a = "cabababX"
+    b____ = "Xabababc"
+    expected_result = "cabababababc"
+    overlap_ratio = 0.5
+
+    result = merge_strings(a, b____, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_longer_multiple_repetitions_full_overlap():
+    a_ = "abababX"
+    b = "Xababab"
+    expected_result = "ababab"
+    overlap_ratio = 1.0
+
+    result = merge_strings(a_, b, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_one_different_letter():
+    a = "one_differon"
+    b_______ = "ferent_letter"
+    expected_result = "one_differont_letter"
+    overlap_ratio = 0.5
+
+    result = merge_strings(a, b_______, overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_merge_multi_strings_example_from_docs():
+    strings = ["abc", "bcdef", "difghi", "aijkl"]
+    expected_result = "abcdefghijkl"
+    overlap_ratio = 0.5
+    last_overlap_ratio = 0.1
+
+    result = merge_multi_strings(strings, overlap_ratio, last_overlap_ratio)
+
+    assert result == expected_result
+
+
+def test_get_index_closest_to_target_index_with_perfect_match():
+    indexes: list[int] = [0, 3, 5]
+    target_index: int = 3
+
+    result = _get_index_closest_to_target_index(indexes, target_index)
+
+    assert result == 3
+
+
+def test_get_index_closest_to_target_index_with_non_perfect_match():
+    indexes: list[int] = [0, 3, 5]
+    target_index: int = 4
+
+    result = _get_index_closest_to_target_index(indexes, target_index)
+
+    assert result == 3


### PR DESCRIPTION
Hello again @felixdittrich92 :)

I took a deeper look into the splitting and merging of the crops for the recognition and came up with a first version we can have a look at.
I tried to stick to the original approach and keep it simple.
You've had the idea to dynamically compute the hyperparameters for the aspect ratios per crop.
That's not implemented yet, but we I guess this PR is work in progress anyway :)

The main idea so far is:
- Split the crop into equally sized sub-crops with known overlap ratios
- Use the known overlap of neighboring sub-crops to estimate the overlap when merging recognized strings

This worked well for the examples I provided in the issue #1936.

Sub-crops right before being processed by recognizer - with recognized string per sub-crop:
![crops_for_recognition_after_preprocessing_batch_0_file_0](https://github.com/user-attachments/assets/0d3a8ab2-f8da-4c6f-a451-66b4371af415)
2025-02-20T
![crops_for_recognition_after_preprocessing_batch_0_file_1](https://github.com/user-attachments/assets/ed053430-7a90-4d40-905f-cee66683060f)
2-20T06:51:
![crops_for_recognition_after_preprocessing_batch_0_file_2](https://github.com/user-attachments/assets/72aaf9ee-f940-4f03-a11e-683662aae159)
06:51:13.000
![crops_for_recognition_after_preprocessing_batch_0_file_3](https://github.com/user-attachments/assets/784b4a86-ada9-4890-90c3-5b15c52ab99e)
:51:13.000Z
Merged result: 2025-02-20T06:51:13.000Z 
:white_check_mark: 

![crops_for_recognition_after_preprocessing_batch_0_file_0](https://github.com/user-attachments/assets/1d8ee873-3e4a-47bc-aaf0-5fd1eabb54db)
XUrA+b3iHQP
![crops_for_recognition_after_preprocessing_batch_0_file_1](https://github.com/user-attachments/assets/fb816614-cfd8-4881-92cd-3f2fd228365b)
3iHQP+F3qxu
![crops_for_recognition_after_preprocessing_batch_0_file_2](https://github.com/user-attachments/assets/bf9c43f8-1e77-41b9-b661-b14b3781e3c7)
+F3qxuOZZDR:
![crops_for_recognition_after_preprocessing_batch_0_file_3](https://github.com/user-attachments/assets/85d34587-f612-4136-82ef-55e9bbf838c6)
OZZDRA/628+
![crops_for_recognition_after_preprocessing_batch_0_file_4](https://github.com/user-attachments/assets/8185db0b-4577-4ee5-9e1a-6faae26e3667)
RA/6Z8+6nbf
Merged result: XUrA+b3iHQP+F3qxuOZZDRA/628+6nbf 
Not perfectly correct but at least correctly merged :)

I used the evaluation script from the repo to check how the changes affect the scores - thanks for providing that script btw.
To summarize, the results are actually not that different to the existing approach..
But at least significantly faster on the CORD dataset.
I've looked into the data and my hypothesis is that there are mostly short words and numbers that do not benefit from the split and merge.

Additionally I ran an evaluation on a dataset we labeled ourselves.
It consists of 160 photographies of german shopping receipts - so it includes at least some lengthy words ;)
The average accuracy improved by 1%.
For dates - consisting of the long datetimes as shown in the example, but also shorter versions of just time or date - the accuracy improved by ~7%.
It's not much, but at least something :)

I'm eager to hear your feedback about the changes. No pressure though ;) 

---

Appendix:
The full results of the evaluation on FUNSD and CORD
Variant 2 and 3 use the same critical_ar and target_ar parameters of 8 and 6 - the default from docTR - to generate sub-crops of comparable sizes. Mostly relevant to compare the run durations. 
Variant 4 uses critical_ar of 4 and target_ar of 4, because this utilizes the input window (32 times 128 pixels) of the recognizer fully.
This variant worked best on our data, but had slightly worse results on FUNSD and CORD.

- Models: db_resnet50 + parseq
- **FUNSD**
	- **1 docTR main**
		- Text Recognition - Accuracy: 86.67% (unicase: 87.47%) OCR - Recall: 73.46% (unicase: 73.99%), Precision: 76.20% (unicase: 76.75%), Mean IoU: 68.00%  
			- 149/149 [30:44<00:00, 12.38s/it]
			- 50/50 [12:03<00:00, 14.48s/it]
	- **2 docTR main - only with fixed computation of number of sub-crops**
		- Text Recognition - Accuracy: 86.46% (unicase: 87.25%) OCR - Recall: 73.34% (unicase: 73.87%), Precision: 76.08% (unicase: 76.63%), Mean IoU: 68.00%  
			- 149/149 [31:42<00:00, 12.77s/it]
			- 50/50 [12:17<00:00, 14.75s/it]
	- **3 Fix with crop parameters similar to version 2**
		- Text Recognition - Accuracy: 86.60% (unicase: 87.40%) OCR - Recall: 73.45% (unicase: 73.98%), Precision: 76.19% (unicase: 76.74%), Mean IoU: 68.00%  
			- 149/149 [32:01<00:00, 12.90s/it]
			- 50/50 [12:14<00:00, 14.69s/it]
	- **4 Fix with full utilization of recognition input window**
		- Text Recognition - Accuracy: 85.71% (unicase: 86.51%) OCR - Recall: 73.14% (unicase: 73.63%), Precision: 75.87% (unicase: 76.38%), Mean IoU: 68.00%

- **CORD - ran on different machine so timings not comparable to FUNSD**
	- **1 docTR main**
		- Text Recognition - Accuracy: 91.71% (unicase: 92.07%) OCR - Recall: 85.03% (unicase: 85.34%), Precision: 79.30% (unicase: 79.58%), Mean IoU: 73.00%
			- 800/800 [38:29<00:00,  2.89s/it]
			- 100/100 [04:40<00:00,  2.80s/it]
	- **2 docTR main - only with fixed computation of number of sub-crops**
		- Text Recognition - Accuracy: 91.68% (unicase: 92.04%) OCR - Recall: 85.03% (unicase: 85.32%), Precision: 79.30% (unicase: 79.57%), Mean IoU: 73.00%
			- 800/800 [38:22<00:00,  2.88s/it]
			- 100/100 [04:38<00:00,  2.78s/it]
	- **3 Fix with crop parameters similar to version 2**
		- Text Recognition - Accuracy: 91.72% (unicase: 92.08%) OCR - Recall: 85.09% (unicase: 85.39%), Precision: 79.35% (unicase: 79.63%), Mean IoU: 73.00%  
			- 800/800 [27:01<00:00,  2.03s/it]
			- 100/100 [03:19<00:00,  1.99s/it]
		- Significantly faster with similar results - maybe because of Hamming distance instead of Levenshtein
	- **4 Fix with full utilization of recognition input window**
		- Text Recognition - Accuracy: 90.16% (unicase: 90.57%) OCR - Recall: 84.25% (unicase: 84.55%), Precision: 78.57% (unicase: 78.85%), Mean IoU: 73.00%
			- 800/800 [38:36<00:00,  2.90s/it]
			- 100/100 [04:30<00:00,  2.71s/it]


