### PR TITLE
fix: handle empty batches in detection and end-to-end predictors

### DIFF
--- a/doctr/models/detection/predictor/pytorch.py
+++ b/doctr/models/detection/predictor/pytorch.py
@@ -40,6 +40,9 @@ class DetectionPredictor(nn.Module):
         return_maps: bool = False,
         **kwargs: Any,
     ) -> list[dict[str, np.ndarray]] | tuple[list[dict[str, np.ndarray]], list[np.ndarray]]:
+        if len(pages) == 0:
+            return ([], []) if return_maps else []
+
         # Extract parameters from the preprocessor
         preserve_aspect_ratio = self.pre_processor.resize.preserve_aspect_ratio
         symmetric_pad = self.pre_processor.resize.symmetric_pad

--- a/doctr/models/kie_predictor/pytorch.py
+++ b/doctr/models/kie_predictor/pytorch.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from torch import nn
 
-from doctr.io.elements import Document
+from doctr.io.elements import Document, KIEDocument
 from doctr.models._utils import get_language, invert_data_structure
 from doctr.models.detection.predictor import DetectionPredictor
 from doctr.models.layout.predictor import LayoutPredictor
@@ -79,6 +79,9 @@ class KIEPredictor(nn.Module, _KIEPredictor):
         pages: list[np.ndarray],
         **kwargs: Any,
     ) -> Document:
+        if len(pages) == 0:
+            return KIEDocument(pages=[])
+
         # Dimension check
         if any(page.ndim != 3 for page in pages):
             raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")

--- a/doctr/models/predictor/pytorch.py
+++ b/doctr/models/predictor/pytorch.py
@@ -93,6 +93,9 @@ class OCRPredictor(nn.Module, _OCRPredictor):
         pages: list[np.ndarray],
         **kwargs: Any,
     ) -> Document:
+        if len(pages) == 0:
+            return Document(pages=[])
+
         # Dimension check
         if any(page.ndim != 3 for page in pages):
             raise ValueError("incorrect input shape: all pages are expected to be multi-channel 2D images.")

--- a/tests/pytorch/test_models_zoo_pt.py
+++ b/tests/pytorch/test_models_zoo_pt.py
@@ -124,6 +124,47 @@ def test_ocrpredictor(
     assert out.pages[0].orientation["value"] == orientation
 
 
+def test_predictors_on_empty_batch(mock_vocab):
+    """An empty page list must yield an empty Document instead of raising.
+
+    Filtering a batch down to nothing is ordinary caller code, and
+    `RecognitionPredictor` (and `OrientationPredictor` since #2069) already
+    return empty results for it. The detection and end-to-end predictors did
+    not, so they crashed deep in the stack -- `IndexError` from `samples[0]` in
+    `PreProcessor.batch_inputs`, then `ValueError` from `zip(*...)` in
+    `detach_scores`, then `IndexError` from `x[0]` in `invert_data_structure`
+    on the KIE path -- none of which names the empty input.
+    """
+    det_predictor = DetectionPredictor(
+        PreProcessor(output_size=(512, 512), batch_size=2),
+        detection.db_mobilenet_v3_large(pretrained=False, pretrained_backbone=False, assume_straight_pages=True),
+    )
+    reco_predictor = RecognitionPredictor(
+        PreProcessor(output_size=(32, 128), batch_size=32, preserve_aspect_ratio=True),
+        recognition.crnn_vgg16_bn(pretrained=False, pretrained_backbone=False, vocab=mock_vocab),
+    )
+
+    # Detection keeps the shape its `return_maps` contract promises.
+    assert det_predictor([]) == []
+    assert det_predictor([], return_maps=True) == ([], [])
+
+    # The recognition predictor already behaved; asserted here so the three
+    # stay consistent if one of them is touched again.
+    assert reco_predictor([]) == []
+
+    for predictor, expected_type in (
+        (OCRPredictor(det_predictor, reco_predictor, assume_straight_pages=True), Document),
+        (KIEPredictor(det_predictor, reco_predictor, assume_straight_pages=True), KIEDocument),
+    ):
+        out = predictor([])
+        # Exact type, not isinstance: KIEDocument subclasses Document, so an
+        # isinstance check would not notice the KIE path degrading to the base
+        # class and dropping the per-class prediction shape.
+        assert type(out) is expected_type
+        assert out.pages == []
+        assert out.export() == {"pages": []}
+
+
 def test_ocrpredictor_layout(mock_pdf, mock_vocab, mock_payslip):
     det_predictor = DetectionPredictor(
         PreProcessor(output_size=(512, 512), batch_size=2),


### PR DESCRIPTION
`DetectionPredictor`, `OCRPredictor` and `KIEPredictor` raise on an empty page list instead of returning an empty result. `RecognitionPredictor` has always short-circuited on empty input (`recognition/predictor/pytorch.py:50`), and `OrientationPredictor` gained the same behaviour in #2069 — these three were the remaining gap, so this follows that precedent rather than introducing a new convention.

Filtering a batch down to nothing is ordinary caller code (skip already-processed pages, drop files that failed a check upstream), and today it fails from internals that never mention the empty input.

### Reproduction

```python
from doctr.models import ocr_predictor, kie_predictor, detection

ocr_predictor(pretrained=False)([])       # IndexError: list index out of range
kie_predictor(pretrained=False)([])       # IndexError: list index out of range
detection.detection_predictor(pretrained=False)([])  # IndexError
```

There are three separate failure points on the way down, which is why the fix is not a one-liner in a single helper:

| Location | Failure |
|---|---|
| `preprocessor/pytorch.py:73` | `num_batches` is correctly `0`, then `samples[0]` is read to pick the tuple/tensor branch → `IndexError` |
| `utils/geometry.py:124` | `zip(*(_detach(box) for box in boxes))` over no boxes → `ValueError: not enough values to unpack (expected 2, got 0)` |
| `models/_utils.py:276` | KIE path only: `{k: ... for k in x[0]}` → `IndexError` |

I confirmed the ordering by fixing them one at a time: guarding `batch_inputs` moved the crash to `detach_scores`, and guarding that one let the whole call return `Document(pages=[])`.

### Fix

Guard at the three public entry points instead of patching each internal, so `batch_inputs`, `detach_scores` and `invert_data_structure` keep their non-empty precondition and stay simple.

Two details worth flagging:

- `DetectionPredictor` returns the shape its own `return_maps` contract promises: `[]` normally, `([], [])` when `return_maps=True`.
- `KIEPredictor` returns `KIEDocument(pages=[])`, not `Document(pages=[])`. `KIEDocument` subclasses `Document`, so returning the base class would type-check and pass an `isinstance` assertion while silently dropping the per-class page shape. The test asserts the exact type for this reason — I verified it catches the degradation by deliberately returning `Document` there and watching the test go red.

### Tests

Added `test_predictors_on_empty_batch`, which covers detection (both `return_maps` values), recognition (already-correct, asserted so the three stay consistent), and both end-to-end predictors.

The test is load-bearing: reverting the guards fails it at `preprocessor/pytorch.py:73`.

```
tests/pytorch/test_models_zoo_pt.py::test_predictors_on_empty_batch  1 passed
tests/pytorch/test_models_zoo_pt.py                                 14 passed, 6 errors
tests/common/                                                        523 passed, 1 failed, 7 errors
ruff check . / ruff format --check                                   clean
mypy doctr/                                                          clean (171 source files)
```

The errors and the one failure are pre-existing on this machine and unrelated: the errors are `requests.exceptions.ConnectionError` from tests that download weights or fixtures, and `tests/common/test_io.py::test_read_html` fails with `OSError: cannot load library` (missing WeasyPrint system libs). I verified the `test_read_html` failure reproduces on a clean checkout via `git stash`.

AI assistance was used for this change; I reviewed every changed line and ran the commands above locally.
