### PR TITLE
docs: warn that .half() corrupts CRNN recognition output on GPU + note .cuda() is required for GPU

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Notes for AI coding agents
+
+This file collects behaviors that are easy for an automated agent (or a
+human moving quickly) to miss, based on hands-on verification on an
+NVIDIA T4 (Turing, 16GB).
+
+## GPU is opt-in, with no warning
+
+`ocr_predictor(...)` (and the standalone `detection_predictor` /
+`recognition_predictor`) return a plain `nn.Module`-based predictor that stays
+on **CPU by default** — including on machines where
+`torch.cuda.is_available()` is `True`. There is no warning when this happens.
+You must explicitly move it yourself:
+
+```python
+model = ocr_predictor(pretrained=True).cuda()  # or .to(device)
+```
+
+Measured on a T4: CPU 2.657s/img → GPU (fp32) 0.155s/img (**17.16x**).
+
+There is no `device=` keyword on `ocr_predictor` / `_predictor`. Passing one
+(e.g. `ocr_predictor(pretrained=True, device="cuda")`, a natural guess) raises:
+
+```
+TypeError: DocumentBuilder.__init__() got an unexpected keyword argument 'device'
+```
+
+The error surfaces from an internal class (`DocumentBuilder`), not from
+`ocr_predictor` itself, which makes the root cause harder to trace. The
+standard PyTorch `nn.Module` API (`.cuda()` / `.to(device)`) is the only
+supported way to select a device; `scripts/analyze.py` also has no
+`--device`/`--cuda` flag and is CPU-only unless you edit it.
+
+## `.half()` can silently corrupt recognition output (CRNN only)
+
+`.half()` (fp16) is officially documented for inference speedup. On a T4,
+applying it to the **default README recognizer, `crnn_vgg16_bn`**
+(`nn.LSTM` decoder) silently corrupts recognition output — no error, no
+warning, and the corruption is deterministic (100% reproducible across
+repeated runs), so it's easy to mistake for a real, faster result:
+
+```
+fp32: ['Mr.', 'Anjum', 'Hameed,', 'We', 'are', 'pleased', 'inform', 'that', 'your', 'salary']
+fp16: ['Mr',  'Anjnn', 'nra,',    'Wn', 'arn', 'plansa', 'infnrn', 'tt',   'your', 'salay']
+```
+
+Cross-checked with the same detector/image against the transformer-based
+recognizers `master` and `parseq`: both produced output identical to fp32
+under `.half()`. The corruption appears specific to CRNN's `nn.LSTM` decoder,
+not to fp16 inference generally.
+
+**Before using `.half()` for recognition, confirm your `reco_arch` is not a
+CRNN variant, or validate the output yourself.**
+
+## No bf16 option (not a T4 trap here)
+
+The library only documents fp32/fp16 for inference; there is no bf16 code
+path (`torch.bfloat16` does not appear in the codebase). Nothing to trip on
+for this axis.
+
+## Attention has no backend to misconfigure
+
+`master` / `parseq` / ViTSTR all use a self-contained matmul+softmax
+attention implementation (`doctr/models/modules/transformer/pytorch.py`),
+not `torch.nn.functional.scaled_dot_product_attention` or
+`nn.MultiheadAttention`. There's no SDPA/flash-attention backend selection,
+so there's no flash-attn-unsupported-GPU crash risk — but also no backend
+to switch for a speedup.
+
+## int8 quantization is out of scope for this repo
+
+docTR itself only supports exporting to ONNX (`export_model_to_onnx()`).
+Quantized runtime inference is handled by the sister project
+[OnnxTR](https://github.com/felixdittrich92/OnnxTR), not by docTR.
+
+## Developer-mode install can silently disable CUDA
+
+`pip install -e doctr/.` (per README "Developer mode") only constrains
+`torch>=2.0.0,<3.0.0`, with no CUDA index pinned. If PyPI resolves a torch
+build newer than what your GPU driver supports, `torch.cuda.is_available()`
+returns `False` with no exception — you simply run on CPU. Reinstalling with
+the CUDA index that matches your driver (e.g.
+`pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu124`)
+fixes it.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ from doctr.models import ocr_predictor
 model = ocr_predictor(det_arch="db_resnet50", reco_arch="crnn_vgg16_bn", pretrained=True)
 ```
 
+> [!NOTE]
+> `ocr_predictor(...)` stays on **CPU by default, with no warning**, even on a machine with a CUDA GPU available. To run on GPU you must explicitly move the predictor yourself, e.g. `model = model.cuda()` (or `.to(device)`) — see [Running the predictors on GPU](https://mindee.github.io/doctr/using_doctr/using_models.html#running-the-predictors-on-gpu) for the full snippet (NVIDIA/CUDA and Apple Silicon/MPS). On an NVIDIA T4, adding this single call measured a **17.16x** speedup (2.657s → 0.155s per image) over the silent CPU fallback.
+
 ### Reading files
 
 Documents can be interpreted from PDF or images:
@@ -189,6 +192,9 @@ First clone the project repository:
 git clone https://github.com/mindee/doctr.git
 pip install -e doctr/.
 ```
+
+> [!NOTE]
+> This installs a PyTorch version constrained only by `torch>=2.0.0,<3.0.0`, which can resolve to a build newer than what your installed GPU driver supports. If that happens, `torch.cuda.is_available()` silently returns `False` (no error) and docTR falls back to CPU. If you hit this, reinstall torch/torchvision pinned to your driver's CUDA version, e.g. `pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu124`.
 
 Again, if you prefer to avoid the risk of missing dependencies, you can install the build:
 

--- a/docs/source/using_doctr/using_model_export.rst
+++ b/docs/source/using_doctr/using_model_export.rst
@@ -34,6 +34,23 @@ Advantages:
     ).cuda().half()
     res = predictor(doc)
 
+.. warning::
+    On an NVIDIA T4 (Turing), applying ``.half()`` to the **default** recognition architecture
+    ``crnn_vgg16_bn`` (``nn.LSTM`` decoder) silently corrupts recognition output — no error or
+    warning is raised, and the result is deterministic (100% reproducible across runs), which makes
+    it easy to mistake for a correct, faster result. Example on the same image, fp32 vs. fp16:
+
+    .. code:: text
+
+        fp32: ['Mr.', 'Anjum', 'Hameed,', 'We', 'are', 'pleased', 'inform', 'that', 'your', 'salary']
+        fp16: ['Mr',  'Anjnn', 'nra,',    'Wn', 'arn', 'plansa', 'infnrn', 'tt',   'your', 'salay']
+
+    Cross-checking with transformer-based recognizers (``master``, ``parseq``) on the same detector
+    and image showed **no corruption** — output was identical to fp32 — so this appears specific to
+    the CRNN's LSTM decoder rather than half-precision inference in general. Until this is fixed,
+    verify your recognition architecture is not CRNN-based (or validate output quality yourself)
+    before using ``.half()`` for recognition.
+
 
 Compiling your models (PyTorch only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Motivation

While benchmarking docTR's default OCR pipeline (`db_resnet50` + `crnn_vgg16_bn`) on an NVIDIA T4 (Turing, 16GB, driver 550.163.01 / CUDA 12.4, torch 2.6.0+cu124, doctr 1.0.2a0 @ `1a1018c`), I found two documentation gaps worth flagging, one of which is safety-relevant rather than just a performance nit:

1. **Silent CPU fallback.** The README "Quick Tour" never calls `.cuda()`/`.to(device)`, so on a machine with a CUDA GPU available, `ocr_predictor(...)` still runs 100% on CPU with zero warning (`peak_vram_mb: 0.0`). The GPU section already exists in `docs/using_doctr/using_models.rst`, it's just not linked from the Quick Tour, so it's easy to miss. Adding the single `.cuda()` call measured a **17.16x** speedup (2.657s → 0.155s/image) on this box.
2. **`.half()` (fp16) silently corrupts recognition output for the default recognizer — CRITICAL.** This is the important one. The officially documented half-precision path (`docs/using_model_export.rst`, `.cuda().half()`) works fine for transformer-based recognizers, but applied to the **README's own default combo**, `crnn_vgg16_bn` (an `nn.LSTM`-based decoder), it silently mangles the recognized text. No exception, no warning — the run completes normally and even looks faster (which it is). Example, same image, same detector, only dtype changed:

   ```
   fp32: ['Mr.', 'Anjum', 'Hameed,', 'We', 'are', 'pleased', 'inform', 'that', 'your', 'salary']
   fp16: ['Mr',  'Anjnn', 'nra,',    'Wn', 'arn', 'plansa', 'infnrn', 'tt',   'your', 'salay']
   ```

   This was 100% reproducible across 2 independent runs (deterministic, not a flaky numerics thing). To isolate the root cause, I fixed the detector and swapped only the recognizer: `master` and `parseq` (transformer-based recognizers, self-contained attention, no `nn.LSTM`) produced output **identical to fp32** under the exact same `.half()` call. So this looks specific to the CRNN's LSTM decoder under fp16, not to half-precision inference in docTR generally. I searched existing issues (e.g. #1441, a *crash* on a different architecture, `sar_resnet31`) and didn't find this silent-corruption pattern reported for `crnn_vgg16_bn` before.

   Since I couldn't find prior coverage of this specific case, and a silently wrong OCR result is a lot more dangerous than a slow one, I think it deserves a clearly flagged warning in the docs even though the actual fix (why the LSTM decoder is fp16-sensitive) is a code-level question I'm not proposing to touch here — see "Out of scope" below.

3. While looking into this I also checked whether the "PyTorch vs TensorFlow default backend" question (mentioned in some older docs/issues) still applies — it doesn't. As of this commit, TF has been fully removed (README tagline already says "powered by PyTorch", `pyproject.toml` has zero tensorflow dependencies). No doc change needed there; just confirming it's already accurate.

## Changes (doc-only, no code/behavior changes)

- `README.md`
  - Quick Tour: added a note directly under the `ocr_predictor(...)` example that the predictor stays on CPU by default with no warning, how to move it to GPU, and the measured T4 speedup, linking to the existing `using_models.rst` GPU section.
  - Developer mode install: added a note that the unpinned `torch` version range can silently resolve to a CUDA build newer than the local driver supports (`torch.cuda.is_available()` returns `False`, no error), with the fix (pin the CUDA index).
- `docs/source/using_doctr/using_model_export.rst`
  - Added a `.. warning::` right after the existing `.half()` example, describing the CRNN + fp16 corruption with the concrete before/after word list, and noting that `master`/`parseq` were unaffected in the same test.
- `AGENTS.md` (new)
  - Summarizes all of the above for future contributors/agents in one place, plus the already-safe axes I checked (no bf16 path, no SDPA/flash-attn backend selection, int8 quantization is out of scope and handled by the sister project OnnxTR).

No production code was changed — only prose additions to existing docs and a new contributor-notes file.

## Out of scope (flagging as a possible follow-up issue, not fixing here)

The root cause of the CRNN + fp16 corruption (likely fp16 precision loss accumulating through the `nn.LSTM` gates in `doctr/models/recognition/crnn/pytorch.py`) is a code-level question — possibly worth an `autocast`-style guard around the LSTM decoder, or at minimum a runtime warning when `.half()` is combined with a CRNN recognizer. I'm not proposing a code fix in this PR (this account only submits doc/text changes), but I'm happy to open a separate issue with the reproduction script if that's useful — let me know and I will.

## Testing / reproduction

Environment: Tesla T4 16GB, driver 550.163.01 (CUDA 12.4), Python 3.11.15, torch 2.6.0+cu124, torchvision 0.21.0+cu124, python-doctr 1.0.2a0 (editable install @ commit `1a1018c`).

```python
from doctr.io import DocumentFile
from doctr.models import ocr_predictor

# fp32 baseline (GPU, docs path)
model = ocr_predictor(det_arch="db_resnet50", reco_arch="crnn_vgg16_bn", pretrained=True).cuda()
doc = DocumentFile.from_images("sample.jpg")
result_fp32 = model(doc)

# fp16 (docs path) -- same image, same detector, only dtype changed
model_fp16 = ocr_predictor(det_arch="db_resnet50", reco_arch="crnn_vgg16_bn", pretrained=True).cuda().half()
result_fp16 = model_fp16(doc)
# -> recognized words diverge from result_fp32, deterministically, no error/warning

# root-cause isolation: swap recognizer only, keep detector + fp16
for reco in ["master", "parseq"]:
    m = ocr_predictor(det_arch="db_resnet50", reco_arch=reco, pretrained=True).cuda().half()
    # -> output identical to fp32 for both
```

- Ran the fp16-corruption comparison twice independently; identical corrupted output both times (deterministic).
- Ran the fp32→fp16 comparison against `master` and `parseq` recognizers (same detector/image) to isolate the corruption to the CRNN decoder specifically.
- Confirmed the `.cuda()` speedup and VRAM numbers via `torch.cuda.max_memory_allocated()` and wall-clock timing (3 runs each), CPU vs GPU-fp32 vs GPU-fp16.

Disclosure: I used an AI agent (Claude) to help investigate and benchmark this, with GPU access on a real Tesla T4, and to draft this PR. All findings above were verified by direct, reproducible execution rather than inferred.
