### PR TITLE
fix(visualization): honor add_labels in visualize_kie_page

### DIFF
--- a/doctr/utils/visualization.py
+++ b/doctr/utils/visualization.py
@@ -388,6 +388,16 @@ def visualize_kie_page(
                 if interactive:
                     # add patch to cursor's artists
                     artists.append(rect)
+                elif add_labels and len(prediction["geometry"]) == 2:
+                    # We draw only if boxes are in straight format
+                    ax.text(
+                        int(page["dimensions"][1] * prediction["geometry"][0][0]),
+                        int(page["dimensions"][0] * prediction["geometry"][0][1]),
+                        prediction["value"],
+                        size=10,
+                        alpha=0.5,
+                        color=colors[key],
+                    )
 
     if interactive:
         import mplcursors

--- a/tests/common/test_utils_visualization.py
+++ b/tests/common/test_utils_visualization.py
@@ -38,6 +38,12 @@ def test_visualize_kie_page():
     visualization.visualize_kie_page(page_export, image, words_only=False, display_layout=True)
     visualization.visualize_kie_page(page_export, image, words_only=False, display_layout=False, interactive=False)
 
+    # static plots label each prediction when add_labels is set
+    fig = visualization.visualize_kie_page(pages[0].export(), image, interactive=False, add_labels=True)
+    assert [text.get_text() for text in fig.axes[0].texts] == ["hello", "world"]
+    fig = visualization.visualize_kie_page(pages[0].export(), image, interactive=False, add_labels=False)
+    assert len(fig.axes[0].texts) == 0
+
 
 def test_draw_boxes():
     image = np.ones((256, 256, 3), dtype=np.float32)


### PR DESCRIPTION
### What does this PR do?

`visualize_kie_page()` takes `add_labels: bool = True` and documents it as *"for static plot, adds text labels on top of bounding box"*, but the body never calls `ax.text()` — the argument has no effect at all. A non-interactive KIE figure (`page.show(interactive=False)`, or saving the returned figure) therefore renders as coloured boxes with no text, and there is no way to get labels onto it.

`visualize_page()` already does this, on the `elif` branch right after the `interactive` one; this PR mirrors that branch for KIE predictions, using the per-key colour that already exists in `colors` and drawing only for straight (two-point) geometries, exactly as `visualize_page()` does.

`display_artefacts` is also unused here, but that one is inherent — a KIE page export has `predictions`, not `blocks`/`artefacts` — so I left it alone rather than change the public signature in a bug-fix PR.

### Before / after

Run against a two-prediction page (`_mock_kie_pages()` shape, values `hello` / `world`), reading back `fig.axes[0].texts`:

| call | before | after |
|---|---|---|
| `interactive=False, add_labels=True` | `[]` | `['hello', 'world']` |
| `interactive=False, add_labels=False` | `[]` | `[]` |
| `interactive=True, add_labels=True` | `[]` | `[]` |
| `words_only=True` | `[]` (no patches) | `[]` (no patches) |

`visualize_page()` is untouched and still renders its label (`['hi']` on the same harness).

### Test

`test_visualize_kie_page` gains an assertion on both sides of the flag. It fails on `main` (`[] != ['hello', 'world']`) and passes with the fix.

`ruff check` / `ruff format --check` clean on both files with the repo config.

Type of change: Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
