### PR TITLE
Do not use root logger

### DIFF
--- a/doctr/file_utils.py
+++ b/doctr/file_utils.py
@@ -22,7 +22,7 @@ def requires_package(name: str, extra_message: str | None = None) -> None:  # pr
     """
     try:
         _pkg_version = importlib.metadata.version(name)
-        logging.info(f"{name} version {_pkg_version} available.")
+        logging.getLogger(__name__).info(f"{name} version {_pkg_version} available.")
     except importlib.metadata.PackageNotFoundError:
         raise ImportError(
             f"\n\n{extra_message if extra_message is not None else ''} "


### PR DESCRIPTION
Calling logging.info() at module level with no logger configured triggers logging.basicConfig() automatically (Python's "last resort" behavior) — which creates a StreamHandler on root with WARNING level.

This poisons logging config for anything downstream of this.

Instead, create a logger scoped to doctr package.

Example repro script:

```python
#!/usr/bin/env python
from doctr.io import Document

import logging
logging.basicConfig(level=logging.INFO)

logging.info("I do not see this")
logging.warning("I still see this")
```

Output:

```text
WARNING:root:I still see this
```

Expected:

```text
INFO:root:I do not see this
WARNING:root:I still see this
```