### PR TITLE
Do not use root logger

### DIFF
--- a/doctr/file_utils.py
+++ b/doctr/file_utils.py
@@ -22,7 +22,7 @@ def requires_package(name: str, extra_message: str | None = None) -> None:  # pr
     """
     try:
         _pkg_version = importlib.metadata.version(name)
-        logging.info(f"{name} version {_pkg_version} available.")
+        logging.getLogger(__name__).info(f"{name} version {_pkg_version} available.")
     except importlib.metadata.PackageNotFoundError:
         raise ImportError(
             f"\n\n{extra_message if extra_message is not None else ''} "

--- a/doctr/models/factory/hub.py
+++ b/doctr/models/factory/hub.py
@@ -37,7 +37,7 @@ def login_to_hub() -> None:  # pragma: no cover
     """Login to huggingface hub"""
     access_token = get_token()
     if access_token is not None:
-        logging.info("Huggingface Hub token found and valid")
+        logging.getLogger(__name__).info("Huggingface Hub token found and valid")
         login(token=access_token)
     else:
         login()

--- a/doctr/models/utils/pytorch.py
+++ b/doctr/models/utils/pytorch.py
@@ -58,7 +58,7 @@ def load_pretrained_params(
         **kwargs: additional arguments to be passed to `doctr.utils.data.download_from_url`
     """
     if path_or_url is None:
-        logging.warning("No model URL or Path provided, using default initialization.")
+        logging.getLogger(__name__).warning("No model URL or Path provided, using default initialization.")
         return
 
     archive_path = (
@@ -197,7 +197,7 @@ def export_model_to_onnx(
         verbose=False,
         **kwargs,
     )
-    logging.info(f"Model exported to {model_name}.onnx")
+    logging.getLogger(__name__).info(f"Model exported to {model_name}.onnx")
     return f"{model_name}.onnx"
 
 
@@ -451,7 +451,7 @@ def add_whitelist(
 
     if verbose:  # pragma: no cover
         kept = sum(char in allowed for char in vocab)
-        logging.info(
+        logging.getLogger(__name__).info(
             f"add_whitelist: {type(reco_model).__name__} - kept {kept}/{vocab_size} vocabulary "
             f"characters, forbade {vocab_size - kept}"
             + (f", reassigned {reassigned} to a nearest allowed character." if strategy == "nearest" else ".")

--- a/doctr/utils/data.py
+++ b/doctr/utils/data.py
@@ -84,7 +84,7 @@ def download_from_url(
     file_path = folder_path.joinpath(file_name)
     # Check file existence
     if file_path.is_file() and (hash_prefix is None or _check_integrity(file_path, hash_prefix)):
-        logging.info(f"Using downloaded & verified file: {file_path}")
+        logging.getLogger(__name__).info(f"Using downloaded & verified file: {file_path}")
         return file_path
 
     try:
@@ -98,7 +98,7 @@ def download_from_url(
             error_message += (
                 ". You can change default cache directory using 'DOCTR_CACHE_DIR' environment variable if needed."
             )
-        logging.error(error_message)
+        logging.getLogger(__name__).error(error_message)
         raise
     # Download the file
     try:

--- a/doctr/utils/fonts.py
+++ b/doctr/utils/fonts.py
@@ -27,7 +27,7 @@ def get_font(font_family: str | None = None, font_size: int = 13) -> ImageFont.F
             font = ImageFont.truetype("FreeMono.ttf" if platform.system() == "Linux" else "Arial.ttf", font_size)
         except OSError:  # pragma: no cover
             font = ImageFont.load_default()  # type: ignore[assignment]
-            logging.warning(
+            logging.getLogger(__name__).warning(
                 "unable to load recommended font family. Loading default PIL font,"
                 "font size issues may be expected."
                 "To prevent this, it is recommended to specify the value of 'font_family'."

--- a/doctr/utils/reconstitution.py
+++ b/doctr/utils/reconstitution.py
@@ -21,7 +21,7 @@ ROTATION_WARNING = False
 def _warn_rotation(entry: dict[str, Any]) -> None:  # pragma: no cover
     global ROTATION_WARNING
     if not ROTATION_WARNING and len(entry["geometry"]) == 4:
-        logging.warning("Polygons with larger rotations will lead to inaccurate rendering")
+        logging.getLogger(__name__).warning("Polygons with larger rotations will lead to inaccurate rendering")
         ROTATION_WARNING = True
 
 
@@ -84,7 +84,7 @@ def _synthesize(
             d.text((xmin, ymin), anyascii(word_text), font=font, fill=(0, 0, 0), anchor="lt")
     # Catch generic exceptions to avoid crashing the whole rendering
     except Exception:  # pragma: no cover
-        logging.warning(f"Could not render word: {word_text}")
+        logging.getLogger(__name__).warning(f"Could not render word: {word_text}")
 
     if draw_proba:
         confidence = (

--- a/tests/common/test_utils_data.py
+++ b/tests/common/test_utils_data.py
@@ -25,11 +25,11 @@ def test_download_from_url_customizing_cache_dir(mkdir_mock, urlretrieve_mock):
 
 @patch.dict(os.environ, {"HOME": "/"}, clear=True)
 @patch("pathlib.Path.mkdir", side_effect=OSError)
-@patch("logging.error")
-def test_download_from_url_error_creating_directory(logging_mock, mkdir_mock):
+@patch("doctr.utils.data.logging.getLogger")
+def test_download_from_url_error_creating_directory(get_logger_mock, mkdir_mock):
     with pytest.raises(OSError):
         download_from_url("test_url")
-    logging_mock.assert_called_with(
+    get_logger_mock.return_value.error.assert_called_with(
         "Failed creating cache directory at /.cache/doctr."
         " You can change default cache directory using 'DOCTR_CACHE_DIR' environment variable if needed."
     )
@@ -37,10 +37,10 @@ def test_download_from_url_error_creating_directory(logging_mock, mkdir_mock):
 
 @patch.dict(os.environ, {"HOME": "/", "DOCTR_CACHE_DIR": "/test"}, clear=True)
 @patch("pathlib.Path.mkdir", side_effect=OSError)
-@patch("logging.error")
-def test_download_from_url_error_creating_directory_with_env_var(logging_mock, mkdir_mock):
+@patch("doctr.utils.data.logging.getLogger")
+def test_download_from_url_error_creating_directory_with_env_var(get_logger_mock, mkdir_mock):
     with pytest.raises(OSError):
         download_from_url("test_url")
-    logging_mock.assert_called_with(
+    get_logger_mock.return_value.error.assert_called_with(
         "Failed creating cache directory at /test using path from 'DOCTR_CACHE_DIR' environment variable."
     )


### PR DESCRIPTION
Calling logging.info() at module level with no logger configured triggers logging.basicConfig() automatically (Python's "last resort" behavior) — which creates a StreamHandler on root with WARNING level.

This poisons logging config for anything downstream of this.

Instead, create a logger scoped to doctr package.

Example repro script:

```python
#!/usr/bin/env python
from doctr.io import Document

import logging
logging.basicConfig(level=logging.INFO)

logging.info("I do not see this")
logging.warning("I still see this")
```

Output:

```text
WARNING:root:I still see this
```

Expected:

```text
INFO:root:I do not see this
WARNING:root:I still see this
```

Replaces https://github.com/mindee/doctr/pull/2076