### PR TITLE
[Build] Add TensorFlow deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ The KIE predictor results per page are in a dictionary format with each key repr
 
 ## Installation
 
+> [!WARNING]
+> **TensorFlow Backend Deprecation Notice**
+>
+> Using docTR with TensorFlow as a backend is deprecated and will be removed in the next major release (v1.0.0).
+> We **recommend switching to the PyTorch backend**, which is more actively maintained and supports the latest features and models.
+> Alternatively, you can use [OnnxTR](https://github.com/felixdittrich92/OnnxTR), which does **not** require TensorFlow or PyTorch.
+>
+> This decision was made based on several considerations:
+>
+> - Allows better focus on improving the core library
+> - Frees up resources to develop new features faster
+> - Enables more targeted optimizations with PyTorch
+
 ### Prerequisites
 
 Python 3.10 (or higher) and [pip](https://pip.pypa.io/en/stable/) are required to install docTR.

--- a/docs/source/getting_started/installing.rst
+++ b/docs/source/getting_started/installing.rst
@@ -19,6 +19,20 @@ For MacBooks with M1 chip, you will need some additional packages or specific ve
 * `TensorFlow 2 Metal Plugin <https://developer.apple.com/metal/tensorflow-plugin/>`_
 * `PyTorch >= 2.0.0 <https://pytorch.org/get-started/locally/#start-locally>`_
 
+.. warning::
+
+   **TensorFlow Backend Deprecation Notice**
+
+   Using docTR with TensorFlow as a backend is **deprecated** and will be removed in the next major release (v1.0.0).
+   We **recommend switching to the PyTorch backend**, which is more actively maintained and supports the latest features and models.
+   Alternatively, you can use `OnnxTR <https://github.com/felixdittrich92/OnnxTR>`_, which does **not** require TensorFlow or PyTorch.
+
+   This decision was made based on several considerations:
+
+   - Allows better focus on improving the core library
+   - Frees up resources to develop new features faster
+   - Enables more targeted optimizations with PyTorch
+
 Via Python Package
 ==================
 

--- a/doctr/file_utils.py
+++ b/doctr/file_utils.py
@@ -80,6 +80,15 @@ if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VA
             logging.info(f"TensorFlow version {_tf_version} available.")
             ensure_keras_v2()
 
+        import warnings
+
+        warnings.simplefilter("always", DeprecationWarning)
+        warnings.warn(
+            "Support for TensorFlow in DocTR is deprecated and will be removed in the next major release (v1.0.0). "
+            "Please switch to the PyTorch backend.",
+            DeprecationWarning,
+        )
+
 else:  # pragma: no cover
     logging.info("Disabling Tensorflow because USE_TORCH is set")
     _tf_available = False


### PR DESCRIPTION
This PR:

- Add TF depreaction warnings:
    - Code ✅
    - Documentation (Readme / Docs) ✅
    
    
Roadmap:

v0.12.0 (possible v0.12.x release) supports TF: ✅
v1.0.0 release supports TF: ❌