### PR TITLE
fix(geometry): apply inclusive last-index per box in extract_crops

### DIFF
--- a/doctr/utils/geometry.py
+++ b/doctr/utils/geometry.py
@@ -464,7 +464,7 @@ def extract_crops(img: np.ndarray, boxes: np.ndarray) -> list[np.ndarray]:
         _boxes[:, [1, 3]] *= h
         _boxes = _boxes.round().astype(int)
         # Add last index
-        _boxes[2:] += 1
+        _boxes[:, 2:] += 1
 
     return deepcopy([img[box[1] : box[3], box[0] : box[2]] for box in _boxes])
 

--- a/tests/common/test_utils_geometry.py
+++ b/tests/common/test_utils_geometry.py
@@ -272,6 +272,12 @@ def test_extract_crops(mock_pdf):
     # Identity
     assert np.all(doc_img == geometry.extract_crops(doc_img, np.array([[0, 0, 1, 1]], dtype=np.float32))[0])
 
+    # Identical boxes must yield identical crops regardless of their position in the batch
+    gradient_img = np.tile(np.arange(100, dtype=np.uint8).reshape(100, 1, 1), (1, 100, 3))
+    same_box = [0.1, 0.1, 0.2, 0.2]
+    identical_crops = geometry.extract_crops(gradient_img, np.array([same_box, same_box, same_box], dtype=np.float32))
+    assert all(np.array_equal(crop, identical_crops[0]) for crop in identical_crops)
+
     # No box
     assert geometry.extract_crops(doc_img, np.zeros((0, 4))) == []
 


### PR DESCRIPTION
## What's broken

`extract_crops` is meant to add an inclusive `+1` to each box's `xmax`/`ymax` ("Add last index"), but the increment lands on the wrong axis: `_boxes[2:] += 1` adds 1 to all four coordinates of every box from batch index 2 onward, instead of adding 1 to the xmax/ymax columns of every box. So with 3+ boxes, every crop from index 2 on is cut from a region shifted one pixel in both x and y. The detection→recognition pipeline calls this with many boxes per page, so crops 3+ are silently misaligned.

```python
img = np.tile(np.arange(100, dtype=np.uint8).reshape(100,1,1), (1,100,3))
box = [0.10,0.10,0.20,0.20]
crops = extract_crops(img, np.array([box,box,box], dtype=np.float32))
print([int(c[0,0,0]) for c in crops])   # [10, 10, 11]  -> 3rd identical box starts a row too low
```

## Why it happens

`_boxes[2:] += 1` indexes the box axis; it should be `_boxes[:, 2:] += 1` (the coordinate columns).

## Fix

Change `_boxes[2:] += 1` to `_boxes[:, 2:] += 1`.

## Test

Added a case to `test_extract_crops` using a vertical-gradient image: three identical boxes must yield identical crops regardless of batch position. Fails before, passes after.
