### PR TITLE
Fix: Update min_loss only on improved validation loss to ensure best …

### DIFF
--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -589,7 +589,7 @@ def main(args):
                 params = model.module if hasattr(model, "module") else model
 
                 torch.save(params.state_dict(), Path(args.output_dir) / f"{exp_name}.pt")
-                min_loss = val_loss # Update min_loss only when a new minimum is found, to avoid saving suboptimal checkpoints
+                min_loss = val_loss 
             pbar.write(
                 f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} "
                 f"(Exact: {exact_match:.2%} | Partial: {partial_match:.2%})"

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -589,7 +589,7 @@ def main(args):
                 params = model.module if hasattr(model, "module") else model
 
                 torch.save(params.state_dict(), Path(args.output_dir) / f"{exp_name}.pt")
-            min_loss = val_loss
+                min_loss = val_loss # Update min_loss only when a new minimum is found, to avoid saving suboptimal checkpoints
             pbar.write(
                 f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} "
                 f"(Exact: {exact_match:.2%} | Partial: {partial_match:.2%})"


### PR DESCRIPTION
## What does this PR fix?

Previously, model checkpoints were being saved whenever the validation loss decreased compared to the previous epoch, rather than being compared to the *minimum* validation loss so far. This could result in overwriting the best checkpoint with a suboptimal one.

## Solution

- Track the minimum validation loss seen so far.
- Only save the model if the current validation loss is lower than this minimum.

Tested on distributed multi-GPU training; now only the true best checkpoint is preserved.
