### PR TITLE
[models] Drop viptr base config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: no-commit-to-branch
         args: ['--branch', 'main']
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/demo/backend/pytorch.py
+++ b/demo/backend/pytorch.py
@@ -30,7 +30,6 @@ RECO_ARCHS = [
     "vitstr_base",
     "parseq",
     "viptr_tiny",
-    "viptr_base",
 ]
 
 

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -93,8 +93,6 @@ doctr.models.recognition
 
 .. autofunction:: doctr.models.recognition.viptr_tiny
 
-.. autofunction:: doctr.models.recognition.viptr_base
-
 .. autofunction:: doctr.models.recognition.recognition_predictor
 
 

--- a/docs/source/using_doctr/using_models.rst
+++ b/docs/source/using_doctr/using_models.rst
@@ -130,7 +130,6 @@ The following architectures are currently supported:
 * :py:meth:`vitstr_base <doctr.models.recognition.vitstr_base>`
 * :py:meth:`parseq <doctr.models.recognition.parseq>`
 * :py:meth:`viptr_tiny <doctr.models.recognition.viptr_tiny>`
-* :py:meth:`viptr_base <doctr.models.recognition.viptr_base>`
 
 
 For a comprehensive comparison, we have compiled a detailed benchmark on publicly available datasets:
@@ -174,8 +173,6 @@ For a comprehensive comparison, we have compiled a detailed benchmark on publicl
 | PyTorch        | parseq                          | (32, 128, 3)    | 23.8 M       | 88.53      | 89.24         | 95.56      | 95.91         | 2.2                |
 +----------------+---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+--------------------+
 | PyTorch        | viptr_tiny                      | (32, 128, 3)    | 3.2 M        |            |               |            |               | 0.08               |
-+----------------+---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+--------------------+
-| PyTorch        | viptr_base                      | (32, 128, 3)    | 20.2 M       |            |               |            |               | 0.35               |
 +----------------+---------------------------------+-----------------+--------------+------------+---------------+------------+---------------+--------------------+
 
 

--- a/doctr/models/recognition/viptr/pytorch.py
+++ b/doctr/models/recognition/viptr/pytorch.py
@@ -15,22 +15,15 @@ from torchvision.models._utils import IntermediateLayerGetter
 
 from doctr.datasets import VOCABS, decode_sequence
 
-from ...classification import vip_base, vip_tiny
+from ...classification import vip_tiny
 from ...utils.pytorch import _bf16_to_float32, load_pretrained_params
 from ..core import RecognitionModel, RecognitionPostProcessor
 
-__all__ = ["VIPTR", "viptr_base", "viptr_tiny"]
+__all__ = ["VIPTR", "viptr_tiny"]
 
 
 default_cfgs: dict[str, dict[str, Any]] = {
     "viptr_tiny": {
-        "mean": (0.694, 0.695, 0.693),
-        "std": (0.299, 0.296, 0.301),
-        "input_shape": (3, 32, 128),
-        "vocab": VOCABS["french"],
-        "url": None,
-    },
-    "viptr_base": {
         "mean": (0.694, 0.695, 0.693),
         "std": (0.299, 0.296, 0.301),
         "input_shape": (3, 32, 128),
@@ -255,33 +248,6 @@ def _viptr(
         model.from_pretrained(default_cfgs[arch]["url"], ignore_keys=_ignore_keys)
 
     return model
-
-
-def viptr_base(pretrained: bool = False, **kwargs: Any) -> VIPTR:
-    """VIPTR-Base as described in `"A Vision Permutable Extractor for Fast and Efficient Scene Text Recognition"
-    <https://arxiv.org/abs/2401.10110>`_.
-
-    >>> import torch
-    >>> from doctr.models import viptr_base
-    >>> model = viptr_base(pretrained=False)
-    >>> input_tensor = torch.rand((1, 3, 32, 128))
-    >>> out = model(input_tensor)
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on our text recognition dataset
-        **kwargs: keyword arguments of the VIPTR architecture
-
-    Returns:
-        VIPTR: a VIPTR model instance
-    """
-    return _viptr(
-        "viptr_base",
-        pretrained,
-        vip_base,
-        "5",
-        ignore_keys=["head.weight", "head.bias"],
-        **kwargs,
-    )
 
 
 def viptr_tiny(pretrained: bool = False, **kwargs: Any) -> VIPTR:

--- a/doctr/models/recognition/zoo.py
+++ b/doctr/models/recognition/zoo.py
@@ -26,7 +26,7 @@ ARCHS: list[str] = [
 ]
 
 if is_torch_available():
-    ARCHS.extend(["viptr_base", "viptr_tiny"])
+    ARCHS.extend(["viptr_tiny"])
 
 
 def _predictor(arch: Any, pretrained: bool, **kwargs: Any) -> RecognitionPredictor:

--- a/references/recognition/train_pytorch.py
+++ b/references/recognition/train_pytorch.py
@@ -589,7 +589,7 @@ def main(args):
                 params = model.module if hasattr(model, "module") else model
 
                 torch.save(params.state_dict(), Path(args.output_dir) / f"{exp_name}.pt")
-                min_loss = val_loss 
+                min_loss = val_loss
             pbar.write(
                 f"Epoch {epoch + 1}/{args.epochs} - Validation loss: {val_loss:.6} "
                 f"(Exact: {exact_match:.2%} | Partial: {partial_match:.2%})"

--- a/tests/pytorch/test_models_factory.py
+++ b/tests/pytorch/test_models_factory.py
@@ -49,7 +49,6 @@ def test_push_to_hf_hub():
         ["vitstr_small", "recognition", "Felix92/doctr-dummy-torch-vitstr-small"],
         ["parseq", "recognition", "Felix92/doctr-dummy-torch-parseq"],
         # TODO: Add dummy models for the following architectures until they are pretrained
-        # ["viptr_base", "recognition", None],
         # ["viptr_tiny", "recognition", None],
     ],
 )

--- a/tests/pytorch/test_models_recognition_pt.py
+++ b/tests/pytorch/test_models_recognition_pt.py
@@ -33,7 +33,6 @@ system_available_memory = int(psutil.virtual_memory().available / 1024**3)
         ["vitstr_small", (3, 32, 128)],
         ["vitstr_base", (3, 32, 128)],
         ["parseq", (3, 32, 128)],
-        ["viptr_base", (3, 32, 128)],
         ["viptr_tiny", (3, 32, 128)],
     ],
 )
@@ -107,7 +106,6 @@ def test_reco_postprocessors(post_processor, input_shape, mock_vocab):
         "vitstr_base",
         "parseq",
         "viptr_tiny",
-        "viptr_base",
     ],
 )
 def test_recognition_zoo(arch_name, input_shape):
@@ -146,7 +144,6 @@ def test_recognition_zoo(arch_name, input_shape):
         ["vitstr_small", (3, 32, 128)],  # testing one vitstr version is enough
         ["parseq", (3, 32, 128)],
         ["viptr_tiny", (3, 32, 128)],
-        ["viptr_base", (3, 32, 128)],
     ],
 )
 def test_models_onnx_export(arch_name, input_shape):
@@ -187,7 +184,6 @@ def test_models_onnx_export(arch_name, input_shape):
         "parseq",
         # TODO: Add viptr models when they are pretrained
         # "viptr_tiny",
-        # "viptr_base",
     ],
 )
 def test_torch_compiled_models(arch_name, mock_text_box):


### PR DESCRIPTION
This PR:

- Drop viptr base config

Explanation:

We drop the base config because after some experiments the arch with it's base config doesn't learns well / needs tons of more data (10M +++)
After a param (config) grid search the official tiny config is close the best fit 