### PR TITLE
fix: handle empty inputs in OrientationPredictor

### DIFF
--- a/doctr/models/classification/predictor/pytorch.py
+++ b/doctr/models/classification/predictor/pytorch.py
@@ -37,6 +37,9 @@ class OrientationPredictor(nn.Module):
         self,
         inputs: list[np.ndarray],
     ) -> list[list[int] | list[float]]:
+        if len(inputs) == 0:
+            return [[], [], []]
+
         # Dimension check
         if any(input.ndim != 3 for input in inputs):
             raise ValueError("incorrect input shape: all inputs are expected to be multi-channel 2D images.")

--- a/tests/pytorch/test_models_classification_pt.py
+++ b/tests/pytorch/test_models_classification_pt.py
@@ -137,6 +137,7 @@ def test_crop_orientation_model(mock_text_box):
     # 270 degrees is equivalent to -90 degrees
     assert classifier([text_box_0, text_box_270, text_box_180, text_box_90])[1] == [0, -90, 180, 90]
     assert all(isinstance(pred, float) for pred in classifier([text_box_0, text_box_270, text_box_180, text_box_90])[2])
+    assert classifier([]) == [[], [], []]
 
     # Test with disabled predictor
     classifier = classification.crop_orientation_predictor(
@@ -147,6 +148,7 @@ def test_crop_orientation_model(mock_text_box):
         [0, 0, 0, 0],
         [1.0, 1.0, 1.0, 1.0],
     ]
+    assert classifier([]) == [[], [], []]
 
     # Test custom model loading
     classifier = classification.crop_orientation_predictor(
@@ -182,6 +184,7 @@ def test_page_orientation_model(mock_payslip):
     # 270 degrees is equivalent to -90 degrees
     assert classifier([text_box_0, text_box_270, text_box_180, text_box_90])[1] == [0, -90, 180, 90]
     assert all(isinstance(pred, float) for pred in classifier([text_box_0, text_box_270, text_box_180, text_box_90])[2])
+    assert classifier([]) == [[], [], []]
 
     # Test with disabled predictor
     classifier = classification.page_orientation_predictor(
@@ -192,6 +195,7 @@ def test_page_orientation_model(mock_payslip):
         [0, 0, 0, 0],
         [1.0, 1.0, 1.0, 1.0],
     ]
+    assert classifier([]) == [[], [], []]
 
     # Test custom model loading
     classifier = classification.page_orientation_predictor(


### PR DESCRIPTION
`OrientationPredictor` does not handle empty input batches and can raise an exception when orientation detection is enabled and no valid crops/images are passed to the predictor. This PR handles empty inputs similar to the `RecognitionPredictor`.

### Reproduction

```python
import requests

from doctr.io import DocumentFile
from doctr.models import ocr_predictor

receipt = requests.get(
    "https://github.com/mindee/doctr/releases/download/v0.3.0/mock_receipt.jpeg"
).content

predictor = ocr_predictor(
    pretrained=True,
    det_arch="fast_base",
    reco_arch="parseq",
    assume_straight_pages=False,
    detect_orientation=True,
    disable_crop_orientation=False,
    disable_page_orientation=False,
    straighten_pages=True,
)

docs = DocumentFile.from_images([receipt])
docs[0] = docs[0][:10, :10]

result = predictor(docs)
```

Result:

```text
File "/home/ubuntu/dev/pr/doctr/doctr/models/preprocessor/pytorch.py", line 73, in batch_inputs
    if isinstance(samples[0], tuple):
                  ~~~~~~~^^^
IndexError: list index out of range
```