### PR TITLE
[Fix] DDP init with device id

### DIFF
--- a/references/detection/ddp_utils.py
+++ b/references/detection/ddp_utils.py
@@ -84,15 +84,21 @@ def sync_val_metric(
 def barrier_download(rank: int, distributed: bool):
     """Context manager that lets rank 0 populate the docTR cache before the others read it"""
 
+    def _barrier():
+        if torch.cuda.is_available() and dist.get_backend() == "nccl":
+            dist.barrier(device_ids=[torch.cuda.current_device()])
+        else:
+            dist.barrier()
+
     class _BarrierDownload:
         def __enter__(self):
             if distributed and rank != 0:
-                dist.barrier()  # wait for rank 0 to finish downloading
+                _barrier()  # wait for rank 0 to finish downloading
             return self
 
         def __exit__(self, *exc_info):
             if distributed and rank == 0:
-                dist.barrier()  # release the other ranks
+                _barrier()  # release the other ranks
             return False
 
     return _BarrierDownload()

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -230,9 +230,9 @@ def main(args):
     # GPU setup
     if distributed:
         rank = int(os.environ.get("LOCAL_RANK", 0))
-        dist.init_process_group(backend=args.backend)
         device = torch.device("cuda", rank)
         torch.cuda.set_device(device)
+        dist.init_process_group(backend=args.backend, device_id=device)
 
     else:
         # single process

--- a/references/layout/ddp_utils.py
+++ b/references/layout/ddp_utils.py
@@ -84,15 +84,21 @@ def sync_val_metric(
 def barrier_download(rank: int, distributed: bool):
     """Context manager that lets rank 0 populate the docTR cache before the others read it"""
 
+    def _barrier():
+        if torch.cuda.is_available() and dist.get_backend() == "nccl":
+            dist.barrier(device_ids=[torch.cuda.current_device()])
+        else:
+            dist.barrier()
+
     class _BarrierDownload:
         def __enter__(self):
             if distributed and rank != 0:
-                dist.barrier()  # wait for rank 0 to finish downloading
+                _barrier()  # wait for rank 0 to finish downloading
             return self
 
         def __exit__(self, *exc_info):
             if distributed and rank == 0:
-                dist.barrier()  # release the other ranks
+                _barrier()  # release the other ranks
             return False
 
     return _BarrierDownload()

--- a/references/layout/train.py
+++ b/references/layout/train.py
@@ -233,9 +233,9 @@ def main(args):
     # GPU setup
     if distributed:
         rank = int(os.environ.get("LOCAL_RANK", 0))
-        dist.init_process_group(backend=args.backend)
         device = torch.device("cuda", rank)
         torch.cuda.set_device(device)
+        dist.init_process_group(backend=args.backend, device_id=device)
     else:
         # single process
         rank = 0

--- a/references/recognition/ddp_utils.py
+++ b/references/recognition/ddp_utils.py
@@ -84,15 +84,21 @@ def sync_val_metric(
 def barrier_download(rank: int, distributed: bool):
     """Context manager that lets rank 0 populate the docTR cache before the others read it"""
 
+    def _barrier():
+        if torch.cuda.is_available() and dist.get_backend() == "nccl":
+            dist.barrier(device_ids=[torch.cuda.current_device()])
+        else:
+            dist.barrier()
+
     class _BarrierDownload:
         def __enter__(self):
             if distributed and rank != 0:
-                dist.barrier()  # wait for rank 0 to finish downloading
+                _barrier()  # wait for rank 0 to finish downloading
             return self
 
         def __exit__(self, *exc_info):
             if distributed and rank == 0:
-                dist.barrier()  # release the other ranks
+                _barrier()  # release the other ranks
             return False
 
     return _BarrierDownload()

--- a/references/recognition/train.py
+++ b/references/recognition/train.py
@@ -210,10 +210,9 @@ def main(args):
     # GPU setup
     if distributed:
         rank = int(os.environ.get("LOCAL_RANK", 0))
-        dist.init_process_group(backend=args.backend)
         device = torch.device("cuda", rank)
         torch.cuda.set_device(device)
-
+        dist.init_process_group(backend=args.backend, device_id=device)
     else:
         # single process
         rank = 0

--- a/references/table/ddp_utils.py
+++ b/references/table/ddp_utils.py
@@ -84,15 +84,21 @@ def sync_val_metric(
 def barrier_download(rank: int, distributed: bool):
     """Context manager that lets rank 0 populate the docTR cache before the others read it"""
 
+    def _barrier():
+        if torch.cuda.is_available() and dist.get_backend() == "nccl":
+            dist.barrier(device_ids=[torch.cuda.current_device()])
+        else:
+            dist.barrier()
+
     class _BarrierDownload:
         def __enter__(self):
             if distributed and rank != 0:
-                dist.barrier()  # wait for rank 0 to finish downloading
+                _barrier()  # wait for rank 0 to finish downloading
             return self
 
         def __exit__(self, *exc_info):
             if distributed and rank == 0:
-                dist.barrier()  # release the other ranks
+                _barrier()  # release the other ranks
             return False
 
     return _BarrierDownload()

--- a/references/table/train.py
+++ b/references/table/train.py
@@ -197,9 +197,9 @@ def main(args):
 
     if distributed:
         rank = int(os.environ.get("LOCAL_RANK", 0))
-        dist.init_process_group(backend=args.backend)
         device = torch.device("cuda", rank)
         torch.cuda.set_device(device)
+        dist.init_process_group(backend=args.backend, device_id=device)
     else:
         rank = 0
         if isinstance(args.device, int):


### PR DESCRIPTION
This pull request improves distributed training reliability and device management for all detection, recognition, layout, and table training scripts. The main changes ensure that PyTorch's distributed process group is correctly initialized with device information and that CUDA-aware barriers are used for synchronization, which helps prevent deadlocks and device mismatch errors.

**Distributed Training Initialization:**
- All `train.py` scripts (`detection`, `recognition`, `layout`, `table`) now initialize the process group with the `device_id` argument, ensuring each process is explicitly associated with the correct CUDA device. [[1]](diffhunk://#diff-ca22b647c1f1d7567a1b0f55594ddc02676e813ab3831b2d4692169e6bb1a23eL233-R235) [[2]](diffhunk://#diff-cfba147bf8e130363cf4467eea71b8d3e45eb3ac0832c4f3235ebfc29f920877L213-R215) [[3]](diffhunk://#diff-e554a7d3cab55a6c2ec2acd61e7ed9b7c0cb151be3a6c33d82849efdb8f176caL236-R238) [[4]](diffhunk://#diff-810510c464cd8d3e75274ab5a2c76b3cce558a1e6d6d1de8f440f5776ab6f06bL200-R202)

**Barrier Synchronization Improvements:**
- The `barrier_download` context manager in all `ddp_utils.py` modules (`detection`, `recognition`, `layout`, `table`) now uses a helper function to call `dist.barrier` with `device_ids` when using the NCCL backend and CUDA, ensuring correct device synchronization and avoiding potential deadlocks.

These changes collectively improve robustness and compatibility for multi-GPU distributed training across all relevant modules.