### PR TITLE
feat(io): estimate x_size and x_fsize in hOCR export

### DIFF
--- a/doctr/io/exporters.py
+++ b/doctr/io/exporters.py
@@ -640,6 +640,22 @@ def _hocr_bbox(geometry: BoundingBox, width: int, height: int) -> str:
     )
 
 
+def _hocr_text_size(geometry: BoundingBox, height: int, dpi: int = 72) -> tuple[int, int]:
+    """Estimate the hOCR `x_size` and `x_fsize` properties from the height of a relative bounding box.
+
+    Args:
+        geometry: the relative bounding box ((xmin, ymin), (xmax, ymax))
+        height: the page height in pixels
+        dpi: the page resolution in dots per inch, used to convert the text height to font points
+
+    Returns:
+        a tuple of the text height in pixels (`x_size`), and the estimated font size in points (`x_fsize`)
+    """
+    (_, ymin), (_, ymax) = geometry
+    x_size = int(round((ymax - ymin) * height))
+    return x_size, int(round(x_size * 72 / dpi))
+
+
 class XMLExporter:
     """hOCR (XML) exporter for pages, KIE pages and documents.
     See the hOCR 1.2 specification for the XML convention: https://github.com/kba/hocr-spec/blob/master/1.2/spec.md
@@ -664,7 +680,9 @@ class XMLExporter:
         SubElement(head, "meta", attrib={"name": "ocr-capabilities", "content": self.ocr_capabilities})
         return root, SubElement(root, "body")
 
-    def _add_table(self, page_div: ETElement, table: "Table", width: int, height: int, table_count: int) -> int:
+    def _add_table(
+        self, page_div: ETElement, table: "Table", width: int, height: int, table_count: int, dpi: int = 72
+    ) -> int:
         """Serialize a recognized table as an hOCR text area, with one `ocr_line` per row.
 
         Args:
@@ -673,6 +691,7 @@ class XMLExporter:
             width: the page width in pixels
             height: the page height in pixels
             table_count: the 1-based index of the table on the page
+            dpi: the page resolution in dots per inch, used to estimate font sizes
 
         Returns:
             the index of the next table
@@ -693,14 +712,19 @@ class XMLExporter:
             cells = sorted(rows[row_idx], key=lambda cell: cell.col_start)
             xs = [coord for cell in cells for coord in (cell.geometry[0][0], cell.geometry[1][0])]
             ys = [coord for cell in cells for coord in (cell.geometry[0][1], cell.geometry[1][1])]
-            row_bbox = _hocr_bbox(((min(xs), min(ys)), (max(xs), max(ys))), width, height)
+            row_geometry = ((min(xs), min(ys)), (max(xs), max(ys)))
+            row_bbox = _hocr_bbox(row_geometry, width, height)
+            row_x_size, row_x_fsize = _hocr_text_size(row_geometry, height, dpi)
             line_span = SubElement(
                 paragraph,
                 "span",
                 attrib={
                     "class": "ocr_line",
                     "id": f"table_{table_count}_row_{row_idx + 1}",
-                    "title": f"{row_bbox}; baseline 0 0; x_size 0; x_descenders 0; x_ascenders 0",
+                    "title": (
+                        f"{row_bbox}; baseline 0 0; x_size {row_x_size}; x_fsize {row_x_fsize}; "
+                        "x_descenders 0; x_ascenders 0"
+                    ),
                 },
             )
             for col_idx, cell in enumerate(cells):
@@ -724,6 +748,7 @@ class XMLExporter:
         file_title: str = "docTR - XML export (hOCR)",
         direction: str = "auto",
         reading_order: bool = True,
+        dpi: int = 72,
     ) -> tuple[bytes, ET.ElementTree]:
         """Export a page as hOCR XML, with its content sorted in reading order.
 
@@ -733,6 +758,7 @@ class XMLExporter:
             direction: reading direction, one of 'auto', 'ltr', 'rtl', 'ttb-rtl' or 'ttb-ltr'
             reading_order: whether the content should be linearized in reading order. Pass False to serialize
                 `page.blocks` then `page.tables` in their raw order.
+            dpi: the page resolution in dots per inch, used to estimate font sizes (`x_size`, `x_fsize`)
 
         Returns:
             a tuple of the XML byte string, and its ElementTree
@@ -762,7 +788,7 @@ class XMLExporter:
         # iterate over the blocks / lines / words and create the XML elements line by line with the attributes
         for item in items:
             if isinstance(item, Table):
-                table_count = self._add_table(page_div, item, width, height, table_count)
+                table_count = self._add_table(page_div, item, width, height, table_count, dpi=dpi)
                 continue
             block = item
             if len(block.geometry) != 2:
@@ -780,7 +806,9 @@ class XMLExporter:
             )
             block_count += 1
             for line in block.lines:
-                # NOTE: baseline, x_size, x_descenders, x_ascenders is currently initalized to 0
+                # NOTE: baseline, x_descenders, x_ascenders are currently initialized to 0,
+                # while x_size and x_fsize are estimated from the line box height
+                x_size, x_fsize = _hocr_text_size(line.geometry, height, dpi)
                 line_span = SubElement(
                     paragraph,
                     "span",
@@ -789,7 +817,7 @@ class XMLExporter:
                         "id": f"line_{line_count}",
                         "title": (
                             f"{_hocr_bbox(line.geometry, width, height)}; "
-                            "baseline 0 0; x_size 0; x_descenders 0; x_ascenders 0"
+                            f"baseline 0 0; x_size {x_size}; x_fsize {x_fsize}; x_descenders 0; x_ascenders 0"
                         ),
                     },
                 )
@@ -817,6 +845,7 @@ class XMLExporter:
         file_title: str = "docTR - XML export (hOCR)",
         direction: str = "auto",
         reading_order: bool = True,
+        dpi: int = 72,
     ) -> tuple[bytes, ET.ElementTree]:
         """Export a KIE page as hOCR XML, with the predictions of each class sorted in reading order.
 
@@ -825,6 +854,7 @@ class XMLExporter:
             file_title: the title of the XML file
             direction: reading direction, one of 'auto', 'ltr', 'rtl', 'ttb-rtl' or 'ttb-ltr'
             reading_order: whether the predictions of each class should be sorted in reading order
+            dpi: the page resolution in dots per inch, used to estimate font sizes (`x_size`, `x_fsize`)
 
         Returns:
             a tuple of the XML byte string, and its ElementTree
@@ -848,6 +878,7 @@ class XMLExporter:
                 if len(prediction.geometry) != 2:
                     raise TypeError("XML export is only available for straight bounding boxes for now.")
                 prediction_bbox = _hocr_bbox(prediction.geometry, width, height)  # type: ignore[arg-type]
+                x_size, x_fsize = _hocr_text_size(prediction.geometry, height, dpi)  # type: ignore[arg-type]
                 prediction_div = SubElement(
                     body,
                     "div",
@@ -874,7 +905,10 @@ class XMLExporter:
                     attrib={
                         "class": "ocr_line",
                         "id": f"{class_name}_line_{prediction_count}",
-                        "title": f"{prediction_bbox}; baseline 0 0; x_size 0; x_descenders 0; x_ascenders 0",
+                        "title": (
+                            f"{prediction_bbox}; baseline 0 0; x_size {x_size}; x_fsize {x_fsize}; "
+                            "x_descenders 0; x_ascenders 0"
+                        ),
                     },
                 )
                 word_div = SubElement(
@@ -960,6 +994,7 @@ class PageExportsMixin:
         file_title: str = "docTR - XML export (hOCR)",
         direction: str = "auto",
         reading_order: bool = True,
+        dpi: int = 72,
     ) -> tuple[bytes, ET.ElementTree]:
         """Export the page as XML (hOCR-format), with its content sorted in reading order
         convention: https://github.com/kba/hocr-spec/blob/master/1.2/spec.md
@@ -968,12 +1003,13 @@ class PageExportsMixin:
             file_title: the title of the XML file
             direction: reading direction, one of 'auto', 'ltr', 'rtl', 'ttb-rtl' or 'ttb-ltr'
             reading_order: whether the content should be linearized in reading order
+            dpi: the page resolution in dots per inch, used to estimate font sizes (`x_size`, `x_fsize`)
 
         Returns:
             a tuple of the XML byte string, and its ElementTree
         """
         return XMLExporter().export_page(
-            cast("Page", self), file_title=file_title, direction=direction, reading_order=reading_order
+            cast("Page", self), file_title=file_title, direction=direction, reading_order=reading_order, dpi=dpi
         )
 
     def items_in_reading_order(self, direction: str = "auto") -> list["Block | Table"]:
@@ -1113,6 +1149,7 @@ class KIEPageExportsMixin:
         file_title: str = "docTR - XML export (hOCR)",
         direction: str = "auto",
         reading_order: bool = True,
+        dpi: int = 72,
     ) -> tuple[bytes, ET.ElementTree]:
         """Export the page as XML (hOCR-format), with the predictions of each class in reading order
         convention: https://github.com/kba/hocr-spec/blob/master/1.2/spec.md
@@ -1121,12 +1158,13 @@ class KIEPageExportsMixin:
             file_title: the title of the XML file
             direction: reading direction, one of 'auto', 'ltr', 'rtl', 'ttb-rtl' or 'ttb-ltr'
             reading_order: whether the predictions of each class should be sorted in reading order
+            dpi: the page resolution in dots per inch, used to estimate font sizes (`x_size`, `x_fsize`)
 
         Returns:
             a tuple of the XML byte string, and its ElementTree
         """
         return XMLExporter().export_kie_page(
-            cast("KIEPage", self), file_title=file_title, direction=direction, reading_order=reading_order
+            cast("KIEPage", self), file_title=file_title, direction=direction, reading_order=reading_order, dpi=dpi
         )
 
     def export_as_markdown(self, direction: str = "auto", escape: bool = True) -> str:

--- a/tests/common/test_io_exporters.py
+++ b/tests/common/test_io_exporters.py
@@ -579,6 +579,47 @@ def test_xml_exporter_class():
     assert len(doc_xml) == 2 and doc.export_as_xml()[0][0] == doc_xml[0][0]
 
 
+def test_xml_export_text_size():
+    # x_size (text height in pixels) and x_fsize (font size in points) are estimated from the
+    # element box height; the dpi kwarg scales the pixel-to-point conversion (default 72)
+    page = elements.Page(
+        np.zeros((10, 10, 3), dtype=np.uint8),
+        [elements.Block(lines=[_line_at("one two", 0.1, 0.1, 0.9, 0.2)])],
+        0,
+        (1000, 800),
+    )
+    xml = page.export_as_xml()[0].decode()
+    # the line spans y=0.1..0.2 of a 1000px-high page -> 100px text height, 100pt at 72 dpi
+    assert "x_size 100; x_fsize 100;" in xml
+    assert "x_size 0;" not in xml
+    xml = page.export_as_xml(dpi=144)[0].decode()
+    assert "x_size 100; x_fsize 50;" in xml
+
+    # table rows and KIE predictions carry the estimated sizes as well
+    cells = [
+        elements.TableCell("head", 0.9, ((0.1, 0.6), (0.4, 0.65)), 0, 0, 0, 0),
+        elements.TableCell("body", 0.9, ((0.1, 0.66), (0.4, 0.71)), 1, 1, 0, 0),
+    ]
+    table = elements.Table(cells=cells, num_rows=2, num_cols=1, geometry=((0.1, 0.6), (0.4, 0.71)))
+    page = elements.Page(
+        np.zeros((10, 10, 3), dtype=np.uint8),
+        [elements.Block(lines=[_line_at("intro line", 0.1, 0.1, 0.9, 0.15)])],
+        0,
+        (1000, 800),
+        tables=[table],
+    )
+    xml = page.export_as_xml()[0].decode()
+    # row 0 spans y=0.6..0.65 -> 50px, row 1 spans y=0.66..0.71 -> 50px
+    assert "x_size 50; x_fsize 50;" in xml
+
+    predictions = {
+        CLASS_NAME: [elements.Prediction("hi", 0.9, ((0.1, 0.1), (0.9, 0.2)), 0.9, {"value": 0, "confidence": None})]
+    }
+    kie = elements.KIEPage(np.zeros((10, 10, 3), dtype=np.uint8), predictions, 0, (1000, 800))
+    xml = kie.export_as_xml()[0].decode()
+    assert "x_size 100; x_fsize 100;" in xml
+
+
 def _table_page(num_rows=2, num_cols=1, rotated=False):
     """A page with an intro line and one recognized table"""
     geo = ((0.1, 0.6), (0.4, 0.66), (0.4, 0.71), (0.1, 0.71)) if rotated else ((0.1, 0.6), (0.4, 0.71))


### PR DESCRIPTION
The hOCR export was emitting `x_size 0` on every `ocr_line` element (with an in-code note that the value was left uninitialized), so text height and font size were unspecified for consumers of the export.

This PR estimates both properties from the element box height:

- `x_size`: absolute text height in pixels, derived from the bbox height of the line, table row or KIE prediction
- `x_fsize`: font size in points, converted from `x_size` through a new `dpi` export argument (default 72, matching the hOCR point convention and docTR's PDF scale convention)

`baseline`, `x_descenders` and `x_ascenders` remain 0 since the pipeline has no signal for them.

## How was it tested?

New test covering lines, table rows, KIE predictions and the `dpi` scaling, plus the existing export suites: `pytest tests/common/test_io_elements.py tests/common/test_io_exporters.py` (55 passed). `ruff check`, `ruff format --check` and `mypy` are clean.
