### PR TITLE
[Feat] Add Vit-Det as LW-DETR encoder

### DIFF
--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -45,6 +45,10 @@ doctr.models.classification
 
 .. autofunction:: doctr.models.classification.vip_base
 
+.. autofunction:: doctr.models.classification.vit_det_s
+
+.. autofunction:: doctr.models.classification.vit_det_m
+
 .. autofunction:: doctr.models.classification.crop_orientation_predictor
 
 .. autofunction:: doctr.models.classification.page_orientation_predictor

--- a/doctr/models/classification/__init__.py
+++ b/doctr/models/classification/__init__.py
@@ -5,4 +5,5 @@ from .magc_resnet import *
 from .vit import *
 from .textnet import *
 from .vip import *
+from .vit_det import *
 from .zoo import *

--- a/doctr/models/classification/predictor/pytorch.py
+++ b/doctr/models/classification/predictor/pytorch.py
@@ -47,7 +47,7 @@ class OrientationPredictor(nn.Module):
 
         processed_batches = self.pre_processor(inputs)
         _params = next(self.model.parameters())
-        self.model, processed_batches = set_device_and_dtype(
+        self.model, processed_batches = set_device_and_dtype(  # type: ignore[assignment]
             self.model, processed_batches, _params.device, _params.dtype
         )
         predicted_batches = [self.model(batch) for batch in processed_batches]

--- a/doctr/models/classification/textnet/pytorch.py
+++ b/doctr/models/classification/textnet/pytorch.py
@@ -63,7 +63,7 @@ class TextNet(nn.Sequential):
     ) -> None:
         _layers: list[nn.Module] = [
             *conv_sequence_pt(
-                in_channels=3, out_channels=64, relu=True, bn=True, kernel_size=3, stride=2, padding=(1, 1)
+                in_channels=3, out_channels=64, act=True, bn=True, kernel_size=3, stride=2, padding=(1, 1)
             ),
             *[
                 nn.Sequential(*[

--- a/doctr/models/classification/vip/layers/pytorch.py
+++ b/doctr/models/classification/vip/layers/pytorch.py
@@ -63,11 +63,11 @@ class PatchEmbed(nn.Module):
         self.embed_dim = embed_dim
         self.proj = nn.Sequential(
             *conv_sequence_pt(
-                in_channels, embed_dim // 2, kernel_size=3, stride=2, padding=1, bias=False, bn=True, relu=False
+                in_channels, embed_dim // 2, kernel_size=3, stride=2, padding=1, bias=False, bn=True, act=False
             ),
             nn.GELU(),
             *conv_sequence_pt(
-                embed_dim // 2, embed_dim, kernel_size=3, stride=2, padding=1, bias=False, bn=True, relu=False
+                embed_dim // 2, embed_dim, kernel_size=3, stride=2, padding=1, bias=False, bn=True, act=False
             ),
             nn.GELU(),
         )
@@ -240,10 +240,10 @@ class OverlappedSpatialReductionAttention(nn.Module):
                     groups=dim,
                     bias=False,
                     bn=True,
-                    relu=False,
+                    act=False,
                 ),
                 nn.GELU(),
-                *conv_sequence_pt(dim, dim, kernel_size=1, groups=dim, bias=False, bn=True, relu=False),
+                *conv_sequence_pt(dim, dim, kernel_size=1, groups=dim, bias=False, bn=True, act=False),
             )
         else:
             self.sr = nn.Identity()  # type: ignore[assignment]

--- a/doctr/models/classification/vit_det/__init__.py
+++ b/doctr/models/classification/vit_det/__init__.py
@@ -1,0 +1,1 @@
+from .pytorch import *

--- a/doctr/models/classification/vit_det/layers/__init__.py
+++ b/doctr/models/classification/vit_det/layers/__init__.py
@@ -1,0 +1,1 @@
+from .pytorch import *

--- a/doctr/models/classification/vit_det/layers/pytorch.py
+++ b/doctr/models/classification/vit_det/layers/pytorch.py
@@ -1,0 +1,215 @@
+# Copyright (C) 2021-2026, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from doctr.models.modules import DropPath
+
+__all__ = ["PatchEmbed", "MLP", "AttentionWithCAE", "WindowedCAETransformerBlock"]
+
+
+class PatchEmbed(nn.Module):
+    """Simple 2D convolutional patch embedding layer for ViT Det
+
+    Args:
+        kernel_size: kernel size of the projection layer.
+        stride: stride of the projection layer.
+        padding: padding size of the projection layer.
+        in_chans: Number of input image channels.
+        embed_dim:  embed_dim (int): Patch embedding dimension.
+    """
+
+    def __init__(
+        self,
+        kernel_size: tuple[int, int] = (16, 16),
+        stride: tuple[int, int] = (16, 16),
+        padding: tuple[int, int] = (0, 0),
+        in_chans: int = 3,
+        embed_dim: int = 768,
+    ):
+        super().__init__()
+
+        self.proj = nn.Conv2d(in_chans, embed_dim, kernel_size=kernel_size, stride=stride, padding=padding)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # B C H W -> B H W C
+        return self.proj(x).permute(0, 2, 3, 1)
+
+
+class MLP(nn.Module):
+    """Simple Multilayer Perceptron (MLP)
+
+    Args:
+        in_features: number of input features
+        hidden_features: number of hidden features (default: in_features)
+        out_features: number of output features (default: in_features)
+        act_layer: activation layer (default: nn.GELU)
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int | None = None,
+        out_features: int | None = None,
+        act_layer=nn.GELU,
+    ):
+        super().__init__()
+
+        hidden_features = hidden_features or in_features
+        out_features = out_features or in_features
+
+        self.net = nn.Sequential(
+            nn.Linear(in_features, hidden_features),
+            act_layer(),
+            nn.Linear(hidden_features, out_features),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class AttentionWithCAE(nn.Module):
+    """Multi-head Attention block with CAE bias construction.
+
+    Args:
+        dim: Number of input channels.
+        num_heads: Number of attention heads.
+        qkv_bias: If True, add a learnable bias to query, key, value.
+        use_cae: If True, use CAE bias construction (separate q and v bias).
+    """
+
+    def __init__(self, dim: int, num_heads: int = 8, qkv_bias: bool = True, use_cae: bool = False):
+        super().__init__()
+
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.use_cae = use_cae
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=(qkv_bias and not use_cae))
+
+        # CAE bias
+        if use_cae:
+            self.q_bias = nn.Parameter(torch.zeros(dim))
+            self.v_bias = nn.Parameter(torch.zeros(dim))
+
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        B, N, C = x.shape
+
+        # QKV projection
+        if self.use_cae:
+            zeros = torch.zeros_like(self.v_bias, requires_grad=False)
+            qkv_bias = torch.cat([self.q_bias, zeros, self.v_bias])
+            qkv = F.linear(x, weight=self.qkv.weight, bias=qkv_bias)
+        else:
+            qkv = self.qkv(x)
+
+        # Reshape to multi-head
+        qkv = qkv.view(B, N, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+
+        # Attention
+        attn = (q * self.scale) @ k.transpose(-2, -1)
+
+        if mask is not None:
+            attn = attn.masked_fill(mask.view(B, 1, 1, N).expand_as(attn), float("-inf"))
+
+        attn = attn.softmax(dim=-1)
+        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        return self.proj(x)
+
+
+class WindowedCAETransformerBlock(nn.Module):
+    """Transformer blocks with support of window attention and residual propagation blocks
+
+    Args:
+        dim (int): Number of input channels.
+        num_heads (int): Number of attention heads in each ViT block.
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim.
+        qkv_bias (bool): If True, add a learnable bias to query, key, value.
+        drop_prob (float): Stochastic depth rate.
+        norm_layer (nn.Module): Normalization layer.
+        act_layer (nn.Module): Activation layer.
+        window (bool): If True, use window attention. Otherwise, use global attention.
+        use_cae (bool): If True, use CAE bias construction (separate q and v bias).
+    """
+
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        mlp_ratio=4.0,
+        qkv_bias=True,
+        drop_prob=0.0,
+        norm_layer=nn.LayerNorm,
+        act_layer=nn.GELU,
+        window=False,
+        use_cae=False,
+    ):
+        super().__init__()
+
+        self.norm1 = norm_layer(dim)
+        self.norm2 = norm_layer(dim)
+
+        self.attn = AttentionWithCAE(
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            use_cae=use_cae,
+        )
+        self.mlp = MLP(
+            in_features=dim,
+            hidden_features=int(dim * mlp_ratio),
+            act_layer=act_layer,
+        )
+        self.drop_path = DropPath(drop_prob) if drop_prob > 0.0 else nn.Identity()
+
+        self.window = window
+        self.use_cae = use_cae
+
+        if use_cae:
+            self.gamma_1 = nn.Parameter(0.1 * torch.ones(dim), requires_grad=True)
+            self.gamma_2 = nn.Parameter(0.1 * torch.ones(dim), requires_grad=True)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        B, HW, C = x.shape
+        shortcut = x
+
+        x = self.norm1(x)
+        mask_r = mask
+
+        # Window partitioning logic
+        if not self.window:
+            x = x.reshape(B // 16, 16 * HW, C)
+            shortcut_r = shortcut.reshape(B // 16, 16 * HW, C)
+
+            if mask is not None:
+                mask_r = mask.reshape(B // 16, 16 * HW)
+            else:
+                mask_r = None
+        else:
+            shortcut_r = shortcut
+
+        # Attention
+        attn_out = self.attn(x, mask_r)
+
+        if self.use_cae:
+            attn_out = self.gamma_1 * attn_out
+
+        x = shortcut_r + self.drop_path(attn_out)
+
+        # Reshape back if needed
+        if not self.window:
+            x = x.reshape(B, HW, C)
+            if mask is not None:
+                mask = mask.reshape(B, HW)
+
+        x = x + self.drop_path((self.gamma_2 * self.mlp(self.norm2(x))) if self.use_cae else self.mlp(self.norm2(x)))
+
+        return x

--- a/doctr/models/classification/vit_det/layers/pytorch.py
+++ b/doctr/models/classification/vit_det/layers/pytorch.py
@@ -107,7 +107,7 @@ class AttentionWithCAE(nn.Module):
             zeros = torch.zeros_like(self.v_bias, requires_grad=False)
             qkv_bias = torch.cat([self.q_bias, zeros, self.v_bias])
             qkv = F.linear(x, weight=self.qkv.weight, bias=qkv_bias)
-        else:
+        else:  # pragma: no cover
             qkv = self.qkv(x)
 
         # Reshape to multi-head
@@ -189,7 +189,7 @@ class WindowedCAETransformerBlock(nn.Module):
             x = x.reshape(B // 16, 16 * HW, C)
             shortcut_r = shortcut.reshape(B // 16, 16 * HW, C)
 
-            if mask is not None:
+            if mask is not None:  # pragma: no cover
                 mask_r = mask.reshape(B // 16, 16 * HW)
             else:
                 mask_r = None
@@ -207,7 +207,7 @@ class WindowedCAETransformerBlock(nn.Module):
         # Reshape back if needed
         if not self.window:
             x = x.reshape(B, HW, C)
-            if mask is not None:
+            if mask is not None:  # pragma: no cover
                 mask = mask.reshape(B, HW)
 
         x = x + self.drop_path((self.gamma_2 * self.mlp(self.norm2(x))) if self.use_cae else self.mlp(self.norm2(x)))

--- a/doctr/models/classification/vit_det/pytorch.py
+++ b/doctr/models/classification/vit_det/pytorch.py
@@ -89,7 +89,7 @@ class ViTInput(nn.Module):
         xy_num = pos_embed.shape[1]
         size = int(math.sqrt(xy_num))
 
-        if size != H or size != W:
+        if size != H or size != W:  # pragma: no cover
             pos_embed = F.interpolate(
                 pos_embed.reshape(1, size, size, -1).permute(0, 3, 1, 2),
                 size=(H, W),

--- a/doctr/models/classification/vit_det/pytorch.py
+++ b/doctr/models/classification/vit_det/pytorch.py
@@ -1,0 +1,346 @@
+# Copyright (C) 2021-2026, Mindee.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+import math
+from copy import deepcopy
+from functools import partial
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from doctr.datasets import VOCABS
+
+from ...utils import load_pretrained_params
+from .layers import PatchEmbed, WindowedCAETransformerBlock
+
+__all__ = ["vit_det_s", "vit_det_m"]
+
+
+default_cfgs: dict[str, dict[str, Any]] = {
+    "vit_det_s": {
+        "mean": (0.694, 0.695, 0.693),
+        "std": (0.299, 0.296, 0.301),
+        "input_shape": (3, 32, 32),
+        "classes": list(VOCABS["french"]),
+        "url": "https://github.com/mindee/doctr/releases/download/v1.0.1/vit_det_s-56a33dee.pt",
+    },
+    "vit_det_m": {
+        "mean": (0.694, 0.695, 0.693),
+        "std": (0.299, 0.296, 0.301),
+        "input_shape": (3, 32, 32),
+        "classes": list(VOCABS["french"]),
+        "url": "https://github.com/mindee/doctr/releases/download/v1.0.1/vit_det_m-669daf92.pt",
+    },
+}
+
+
+class ClassifierHead(nn.Module):
+    """Classifier head for Vision Detection Transformer
+
+    Args:
+        in_channels: number of input channels
+        num_classes: number of output classes
+    """
+
+    def __init__(self, in_channels: int, num_classes: int):
+        super().__init__()
+        self.norm = nn.LayerNorm(in_channels)
+        self.fc = nn.Linear(in_channels, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # (B, C, H, W)
+        x = x.flatten(2).mean(dim=-1)  # global average pooling (B, C)
+        x = self.norm(x)
+        return self.fc(x)
+
+
+class TakeLastFeature(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x[-1]
+
+
+class ViTInput(nn.Module):
+    """ViT input module, which includes the patch embedding and positional embedding
+
+    Args:
+        patch_embed: the patch embedding module
+        pos_embed: the positional embedding module
+        has_cls_token: whether the input includes a cls token
+    """
+
+    def __init__(self, patch_embed: PatchEmbed, pos_embed: torch.Tensor, has_cls_token: bool = True):
+        super().__init__()
+        self.patch_embed = patch_embed
+        self.pos_embed = pos_embed
+        self.has_cls_token = has_cls_token
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)
+        H, W = x.shape[1], x.shape[2]
+
+        pos_embed = self.pos_embed
+        if self.has_cls_token:
+            pos_embed = pos_embed[:, 1:]
+
+        xy_num = pos_embed.shape[1]
+        size = int(math.sqrt(xy_num))
+
+        if size != H or size != W:
+            pos_embed = F.interpolate(
+                pos_embed.reshape(1, size, size, -1).permute(0, 3, 1, 2),
+                size=(H, W),
+                mode="bicubic",
+                align_corners=False,
+            ).permute(0, 2, 3, 1)
+        else:
+            pos_embed = pos_embed.reshape(1, H, W, -1)
+
+        return x + pos_embed
+
+
+class ViTTokenize(nn.Module):
+    """ViT tokenize module, which reshapes the input feature map into a sequence of tokens"""
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, tuple[int, int, int, int, int, int]]:
+        B, H, W, C = x.shape
+        h, w = H // 4, W // 4
+        x = x.reshape(B, 4, h, 4, w, C).permute(0, 1, 3, 2, 4, 5).reshape(B * 16, h * w, C)
+        return x, (B, H, W, h, w, C)
+
+
+class ViTStage(nn.Module):
+    """ "ViT stage module, which includes a list of transformer blocks and outputs the features of the specified blocks
+
+    Args:
+        blocks: a list of transformer blocks
+        out_features_mask: a list of booleans indicating which blocks' features to output
+    """
+
+    def __init__(self, blocks: list[WindowedCAETransformerBlock], out_features_mask: list[bool]):
+        super().__init__()
+        self.blocks = nn.ModuleList(blocks)
+        self.out_features_mask = out_features_mask
+
+    def forward(self, inputs: tuple[torch.Tensor, tuple[int, int, int, int, int, int]]) -> list[torch.Tensor]:
+        x, meta = inputs
+        B, H, W, h, w, C = meta
+
+        outputs = []
+
+        for idx, blk in enumerate(self.blocks):
+            x = blk(x, mask=None)
+
+            if self.out_features_mask[idx]:
+                feat = x.reshape(B, 4, 4, h, w, C).permute(0, 5, 1, 3, 2, 4).reshape(B, C, H, W)
+                outputs.append(feat)
+
+        return outputs
+
+
+class VisionDetectionTransformer(nn.Sequential):
+    """VisionDetectionTransformer architecture as described in
+    `"Exploring Plain Vision Transformer Backbones for Object Detection",
+    <https://arxiv.org/abs/2203.16527>`_.
+
+    Args:
+        d_model: dimension of the transformer layers
+        num_layers: number of transformer layers
+        num_heads: number of attention heads
+        ffd_ratio: multiplier for the hidden dimension of the feedforward layer
+        patch_size: size of the patches
+        input_shape: size of the input image
+        dropout: dropout rate
+        window_block_indexes: list of block indices that use window attention
+        out_feature_indexes: list of block indices whose features are output
+        num_classes: number of output classes
+        include_top: whether the classifier head should be instantiated
+        cfg: additional configuration dictionary
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        num_layers: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        patch_size: tuple[int, int] = (4, 4),
+        input_shape: tuple[int, int, int] = (3, 32, 32),
+        dropout: float = 0.1,
+        window_block_indexes: list[int] = [0, 1, 3, 6, 7, 9],
+        out_feature_indexes: list[int] = [2, 4, 5, 9],
+        num_classes: int = 1000,
+        include_top: bool = True,
+        cfg: dict[str, Any] | None = None,
+    ) -> None:
+
+        in_chans = input_shape[0]
+
+        patch_embed = PatchEmbed(
+            kernel_size=patch_size,
+            stride=patch_size,
+            in_chans=in_chans,
+            embed_dim=d_model,
+        )
+
+        # Initialize absolute positional embedding with pretrain image size.
+        num_patches = (input_shape[1] // patch_size[0]) * (input_shape[2] // patch_size[1])
+        pos_embed = nn.Parameter(torch.zeros(1, (num_patches + 1), d_model))
+        nn.init.trunc_normal_(pos_embed, std=0.02)
+
+        # stochastic depth decay rule
+        dpr = [x.item() for x in torch.linspace(0, dropout, num_layers)]
+
+        # blocks
+        blocks = [
+            WindowedCAETransformerBlock(
+                dim=d_model,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=True,
+                drop_prob=dpr[i],
+                norm_layer=partial(nn.LayerNorm, eps=1e-6),
+                window=(i in window_block_indexes),
+                use_cae=True,
+            )
+            for i in range(num_layers)
+        ]
+
+        # normalize feature indices
+        out_feature_indexes = [i if i >= 0 else i + num_layers for i in out_feature_indexes]
+        out_mask = [i in out_feature_indexes for i in range(num_layers)]
+
+        _layers = [
+            ViTInput(patch_embed, pos_embed, has_cls_token=True),
+            ViTTokenize(),
+            ViTStage(blocks, out_mask),
+        ]
+        if include_top:
+            _layers.extend([
+                TakeLastFeature(),
+                ClassifierHead(d_model, num_classes),
+            ])
+
+        super().__init__(*_layers)
+        self.cfg = cfg
+        self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, (nn.Linear, nn.Conv2d)):
+            nn.init.trunc_normal_(m.weight, mean=0.0, std=0.02)
+            if m.bias is not None:
+                nn.init.zeros_(m.bias)
+        elif isinstance(m, nn.LayerNorm):
+            nn.init.zeros_(m.bias)
+            nn.init.ones_(m.weight)
+        elif isinstance(m, ViTInput):
+            if isinstance(m.pos_embed, torch.nn.Parameter):
+                nn.init.trunc_normal_(m.pos_embed, mean=0.0, std=0.02)
+        elif isinstance(m, WindowedCAETransformerBlock):
+            if m.use_cae:
+                nn.init.constant_(m.gamma_1, 0.1)
+                nn.init.constant_(m.gamma_2, 0.1)
+
+    def from_pretrained(self, path_or_url: str, **kwargs: Any) -> None:
+        """Load pretrained parameters onto the model
+
+        Args:
+            path_or_url: the path or URL to the model parameters (checkpoint)
+            **kwargs: additional arguments to be passed to `doctr.models.utils.load_pretrained_params`
+        """
+        load_pretrained_params(self, path_or_url, **kwargs)
+
+
+def _vit_det(
+    arch: str,
+    pretrained: bool,
+    ignore_keys: list[str] | None = None,
+    **kwargs: Any,
+) -> VisionDetectionTransformer:
+    kwargs["num_classes"] = kwargs.get("num_classes", len(default_cfgs[arch]["classes"]))
+    kwargs["input_shape"] = kwargs.get("input_shape", default_cfgs[arch]["input_shape"])
+    kwargs["classes"] = kwargs.get("classes", default_cfgs[arch]["classes"])
+
+    _cfg = deepcopy(default_cfgs[arch])
+    _cfg["num_classes"] = kwargs["num_classes"]
+    _cfg["input_shape"] = kwargs["input_shape"]
+    _cfg["classes"] = kwargs["classes"]
+    kwargs.pop("classes")
+
+    # Build the model
+    model = VisionDetectionTransformer(cfg=_cfg, **kwargs)
+    # Load pretrained parameters
+    if pretrained:
+        # The number of classes is not the same as the number of classes in the pretrained model =>
+        # remove the last layer weights
+        _ignore_keys = ignore_keys if kwargs["num_classes"] != len(default_cfgs[arch]["classes"]) else None
+        model.from_pretrained(default_cfgs[arch]["url"], ignore_keys=_ignore_keys)
+
+    return model
+
+
+def vit_det_s(pretrained: bool = False, **kwargs: Any) -> VisionDetectionTransformer:
+    """VisionDetectionTransformer-S architecture
+    `"Exploring Plain Vision Transformer Backbones for Object Detection",
+    <https://arxiv.org/abs/2203.16527>`_.
+
+    NOTE: Modified for LW-DETR
+
+    >>> import torch
+    >>> from doctr.models import vit_det_s
+    >>> model = vit_det_s(pretrained=False)
+    >>> input_tensor = torch.rand((1, 3, 32, 32), dtype=torch.float32)
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained: boolean, True if model is pretrained
+        **kwargs: keyword arguments of the VisionDetectionTransformer architecture
+
+    Returns:
+        A feature extractor model
+    """
+    return _vit_det(
+        "vit_det_s",
+        pretrained,
+        d_model=192,
+        num_layers=10,
+        num_heads=12,
+        mlp_ratio=4.0,
+        ignore_keys=["4.norm.weight", "4.norm.bias", "4.fc.weight", "4.fc.bias"],
+        **kwargs,
+    )
+
+
+def vit_det_m(pretrained: bool = False, **kwargs: Any) -> VisionDetectionTransformer:
+    """VisionDetectionTransformer-B architecture as described in
+    `"Exploring Plain Vision Transformer Backbones for Object Detection",
+    <https://arxiv.org/abs/2203.16527>`_.
+
+    NOTE: Modified for LW-DETR
+
+    >>> import torch
+    >>> from doctr.models import vit_det_m
+    >>> model = vit_det_m(pretrained=False)
+    >>> input_tensor = torch.rand((1, 3, 32, 32), dtype=torch.float32)
+    >>> out = model(input_tensor)
+
+    Args:
+        pretrained: boolean, True if model is pretrained
+        **kwargs: keyword arguments of the VisionTransformer architecture
+
+    Returns:
+        A feature extractor model
+    """
+    return _vit_det(
+        "vit_det_m",
+        pretrained,
+        d_model=384,
+        num_layers=10,
+        num_heads=12,
+        mlp_ratio=4.0,
+        ignore_keys=["4.norm.weight", "4.norm.bias", "4.fc.weight", "4.fc.bias"],
+        **kwargs,
+    )

--- a/doctr/models/classification/zoo.py
+++ b/doctr/models/classification/zoo.py
@@ -32,6 +32,8 @@ ARCHS: list[str] = [
     "vit_b",
     "vip_tiny",
     "vip_base",
+    "vit_det_s",
+    "vit_det_m",
 ]
 
 ORIENTATION_ARCHS: list[str] = ["mobilenet_v3_small_crop_orientation", "mobilenet_v3_small_page_orientation"]

--- a/doctr/models/detection/predictor/pytorch.py
+++ b/doctr/models/detection/predictor/pytorch.py
@@ -51,7 +51,7 @@ class DetectionPredictor(nn.Module):
 
         processed_batches = self.pre_processor(pages)
         _params = next(self.model.parameters())
-        self.model, processed_batches = set_device_and_dtype(
+        self.model, processed_batches = set_device_and_dtype(  # type: ignore[assignment]
             self.model, processed_batches, _params.device, _params.dtype
         )
         predicted_batches = [

--- a/doctr/models/modules/layers/pytorch.py
+++ b/doctr/models/modules/layers/pytorch.py
@@ -3,12 +3,11 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-
 import numpy as np
 import torch
 import torch.nn as nn
 
-__all__ = ["FASTConvLayer", "DropPath", "AdaptiveAvgPool2d"]
+__all__ = ["FASTConvLayer", "DropPath", "AdaptiveAvgPool2d", "ChannelLayerNorm"]
 
 
 class DropPath(nn.Module):
@@ -36,7 +35,6 @@ class DropPath(nn.Module):
 class AdaptiveAvgPool2d(nn.Module):
     """
     Custom AdaptiveAvgPool2d implementation which is ONNX and `torch.compile` compatible.
-
     """
 
     def __init__(self, output_size):
@@ -57,6 +55,29 @@ class AdaptiveAvgPool2d(nn.Module):
                 # average over the window
                 out[:, :, oh, ow] = x[:, :, start_h:end_h, start_w:end_w].mean(dim=(-2, -1))
         return out
+
+
+class ChannelLayerNorm(nn.Module):
+    """
+    A LayerNorm variant, popularized by Transformers, that performs point-wise mean and
+    variance normalization over the channel dimension for inputs that have shape
+    (batch_size, channels, height, width).
+    https://github.com/facebookresearch/ConvNeXt/blob/d1fa8f6fef0a165b27399986cc2bdacc92777e40/models/convnext.py#L119
+    """
+
+    def __init__(self, normalized_shape: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(normalized_shape))
+        self.bias = nn.Parameter(torch.zeros(normalized_shape))
+        self.eps = eps
+        self.normalized_shape = (normalized_shape,)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        u = x.mean(1, keepdim=True)
+        s = (x - u).pow(2).mean(1, keepdim=True)
+        x = (x - u) / torch.sqrt(s + self.eps)
+        x = self.weight[:, None, None] * x + self.bias[:, None, None]
+        return x
 
 
 class FASTConvLayer(nn.Module):

--- a/doctr/models/recognition/predictor/pytorch.py
+++ b/doctr/models/recognition/predictor/pytorch.py
@@ -70,7 +70,7 @@ class RecognitionPredictor(nn.Module):
 
         # Forward it
         _params = next(self.model.parameters())
-        self.model, processed_batches = set_device_and_dtype(
+        self.model, processed_batches = set_device_and_dtype(  # type: ignore[assignment]
             self.model, processed_batches, _params.device, _params.dtype
         )
         raw = [self.model(batch, return_preds=True, **kwargs)["preds"] for batch in processed_batches]

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -86,8 +86,9 @@ def load_pretrained_params(
 def conv_sequence_pt(
     in_channels: int,
     out_channels: int,
-    relu: bool = False,
+    act: bool = False,
     bn: bool = False,
+    activation: nn.Module = nn.ReLU(inplace=True),
     **kwargs: Any,
 ) -> list[nn.Module]:
     """Builds a convolutional-based layer sequence
@@ -99,8 +100,9 @@ def conv_sequence_pt(
     Args:
         in_channels: number of input channels
         out_channels: number of output channels
-        relu: whether ReLU should be used
+        act: should an activation layer be added
         bn: should a batch normalization layer be added
+        activation: the activation layer to be added if act is True
         **kwargs: additional arguments to be passed to the convolutional layer
 
     Returns:
@@ -114,15 +116,18 @@ def conv_sequence_pt(
     if bn:
         conv_seq.append(nn.BatchNorm2d(out_channels))
 
-    if relu:
-        conv_seq.append(nn.ReLU(inplace=True))
+    if act:
+        conv_seq.append(activation)
 
     return conv_seq
 
 
 def set_device_and_dtype(
-    model: Any, batches: list[torch.Tensor], device: str | torch.device, dtype: torch.dtype
-) -> tuple[Any, list[torch.Tensor]]:
+    model: Any,
+    batches: list[torch.Tensor] | tuple[list[torch.Tensor], list[torch.Tensor]],
+    device: str | torch.device,
+    dtype: torch.dtype,
+) -> tuple[Any, list[torch.Tensor] | list[tuple[torch.Tensor, torch.Tensor]]]:
     """Set the device and dtype of a model and its batches
 
     >>> import torch
@@ -141,10 +146,18 @@ def set_device_and_dtype(
     Returns:
         the model and batches set
     """
-    return model.to(device=device, dtype=dtype), [batch.to(device=device, dtype=dtype) for batch in batches]
+    model = model.to(device=device, dtype=dtype)
+    if isinstance(batches, tuple):
+        return model, [
+            (img.to(device=device, dtype=dtype), mask.to(device=device, dtype=torch.bool))
+            for img, mask in zip(*batches)
+        ]
+    return model, [batch.to(device=device, dtype=dtype) for batch in batches]
 
 
-def export_model_to_onnx(model: nn.Module, model_name: str, dummy_input: torch.Tensor, **kwargs: Any) -> str:
+def export_model_to_onnx(
+    model: nn.Module, model_name: str, dummy_input: torch.Tensor | tuple[torch.Tensor, torch.Tensor], **kwargs: Any
+) -> str:
     """Export model to ONNX format.
 
     >>> import torch
@@ -166,9 +179,16 @@ def export_model_to_onnx(model: nn.Module, model_name: str, dummy_input: torch.T
         model,
         dummy_input,  # type: ignore[arg-type]
         f"{model_name}.onnx",
-        input_names=["input"],
-        output_names=["logits"],
-        dynamic_axes={"input": {0: "batch_size"}, "logits": {0: "batch_size"}},
+        input_names=["input", "masks"] if isinstance(dummy_input, tuple) else ["input"],
+        output_names=["logits", "pred_boxes"] if isinstance(dummy_input, tuple) else ["logits"],
+        dynamic_axes={
+            "input": {0: "batch_size"},
+            "masks": {0: "batch_size"},
+            "logits": {0: "batch_size"},
+            "pred_boxes": {0: "batch_size"},
+        }
+        if isinstance(dummy_input, tuple)
+        else {"input": {0: "batch_size"}, "logits": {0: "batch_size"}},
         export_params=True,
         dynamo=False,
         verbose=False,

--- a/tests/pytorch/test_models_classification_pt.py
+++ b/tests/pytorch/test_models_classification_pt.py
@@ -49,6 +49,8 @@ def _test_classification(model, input_shape, output_size, batch_size=2):
         ["vit_s", (3, 64, 64), (126,)],
         ["vip_base", (3, 32, 32), (126,)],
         ["vip_tiny", (3, 32, 32), (126,)],
+        ["vit_det_s", (3, 32, 32), (126,)],
+        ["vit_det_m", (3, 32, 32), (126,)],
     ],
 )
 def test_classification_architectures(arch_name, input_shape, output_size):
@@ -235,6 +237,8 @@ def test_page_orientation_model(mock_payslip):
         ["textnet_base", (3, 32, 32), (126,)],
         ["vip_base", (3, 32, 32), (126,)],
         ["vip_tiny", (3, 32, 32), (126,)],
+        ["vit_det_s", (3, 32, 32), (126,)],
+        ["vit_det_m", (3, 32, 32), (126,)],
     ],
 )
 def test_models_onnx_export(arch_name, input_shape, output_size):

--- a/tests/pytorch/test_models_utils_pt.py
+++ b/tests/pytorch/test_models_utils_pt.py
@@ -58,11 +58,40 @@ def test_conv_sequence():
 def test_set_device_and_dtype():
     model = nn.Sequential(nn.Linear(8, 8), nn.ReLU(), nn.Linear(8, 4))
     batches = [torch.rand(8) for _ in range(2)]
+
     model, batches = set_device_and_dtype(model, batches, device="cpu", dtype=torch.float32)
     assert model[0].weight.device == torch.device("cpu")
     assert model[0].weight.dtype == torch.float32
     assert batches[0].device == torch.device("cpu")
     assert batches[0].dtype == torch.float32
+    # FP16 check
     model, batches = set_device_and_dtype(model, batches, device="cpu", dtype=torch.float16)
     assert model[0].weight.dtype == torch.float16
     assert batches[0].dtype == torch.float16
+
+    img_batches = [torch.rand(8) for _ in range(2)]
+    mask_batches = [torch.ones(8, dtype=torch.bool) for _ in range(2)]
+
+    model, batch = set_device_and_dtype(
+        model,
+        (img_batches, mask_batches),
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    assert model[0].weight.device == torch.device("cpu")
+    assert model[0].weight.dtype == torch.float32
+
+    assert isinstance(batch, list)
+    new_imgs = [img for img, _ in batch]
+    new_masks = [mask for _, mask in batch]
+
+    # image checks
+    assert all(isinstance(t, torch.Tensor) for t in new_imgs)
+    assert all(t.dtype == torch.float32 for t in new_imgs)
+    assert all(t.device == torch.device("cpu") for t in new_imgs)
+
+    # mask checks (should be bool)
+    assert all(isinstance(t, torch.Tensor) for t in new_masks)
+    assert all(t.dtype == torch.bool for t in new_masks)
+    assert all(t.device == torch.device("cpu") for t in new_masks)


### PR DESCRIPTION
This PR:

- Add Vit-Det as classification model (encoder for LW-DETR)
- Add corresponding tests
- Add docs entry
- Add preps for layout models (onnx export / device and dtype set)
- Add ChannelLayerNorm which will be required by LW-DETR