### PR TITLE
[Fix] Fix DDP wb / clearml logging

### DIFF
--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -528,7 +528,7 @@ def main(args):
     global_step = 0  # Shared global step counter
 
     # W&B
-    if args.wb:
+    if rank == 0 and args.wb:
         import wandb
 
         run = wandb.init(name=exp_name, project="text-detection", config=config)
@@ -541,7 +541,7 @@ def main(args):
             })
 
     # ClearML
-    if args.clearml:
+    if rank == 0 and args.clearml:
         from clearml import Logger, Task
 
         task = Task.init(project_name="docTR/text-detection", task_name=exp_name, reuse_last_task_id=False)
@@ -574,9 +574,9 @@ def main(args):
     # Unified logger
     def log_at_step(train_loss=None, val_loss=None, lr=None):
         global global_step
-        if args.wb:
+        if args.wb and rank == 0:
             wandb_log_at_step(train_loss, val_loss, lr)
-        if args.clearml:
+        if args.clearml and rank == 0:
             clearml_log_at_step(train_loss, val_loss, lr)
         global_step += 1  # Increment the shared global step counter
 

--- a/references/layout/train.py
+++ b/references/layout/train.py
@@ -576,7 +576,7 @@ def main(args):
     global_step = 0  # Shared global step counter
 
     # W&B
-    if args.wb:
+    if rank == 0 and args.wb:
         import wandb
 
         run = wandb.init(name=exp_name, project="layout-detection", config=config)
@@ -589,7 +589,7 @@ def main(args):
             })
 
     # ClearML
-    if args.clearml:
+    if rank == 0 and args.clearml:
         from clearml import Logger, Task
 
         task = Task.init(project_name="docTR/layout-detection", task_name=exp_name, reuse_last_task_id=False)
@@ -623,9 +623,9 @@ def main(args):
     # Unified logger
     def log_at_step(train_loss=None, val_loss=None, lr=None):
         global global_step
-        if args.wb:
+        if args.wb and rank == 0:
             wandb_log_at_step(train_loss, val_loss, lr)
-        if args.clearml:
+        if args.clearml and rank == 0:
             clearml_log_at_step(train_loss, val_loss, lr)
         global_step += 1  # Increment the shared global step counter
 
@@ -702,9 +702,8 @@ def main(args):
                 pbar.write("Training halted early due to reaching patience limit.")
                 break
 
-    if rank == 0:
-        if args.wb:
-            run.finish()
+    if rank == 0 and args.wb:
+        run.finish()
 
         if args.push_to_hub:
             push_to_hf_hub(model, exp_name, task="layout", run_config=args)

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -547,9 +547,9 @@ def main(args):
 
     def log_at_step(train_loss=None, val_loss=None, lr=None):
         global global_step
-        if args.wb:
+        if args.wb and rank == 0:
             wandb_log_at_step(train_loss, val_loss, lr)
-        if args.clearml:
+        if args.clearml and rank == 0:
             clearml_log_at_step(train_loss, val_loss, lr)
         global_step += 1  # Increment the shared global step counter
 

--- a/references/table/train.py
+++ b/references/table/train.py
@@ -423,7 +423,7 @@ def main(args):
     global global_step
     global_step = 0
 
-    if args.wb:
+    if rank == 0 and args.wb:
         import wandb
 
         run = wandb.init(name=exp_name, project="table-structure-recognition", config=config)
@@ -435,7 +435,7 @@ def main(args):
                 **({"step_lr": lr} if lr is not None else {}),
             })
 
-    if args.clearml:
+    if rank == 0 and args.clearml:
         from clearml import Logger, Task
 
         task = Task.init(project_name="docTR/table-structure-recognition", task_name=exp_name, reuse_last_task_id=False)
@@ -456,9 +456,9 @@ def main(args):
 
     def log_at_step(train_loss=None, val_loss=None, lr=None):
         global global_step
-        if args.wb:
+        if args.wb and rank == 0:
             wandb_log_at_step(train_loss, val_loss, lr)
-        if args.clearml:
+        if args.clearml and rank == 0:
             clearml_log_at_step(train_loss, val_loss, lr)
         global_step += 1
 


### PR DESCRIPTION
This pull request updates the training scripts for detection, layout, recognition, and table structure recognition to ensure that logging to Weights & Biases (W&B) and ClearML only occurs on the main process (rank 0) in distributed training setups. This prevents duplicate logging and potential conflicts when running on multiple processes.

The most important changes are:

**Distributed Logging Safeguards:**

* All logging calls to W&B and ClearML in `train.py` scripts for detection, layout, recognition, and table recognition are now gated by `rank == 0`, ensuring only the main process logs experiment data. [[1]](diffhunk://#diff-ca22b647c1f1d7567a1b0f55594ddc02676e813ab3831b2d4692169e6bb1a23eL531-R531) [[2]](diffhunk://#diff-ca22b647c1f1d7567a1b0f55594ddc02676e813ab3831b2d4692169e6bb1a23eL544-R544) [[3]](diffhunk://#diff-ca22b647c1f1d7567a1b0f55594ddc02676e813ab3831b2d4692169e6bb1a23eL577-R579) [[4]](diffhunk://#diff-e554a7d3cab55a6c2ec2acd61e7ed9b7c0cb151be3a6c33d82849efdb8f176caL579-R579) [[5]](diffhunk://#diff-e554a7d3cab55a6c2ec2acd61e7ed9b7c0cb151be3a6c33d82849efdb8f176caL592-R592) [[6]](diffhunk://#diff-e554a7d3cab55a6c2ec2acd61e7ed9b7c0cb151be3a6c33d82849efdb8f176caL626-R628) [[7]](diffhunk://#diff-e554a7d3cab55a6c2ec2acd61e7ed9b7c0cb151be3a6c33d82849efdb8f176caL705-R705) [[8]](diffhunk://#diff-cfba147bf8e130363cf4467eea71b8d3e45eb3ac0832c4f3235ebfc29f920877L550-R552) [[9]](diffhunk://#diff-810510c464cd8d3e75274ab5a2c76b3cce558a1e6d6d1de8f440f5776ab6f06bL426-R426) [[10]](diffhunk://#diff-810510c464cd8d3e75274ab5a2c76b3cce558a1e6d6d1de8f440f5776ab6f06bL438-R438) [[11]](diffhunk://#diff-810510c464cd8d3e75274ab5a2c76b3cce558a1e6d6d1de8f440f5776ab6f06bL459-R461)

**Code Consistency and Clarity:**

* The conditional checks for logging are now consistent across all training scripts, making the distributed behavior predictable and easier to maintain. (applies to all references above)