### PR TITLE
[misc] post release v1.1.0

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "doctr-api"
-version = "1.0.2a0"
+version = "1.1.1a0"
 description = "Backend template for your OCR API with docTR"
 authors = ["Mindee <contact@mindee.com>"]
 license = "Apache-2.0"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -35,5 +35,6 @@ deploy_doc "" latest
 deploy_doc "1c9ce92" v0.11.0
 deploy_doc "97d4006" v0.12.0
 deploy_doc "7dabbe1" v1.0.0
-deploy_doc "6541a6e" # v1.0.1 Latest stable release
+deploy_doc "6541a6e" v1.0.1
+deploy_doc "2d8e244" # v1.1.0 Latest stable release
 rm -rf _build _static _conf.py

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -3,11 +3,12 @@
 
 // These two things need to be updated at each release for the version selector.
 // Last stable version
-const stableVersion = "v1.0.1"
+const stableVersion = "v1.1.0"
 // Dictionary doc folder to label. The last stable version should have an empty key.
 const versionMapping = {
     "latest": "latest",
-    "": "v1.0.1 (stable)",
+    "": "v1.1.1 (stable)",
+    "v1.1.0": "v1.1.0",
     "v1.0.0": "v1.0.0",
     "v0.12.0": "v0.12.0",
     "v0.11.0": "v0.11.0",

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v1.1.0 (2026-08-21)
+-------------------
+Release note: `v1.1.0 <https://github.com/mindee/doctr/releases/tag/v1.1.0>`_
+
 v1.0.1 (2026-02-04)
 -------------------
 Release note: `v1.0.1 <https://github.com/mindee/doctr/releases/tag/v1.0.1>`_

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from setuptools import setup
 
 PKG_NAME = "python-doctr"
-VERSION = os.getenv("BUILD_VERSION", "1.0.2a0")
+VERSION = os.getenv("BUILD_VERSION", "1.1.1a0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request updates the project to reflect the new `v1.1.0` release. The main changes include updating version numbers across configuration files, adding the new release to documentation deployment scripts, and updating the changelog.

**Release version updates:**

* `api/pyproject.toml`, `setup.py`: Bumped the package version from `1.0.2a0` to `1.1.1a0` to mark the new release. [[1]](diffhunk://#diff-40f8f985c548e2b57b803d17f42833f8a4d94603ca5b5e0bf48de51872809400L7-R7) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L12-R12)

**Documentation and changelog updates:**

* [`docs/build.sh`](diffhunk://#diff-bcdbd66bdb41241ada207d8561edeabbcc8e8df5a2be4adaf802f239975768c3L38-R39): Added deployment instructions for `v1.1.0` and clarified version tags for stable releases.
* [`docs/source/_static/js/custom.js`](diffhunk://#diff-1e8ca07bac15a563db8fc7f2cabea983bcfd96db04abc801bf509aabc2f25aebL6-R11): Updated the stable version to `v1.1.0` and adjusted the version mapping for the version selector UI.
* [`docs/source/changelog.rst`](diffhunk://#diff-ef86237172bb2f91c585e845b38d6fb28bb6ac128ff8efa541cdd86f81751bf2R4-R7): Added a new changelog entry for `v1.1.0` with a link to the release notes.